### PR TITLE
Bump nexus-staging-maven-plugin from 1.6.3 to 1.6.13 and add missing …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
         <maven.checkstyle.plugin.version>3.1.2</maven.checkstyle.plugin.version>
         <maven.compile.version>3.10.1</maven.compile.version>
         <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.source>11</maven.compiler.source>
         <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.jacoco.reportPath>../target/jacoco.exec</sonar.jacoco.reportPath>
@@ -337,7 +338,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.3</version>
+                        <version>1.6.13</version>
                         <extensions>true</extensions>
                         <configuration>
                             <nexusUrl>https://jakarta.oss.sonatype.org/</nexusUrl>


### PR DESCRIPTION
…<maven.compiler.source> tag to parent pom.xml

[a] **nexus-staging-maven-plugin**: Version 1.6.3 was flagged as an error in IntelliJ IDEA despite the fact that the version does exist in search.maven.org.
[b] The **<maven.compiler.source>** tag was missing, but referenced in the pom.xml file. I assumed JDK 11 since the **<maven.compiler.release>** tag was set to JDK 11.

Everything seemed to be OK with mvn compile and mvn test

I have questions about other small items in the pom.xml files, but I will send an email to the mailing list for clarifications.  My thought is to nip these small items now before the repository starts to grow.

Mike.
