### PR TITLE
Add Streamable interface

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Slice.java
+++ b/api/src/main/java/jakarta/data/repository/Slice.java
@@ -22,7 +22,7 @@ import java.util.List;
 /**
  * A slice of data that indicates whether there's a next or previous slice available.
  */
-public interface Slice<T>  {
+public interface Slice<T> extends Streamable<T> {
 
     /**
      * Returns the page content as {@link List}.

--- a/api/src/main/java/jakarta/data/repository/Streamable.java
+++ b/api/src/main/java/jakarta/data/repository/Streamable.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data.repository;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * This is interface and can therefore be used as the assignment target for a lambda expression or method reference.
+ */
+@FunctionalInterface
+public interface Streamable<T> extends Iterable<T>, Supplier<Stream<T>> {
+
+    /**
+     * Creates a non-parallel {@link Stream} of the underlying {@link Iterable}.
+     *
+     * @return a non-parallel Stream
+     */
+    default Stream<T> stream() {
+        return StreamSupport.stream(spliterator(), false);
+    }
+
+    /**
+     * Creates a new, unmodifiable {@link Set}.
+     *
+     * @return a Set
+     */
+    default Set<T> toSet() {
+        return stream().collect(Collectors.toUnmodifiableSet());
+    }
+
+    @Override
+    default Stream<T> get() {
+        return stream();
+    }
+
+    /**
+     * Returns whether the current {@link Streamable} is empty.
+     *
+     * @return whether the current {@link Streamable} is empty.
+     */
+    default boolean isEmpty() {
+        return !iterator().hasNext();
+    }
+
+    /**
+     * Creates a new, unmodifiable {@link List}.
+     *
+     * @return will never be {@literal null}.
+     */
+    default List<T> toList() {
+        return stream().collect(Collectors.toUnmodifiableList());
+    }
+}

--- a/api/src/main/java/jakarta/data/repository/Streamable.java
+++ b/api/src/main/java/jakarta/data/repository/Streamable.java
@@ -31,7 +31,7 @@ public interface Streamable<T> extends Iterable<T> {
      * Returns a sequential stream of results, which follow the order of the sort criteria if specified.
      * This method does not cause data to be re-fetched from the database when used with {@link Pageable pagination}.
      *
-     * @returns a stream of results.
+     * @return a stream of results.
      */
     default Stream<T> stream() {
         return StreamSupport.stream(spliterator(), false);

--- a/api/src/main/java/jakarta/data/repository/Streamable.java
+++ b/api/src/main/java/jakarta/data/repository/Streamable.java
@@ -25,6 +25,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 /**
+ * Simple interface to ease streamability of {@link Iterable}s.
  * This is interface and can therefore be used as the assignment target for a lambda expression or method reference.
  */
 @FunctionalInterface

--- a/api/src/main/java/jakarta/data/repository/Streamable.java
+++ b/api/src/main/java/jakarta/data/repository/Streamable.java
@@ -70,7 +70,8 @@ public interface Streamable<T> extends Iterable<T>, Supplier<Stream<T>> {
     }
 
     /**
-     * Creates a new, unmodifiable {@link List}.
+     * Returns results as a list that is ordered according to the sort criteria if specified.
+     * The default implementation creates a new, unmodifiable {@link List}.
      *
      * @return will never be {@literal null}.
      */

--- a/api/src/main/java/jakarta/data/repository/Streamable.java
+++ b/api/src/main/java/jakarta/data/repository/Streamable.java
@@ -50,6 +50,12 @@ public interface Streamable<T> extends Iterable<T>, Supplier<Stream<T>> {
     }
 
     @Override
+    /**
+     * Returns a sequential stream of results, which follow the order of the sort criteria if specified.
+     * This method does not cause data to be re-fetched from the database when used with {@link Pageable pagination}.
+     *
+     * @returns a stream of results.
+     */
     default Stream<T> get() {
         return stream();
     }

--- a/api/src/main/java/jakarta/data/repository/Streamable.java
+++ b/api/src/main/java/jakarta/data/repository/Streamable.java
@@ -17,7 +17,6 @@
  */
 package jakarta.data.repository;
 
-import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 

--- a/api/src/main/java/jakarta/data/repository/Streamable.java
+++ b/api/src/main/java/jakarta/data/repository/Streamable.java
@@ -26,7 +26,7 @@ import java.util.stream.StreamSupport;
 
 /**
  * Simple interface to ease streamability of {@link Iterable}s.
- * This is interface and can therefore be used as the assignment target for a lambda expression or method reference.
+ * This is an interface and can therefore be used as the assignment target for a lambda expression or method reference.
  */
 @FunctionalInterface
 public interface Streamable<T> extends Iterable<T>, Supplier<Stream<T>> {

--- a/api/src/main/java/jakarta/data/repository/Streamable.java
+++ b/api/src/main/java/jakarta/data/repository/Streamable.java
@@ -26,16 +26,15 @@ import java.util.stream.StreamSupport;
  * This is an interface and can therefore be used as the assignment target for a lambda expression or method reference.
  */
 @FunctionalInterface
-public interface Streamable<T> extends Iterable<T>, Supplier<Stream<T>> {
+public interface Streamable<T> extends Iterable<T> {
 
-    @Override
     /**
      * Returns a sequential stream of results, which follow the order of the sort criteria if specified.
      * This method does not cause data to be re-fetched from the database when used with {@link Pageable pagination}.
      *
      * @returns a stream of results.
      */
-    default Stream<T> get() {
+    default Stream<T> stream() {
         return StreamSupport.stream(spliterator(), false);
     }
 

--- a/api/src/main/java/jakarta/data/repository/Streamable.java
+++ b/api/src/main/java/jakarta/data/repository/Streamable.java
@@ -31,23 +31,6 @@ import java.util.stream.StreamSupport;
 @FunctionalInterface
 public interface Streamable<T> extends Iterable<T>, Supplier<Stream<T>> {
 
-    /**
-     * Creates a non-parallel {@link Stream} of the underlying {@link Iterable}.
-     *
-     * @return a non-parallel Stream
-     */
-    default Stream<T> stream() {
-        return StreamSupport.stream(spliterator(), false);
-    }
-
-    /**
-     * Creates a new, unmodifiable {@link Set}.
-     *
-     * @return a Set
-     */
-    default Set<T> toSet() {
-        return stream().collect(Collectors.toUnmodifiableSet());
-    }
 
     @Override
     /**
@@ -57,25 +40,8 @@ public interface Streamable<T> extends Iterable<T>, Supplier<Stream<T>> {
      * @returns a stream of results.
      */
     default Stream<T> get() {
-        return stream();
+        return StreamSupport.stream(spliterator(), false);
     }
 
-    /**
-     * Returns whether the current {@link Streamable} is empty.
-     *
-     * @return whether the current {@link Streamable} is empty.
-     */
-    default boolean isEmpty() {
-        return !iterator().hasNext();
-    }
 
-    /**
-     * Returns results as a list that is ordered according to the sort criteria if specified.
-     * The default implementation creates a new, unmodifiable {@link List}.
-     *
-     * @return will never be {@literal null}.
-     */
-    default List<T> toList() {
-        return stream().collect(Collectors.toUnmodifiableList());
-    }
 }

--- a/api/src/main/java/jakarta/data/repository/Streamable.java
+++ b/api/src/main/java/jakarta/data/repository/Streamable.java
@@ -17,10 +17,7 @@
  */
 package jakarta.data.repository;
 
-import java.util.List;
-import java.util.Set;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -30,7 +27,6 @@ import java.util.stream.StreamSupport;
  */
 @FunctionalInterface
 public interface Streamable<T> extends Iterable<T>, Supplier<Stream<T>> {
-
 
     @Override
     /**


### PR DESCRIPTION
As @odrotbohm recommendation, I've created this PR for this discussion:

https://github.com/jakartaee/data/pull/37#issuecomment-1286980442

The main reason for this PR is that the Stream makes sense to handle with Data at Jakarta Data. However, the structure should consider the resource available for it.

> Spring Data's Page implements Streamable, an extension of Iterable that exposes a stream() method defaulting to non-parallel streaming.

https://github.com/jakartaee/data/issues/36#issuecomment-1268074831

So, I created this PR to start the discussion on the ```Streamable``` 

The biggest inspiration comes from [Spring Data Commons](https://github.com/spring-projects/spring-data-commons/blob/main/src/main/java/org/springframework/data/util/Streamable.java), where I took a feel method to start the Topic.

