### PR TITLE
Update license-efsl.adoc to eliminate warning output by running tests…

### DIFF
--- a/spec/src/main/asciidoc/license-efsl.adoc
+++ b/spec/src/main/asciidoc/license-efsl.adoc
@@ -1,3 +1,5 @@
+:doctype: book
+
 [subs="normal"]
 ....
 Specification: {doctitle}
@@ -9,11 +11,11 @@ Status: {revremark}
 Release: {revdate}
 ....
 
-== Copyright
+= Copyright
 
 Copyright (c) {inceptionYear} , {currentYear} Eclipse Foundation.
 
-=== Eclipse Foundation Specification License
+== Eclipse Foundation Specification License
 
 By using and/or copying this document, or the Eclipse Foundation
 document from which this statement is linked, you (the licensee) agree
@@ -53,7 +55,7 @@ The notice is:
 document includes material copied from or derived from [title and URI
 of the Eclipse Foundation specification document]."
 
-==== Disclaimers
+== Disclaimers
 
 THIS DOCUMENT IS PROVIDED &quot;AS IS,&quot; AND THE COPYRIGHT
 HOLDERS AND THE ECLIPSE FOUNDATION MAKE NO REPRESENTATIONS OR


### PR DESCRIPTION
… in which section titles were out of sequence

I attempted what seemed to be a simple fix, but was more complex than I thought.  Here is the proposed update to the license-efsl.adoc file that satisfied IntelliJ errors and eliminated the warning.
