### PR TITLE
remaining documentation updates for Limit

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Limit.java
+++ b/api/src/main/java/jakarta/data/repository/Limit.java
@@ -37,6 +37,8 @@ package jakarta.data.repository;
  * <ul>
  * <li>multiple <code>Limit</code> parameters are specified on the
  *     same method.</li>
+ * <li><code>Limit</code> and {@link Pageable} parameters are specified on the
+ *     same method.</li>
  * <li>a <code>Limit</code> parameter is specified in combination
  *     with the <code>First</code> keyword.</li>
  * </ul>

--- a/api/src/main/java/jakarta/data/repository/Pageable.java
+++ b/api/src/main/java/jakarta/data/repository/Pageable.java
@@ -20,7 +20,33 @@ package jakarta.data.repository;
 import java.util.Objects;
 
 /**
- * Abstract interface for pagination information.
+ * <p>Abstract interface for pagination information.</p>
+ *
+ * <p><code>Pageable</code> is optionally specified as a parameter to a
+ * repository method in one of the parameter positions after the
+ * query parameters. For example,</p>
+ *
+ * <pre>
+ * &#64;OrderBy("age")
+ * &#64;OrderBy("ssn")
+ * Person[] findByAgeBetween(int minAge, int maxAge, Pageable pagination);
+ *
+ * ...
+ * for (Pageable p = Pageable.of(1, 100); p != null; p = page.length == 0 ? null : p.next()) {
+ *   page = people.findByAgeBetween(35, 59, p);
+ *   ...
+ * }
+ * </pre>
+ *
+ * <p>A repository method will raise {@link IllegalArgumentException} if</p>
+ * <ul>
+ * <li>multiple <code>Pageable</code> parameters are specified on the
+ *     same method.</li>
+ * <li><code>Pageable</code> and {@link Limit} parameters are specified on the
+ *     same method.</li>
+ * <li>a <code>Pageable</code> parameter is specified in combination
+ *     with the <code>First</code> keyword.</li>
+ * </ul>
  */
 public class Pageable {
 

--- a/api/src/main/java/jakarta/data/repository/Repository.java
+++ b/api/src/main/java/jakarta/data/repository/Repository.java
@@ -327,7 +327,7 @@ import java.lang.annotation.Target;
  * <h3>Limits</h3>
  *
  * <p>You can cap the number of results that can be returned by a single
- * invocation of a repository method by adding a <code>Limit</code> parameter.
+ * invocation of a repository find method by adding a {@link Limit} parameter.
  * For example,</p>
  *
  * <pre>
@@ -338,8 +338,34 @@ import java.lang.annotation.Target;
  * found = products.highlyDiscounted(0.30, Limit.of(50));
  * </pre>
  *
- * TODO write this section after pagination and sorting and other aspects
- * are discussed and defined.
+ * <h3>Pagination</h3>
+ *
+ * <p>You can request that results be paginated by adding a {@link Pageable}
+ * parameter to a repository find method. For example,</p>
+ *
+ * <pre>
+ * Product[] findByNameLikeOrderByAmountSoldDescNameAsc(
+ *           String pattern, Pageable pagination);
+ * ...
+ * page1 = products.findByNameLikeOrderByAmountSoldDescNameAsc(
+ *                  "%phone%", Pageable.of(1, 20));
+ * </pre>
+ *
+ * <h3>Sorting</h3>
+ *
+ * <p>You can dynamically supply sorting criteria by adding one or more
+ * {@link Sort} parameters (or <code>Sort...</code>)
+ * to a repository find method. For example,</p>
+ *
+ * <pre>
+ * Product[] findByNameLike(String pattern, Limit max, Sort... sortBy);
+ *
+ * ...
+ * page1 = products.findByNameLike(namePattern, Pagination.of(1, 25),
+ *                                 Sort.desc("price"),
+ *                                 Sort.desc("amountSold"),
+ *                                 Sort.asc("name"));
+ * </pre>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/jakarta/data/repository/Sort.java
+++ b/api/src/main/java/jakarta/data/repository/Sort.java
@@ -20,7 +20,31 @@ package jakarta.data.repository;
 import java.util.Objects;
 
 /**
- * Order implements the pairing of a {@link Direction} and a property. It is used to provide input for Sort
+ * <p><code>Sort</code> implements the pairing of a {@link Direction} and a property.</p>
+ *
+ * <p>Dynamic <code>Sort</code> criteria are optionally specified as
+ * parameters to a repository method in any of the positions that are after
+ * the query parameters. You can use <code>Sort...</code> to allow a variable
+ * number of <code>Sort</code> criteria. For example,</p>
+ *
+ * <pre>
+ * Employee[] findByYearHired(int yearYired, Limit maxResults, Sort... sortBy);
+ * ...
+ * highestPaidNewHires = employees.findByYearHired(Year.now(),
+ *                                                 Limit.of(10),
+ *                                                 Sort.desc("salary"),
+ *                                                 Sort.asc("lastName"),
+ *                                                 Sort.asc("firstName"));
+ * </pre>
+ *
+ * <p>It is preferable to use static sorting criteria
+ * (<code>OrderBy</code> keyword or {@link Query} or {@link OrderBy} annotation)
+ * where possible to better allow for optimizations by the provider.</p>
+ *
+ * <p>A repository method will raise {@link IllegalArgumentException} if
+ * a <code>Sort</code> parameter is specified in combination
+ * with an <code>OrderBy</code> keyword or {@link Query} or
+ * {@link OrderBy} annotation.</p>
  */
 public class Sort {
 
@@ -97,8 +121,7 @@ public class Sort {
      * Create a {@link Sort} instance with ascending direction {@link  Direction#ASC}
      *
      * @param property the property name to order by
-     * @return the Order type
-     * @return an {@link Sort} instance
+     * @return a {@link Sort} instance
      * @throws NullPointerException when the property is null
      */
     public static Sort asc(String property) {
@@ -109,8 +132,7 @@ public class Sort {
      * Create a {@link Sort} instance on descending direction {@link  Direction#DESC}
      *
      * @param property the property name to order by
-     * @return the Order type
-     * @return an {@link Sort} instance
+     * @return a {@link Sort} instance
      * @throws NullPointerException when the property is null
      */
     public static Sort desc(String property) {

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -224,7 +224,7 @@ Jakarta Data implementations often support the following list of predicate keywo
 
 Jakarta Data also supports particular parameters to define pagination and sorting.
 
-Jakarta Data recognizes, when specified on a repository method after the query parameters, specific types, like ```Pageable``` and ```Sort```, to dynamically apply pagination and sorting to queries. The following example demonstrates these features:
+Jakarta Data recognizes, when specified on a repository method after the query parameters, specific types, like ```Limit```, ```Pageable```, and ```Sort```, to dynamically apply limits, pagination, and sorting to queries. The following example demonstrates these features:
 
 [source,java]
 ----
@@ -233,7 +233,7 @@ public interface ProductRepository extends CrudRepository<Product, Long> {
 
   List<Product> findByName(String name, Pageable pageable);
 
-  List<Product> findByName(String name, Sort sort);
+  List<Product> findByNameLike(String pattern, Limit max, Sort sort);
 
 }
 ----


### PR DESCRIPTION
Include Limit in main spec asciidoc.
Update Limit JavaDoc to state incompatibility with Pageable being specified at same time.
Update Pageable JavaDoc to state incompatibility with Limit being specified at same time.
Update Sort JavaDoc with incompatibilities and fix JavaDoc warnings.
Update Repository JavaDoc to replace the TODO with links to Pageable and Sort.

Also added some more examples to the JavaDocs while updating those areas.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>