### PR TITLE
Explicit sourceDirectory

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -78,6 +78,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <sourceDirectory>src/main/asciidoc</sourceDirectory>
                     <sourceDocumentName>jakarta-data.asciidoc</sourceDocumentName>
                     <sourceHighlighter>coderay</sourceHighlighter>
                     <embedAssets>true</embedAssets>


### PR DESCRIPTION
Avoid autodiscovery and:
```
[INFO] sourceDirectory /usr/local/apps/jakartaee-apps/data-api/spec/src/docs/asciidoc does not exist
[INFO] sourceDirectory /usr/local/apps/jakartaee-apps/data-api/spec/src/asciidoc does not exist
```

Ref: https://www.eclipse.org/lists/data-dev/msg00048.html