### PR TITLE
Replacing assertion libraries: Hamcrest by AssertJ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.1] - 03-10-2022
+
+### Changed
+- `jakarta-data-api`
+  - Removed `hamcrest-all` in favour of `assertj-core`
+  - Changed the assertions in `PageableTest` and `SortTest`
+  - Removed redundant tests on `SortTest`
+- `jakarta-data-parent`
+  - Updated the following libraries
+    - `mockito`.version` to `4.8.0`
+    - `junit` to `5.9.0`
+  - Fix typo on `mockito.version` 
+ 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.0.1] - 03-10-2022
 
 ### Changed
-- `jakarta-data-api`
+- jakarta-data-api
   - Removed `hamcrest-all` in favour of `assertj-core`
   - Changed the assertions in `PageableTest` and `SortTest`
   - Removed redundant tests on `SortTest`
-- `jakarta-data-parent`
+- jakarta-data-parent
   - Updated the following libraries
     - `mockito`.version` to `4.8.0`
     - `junit` to `5.9.0`

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>jakarta.data</groupId>
         <artifactId>jakarta-data-parent</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
+<version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jakarta-data-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -24,18 +24,22 @@
     <parent>
         <groupId>jakarta.data</groupId>
         <artifactId>jakarta-data-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jakarta-data-api</artifactId>
     <name>Jakarta Data API</name>
     <description>Jakarta Data :: API</description>
 
+    <properties>
+        <assertj.version>3.23.1</assertj.version>
+    </properties>
+
     <dependencies>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
-            <version>1.3</version>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/api/src/test/java/jakarta/data/repository/PageableTest.java
+++ b/api/src/test/java/jakarta/data/repository/PageableTest.java
@@ -17,41 +17,45 @@
  */
 package jakarta.data.repository;
 
-import org.junit.jupiter.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class PageableTest {
 
     @Test
-    public void shouldCreatePageable(){
+    @DisplayName("Should correctly paginate")
+    public void shouldCreatePageable() {
         Pageable pageable = Pageable.of(2, 6);
-        Assertions.assertEquals(6L, pageable.getSize());
-        Assertions.assertEquals(2L, pageable.getPage());
+
+        assertSoftly(softly -> {
+            softly.assertThat(pageable.getSize()).isEqualTo(6L);
+            softly.assertThat(pageable.getPage()).isEqualTo(2L);
+        });
     }
 
     @Test
-    public void shouldNext(){
+    @DisplayName("Should navigate next")
+    public void shouldNext() {
         Pageable pageable = Pageable.of(2, 1);
         Pageable next = pageable.next();
-        Assertions.assertEquals(1L, pageable.getSize());
-        Assertions.assertEquals(2L, pageable.getPage());
-        Assertions.assertEquals(3L, next.getPage());
-        Assertions.assertEquals(1L, next.getSize());
+
+        assertSoftly(softly -> {
+            softly.assertThat(pageable.getSize()).isEqualTo(1L);
+            softly.assertThat(pageable.getPage()).isEqualTo(2L);
+            softly.assertThat(next.getPage()).isEqualTo(3L);
+            softly.assertThat(next.getSize()).isEqualTo(1L);
+        });
     }
 
     @Test
+    @DisplayName("Should throw IllegalArgumentException when page is not present")
     public void shouldReturnErrorWhenThereIsIllegalArgument() {
-        Assertions.assertThrows(IllegalArgumentException.class, ()->
-                Pageable.page(0));
-
-        Assertions.assertThrows(IllegalArgumentException.class, ()->
-                Pageable.page(-1));
-
-        Assertions.assertThrows(IllegalArgumentException.class, ()->
-                Pageable.of(1, -1));
-
-        Assertions.assertThrows(IllegalArgumentException.class, ()->
-                Pageable.of(1, 0));
+        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.page(0));
+        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.page(-1));
+        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.of(1, -1));
+        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.of(1, 0));
     }
-
 }

--- a/api/src/test/java/jakarta/data/repository/SortTest.java
+++ b/api/src/test/java/jakarta/data/repository/SortTest.java
@@ -17,70 +17,73 @@
  */
 package jakarta.data.repository;
 
-import org.junit.jupiter.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class SortTest {
 
+    public static final String NAME = "name";
+
     @Test
-    public void shouldReturnErrorWhenPropertyDirectionNull() {
-        Assertions.assertThrows(NullPointerException.class, () ->
-                Sort.of(null, null));
-
-        Assertions.assertThrows(NullPointerException.class, () ->
-                Sort.of("name", null));
-
-        Assertions.assertThrows(NullPointerException.class, () ->
-                Sort.of(null, Direction.ASC));
+    @DisplayName("Should throw NullPointerException when one of the properties are null")
+    void shouldReturnErrorWhenPropertyDirectionNull() {
+        assertThatNullPointerException().isThrownBy(() -> Sort.of(null, null));
+        assertThatNullPointerException().isThrownBy(() -> Sort.of(NAME, null));
+        assertThatNullPointerException().isThrownBy(() -> Sort.of(null, Direction.ASC));
     }
 
     @Test
-    public void shouldCreateSort() {
-        Sort order = Sort.of("name", Direction.ASC);
-        Assertions.assertNotNull(order);
-        Assertions.assertEquals("name", order.getProperty());
-        Assertions.assertTrue(order.isAscending());
-        Assertions.assertFalse(order.isDescending());
+    @DisplayName("Should ascending short when direction is ASC")
+    void shouldCreateAscendingSort() {
+        Sort order = Sort.of(NAME, Direction.ASC);
+
+        assertSoftly(softly -> {
+            softly.assertThat(order).isNotNull();
+            softly.assertThat(order.getProperty()).isEqualTo(NAME);
+            softly.assertThat(order.isAscending()).isTrue();
+            softly.assertThat(order.isDescending()).isFalse();
+        });
     }
 
     @Test
-    public void shouldCreateAsc(){
+    @DisplayName("Should descending short when direction is DESC")
+    void shouldCreateDescendingSort() {
+        Sort order = Sort.of(NAME, Direction.DESC);
+
+        assertSoftly(softly -> {
+            softly.assertThat(order).isNotNull();
+            softly.assertThat(order.getProperty()).isEqualTo(NAME);
+            softly.assertThat(order.isAscending()).isFalse();
+            softly.assertThat(order.isDescending()).isTrue();
+        });
+    }
+
+    @Test
+    @DisplayName("Should ascending sort when Sort.asc method is used")
+    void shouldCreateAsc() {
         Sort order = Sort.asc("name");
-        Assertions.assertNotNull(order);
-        Assertions.assertEquals("name", order.getProperty());
-        Assertions.assertTrue(order.isAscending());
-        Assertions.assertFalse(order.isDescending());
+
+        assertSoftly(softly -> {
+            softly.assertThat(order).isNotNull();
+            softly.assertThat(order.getProperty()).isEqualTo(NAME);
+            softly.assertThat(order.isAscending()).isTrue();
+            softly.assertThat(order.isDescending()).isFalse();
+        });
     }
 
     @Test
-    public void shouldCreateDesc(){
-        Sort order = Sort.desc("name");
-        Assertions.assertNotNull(order);
-        Assertions.assertEquals("name", order.getProperty());
-        Assertions.assertTrue(order.isDescending());
-        Assertions.assertFalse(order.isAscending());
-    }
+    @DisplayName("Should descending sort when Sort.desc method is used")
+    public void shouldCreateDesc() {
+        Sort order = Sort.desc(NAME);
 
-    @Test
-    public void shouldCreateOrder() {
-        Sort order = Sort.of("name",Direction.ASC);
-        Assertions.assertNotNull(order);
-        Assertions.assertEquals("name", order.getProperty());
-    }
-
-    @Test
-    public void shouldAscending(){
-        Sort order = Sort.of("name",Direction.ASC);
-        Assertions.assertEquals("name", order.getProperty());
-        Assertions.assertTrue(order.isAscending());
-        Assertions.assertFalse(order.isDescending());
-    }
-
-    @Test
-    public void shouldDescending(){
-        Sort order = Sort.of("name",Direction.DESC);
-        Assertions.assertEquals("name", order.getProperty());
-        Assertions.assertFalse(order.isAscending());
-        Assertions.assertTrue(order.isDescending());
+        assertSoftly(softly -> {
+            softly.assertThat(order).isNotNull();
+            softly.assertThat(order.getProperty()).isEqualTo(NAME);
+            softly.assertThat(order.isAscending()).isFalse();
+            softly.assertThat(order.isDescending()).isTrue();
+        });
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>jakarta.data</groupId>
     <artifactId>jakarta-data-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Jakarta Data</name>
@@ -69,7 +69,7 @@
         <jakarta.json.version>1.1.6</jakarta.json.version>
         <jakarta.data.version>${project.version}</jakarta.data.version>
         <jakarta.validation.version>2.0.1</jakarta.validation.version>
-        <junit.version>5.8.2</junit.version>
+        <junit.version>5.9.0</junit.version>
         <maven-javadoc-plugin.vesion>3.3.2</maven-javadoc-plugin.vesion>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven.checkstyle.plugin.version>3.1.2</maven.checkstyle.plugin.version>
@@ -79,7 +79,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.jacoco.reportPath>../target/jacoco.exec</sonar.jacoco.reportPath>
         <sonar.maven.version>3.3.0.603</sonar.maven.version>
-        <mockito.verson>4.6.0</mockito.verson>
+        <mockito.version>4.8.0</mockito.version>
         <commons.io.version>2.11.0</commons.io.version>
     </properties>
 
@@ -99,13 +99,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>${mockito.verson}</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>${mockito.verson}</version>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>jakarta.data</groupId>
         <artifactId>jakarta-data-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jakarta-data-spec</artifactId>


### PR DESCRIPTION
## Motivation

This PR replaces Hamcrest with AssertJ in order to add more fluent and understandable assertions.


### Changed

- `jakarta-data-api`
  - Removed `hamcrest-all` in favour of `assertj-core`
  - Changed the assertions in `PageableTest` and `SortTest`
  - Removed redundant tests on `SortTest`
- `jakarta-data-parent`
  - Updated the following libraries
    - `mockito`.version` to `4.8.0`
    - `junit` to `5.9.0`
  - Fix typo on `mockito.version` 