### PR TITLE
page count when using Query annotation

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Query.java
+++ b/api/src/main/java/jakarta/data/repository/Query.java
@@ -36,5 +36,24 @@ public @interface Query {
      * @return the query to be executed when the annotated method is called.
      */
     String value();
+
+    /**
+     * <p>Defines an additional query that counts the number of elements that are
+     * returned by the {@link #value() primary} query. This is used to compute
+     * the {@link Page#getTotalElements() total elements}
+     * and {@link Page#getTotalPages() total pages}
+     * for paginated repository queries that are annotated with
+     * <code>@Query</code> and return a {@link Page} or <code>KeysetAwarePage</code>.
+     * Slices do not use a counting query.</p> TODO use link instead of code above once #52 is merged.
+     *
+     * <p>The default value of empty string indicates that no counting query
+     * is provided. A counting query is unnecessary when pagination is
+     * performed with slices instead of pages and when pagination is
+     * not used at all.</p>
+     *
+     * @return a query for counting the number of elements across all pages.
+     *         Empty string indicates that no counting query is provided.
+     */
+    String count() default "";
 }
 


### PR DESCRIPTION
When name-pattern-based repository methods are used with pagination, a Jakarta Data provider is able to use that same information to query for total page/number of elements count. However, when the user provides a complex query via the `@Query` annotation, the Jakarta Data provider should not be expected parse the query language or modify the user-provided query to obtain the total count of elements/pages.  This is solved in [Spring Data](https://docs.spring.io/spring-data/jpa/docs/current/api/org/springframework/data/jpa/repository/Query.html#countQuery--) and [Micronaut](https://micronaut-projects.github.io/micronaut-data/2.4.4/api/io/micronaut/data/annotation/Query.html#countQuery--) by allowing a counting query to be optionally specified on the `@Query` annotation.  Jakarta Data should allow the same so that pagination with `Page` can work for repository methods that are annotated with `@Query`.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>