### PR TITLE
Add meeting minutes and calendar links on readme/main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,17 @@ The Jakarta Data specification provides an API that allows easy access to databa
 Java developer can split the persistence from the model with several features,
 such as the ability to compose custom query methods on a `Repository` interface where the framework
 will implement it.
+
+## Meetings
+
+* Calendar:
+Europe
+[Eastern](https://calendar.google.com/calendar/u/0/embed?src=eclipse-foundation.org_e9ki8t2gc75sh07qdh95c8ofvc@group.calendar.google.com&ctz=Europe/Athens),
+[Central](https://calendar.google.com/calendar/u/0/embed?src=eclipse-foundation.org_e9ki8t2gc75sh07qdh95c8ofvc@group.calendar.google.com&ctz=Europe/Berlin),
+[Western](https://calendar.google.com/calendar/u/0/embed?src=eclipse-foundation.org_e9ki8t2gc75sh07qdh95c8ofvc@group.calendar.google.com&ctz=Europe/Lisbon) |
+America
+[Eastern](https://calendar.google.com/calendar/u/0/embed?src=eclipse-foundation.org_e9ki8t2gc75sh07qdh95c8ofvc@group.calendar.google.com&ctz=America/Toronto),
+[Central](https://calendar.google.com/calendar/u/0/embed?src=eclipse-foundation.org_e9ki8t2gc75sh07qdh95c8ofvc@group.calendar.google.com&ctz=America/Chicago),
+[Mountain](https://calendar.google.com/calendar/u/0/embed?src=eclipse-foundation.org_e9ki8t2gc75sh07qdh95c8ofvc@group.calendar.google.com&ctz=America/Denver),
+[Pacific](https://calendar.google.com/calendar/u/0/embed?src=eclipse-foundation.org_e9ki8t2gc75sh07qdh95c8ofvc@group.calendar.google.com&ctz=America/Los_Angeles)
+* [Minutes](https://docs.google.com/document/d/1MQbwPpbEBHiAHes1NaYTJQzEBGUYXxaJYw5K-yj053U/edit)


### PR DESCRIPTION
Linking to the meeting schedule and minutes will help participants find the information more quickly.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>