### PR TITLE
Reorder the page and size parameters on the Pageable.java constructor…

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Pageable.java
+++ b/api/src/main/java/jakarta/data/repository/Pageable.java
@@ -56,25 +56,16 @@ public class Pageable {
 
     private static final long DEFAULT_SIZE = 10;
 
-    private final long size;
-
     private final long page;
+
+    private final long size;
 
     private final List<Sort> sorts;
 
-    private Pageable(long size, long page, List<Sort> sorts) {
-        this.size = size;
+    private Pageable(long page, long size, List<Sort> sorts) {
         this.page = page;
+        this.size = size;
         this.sorts = sorts;
-    }
-
-    /**
-     * Returns the size of each page
-     *
-     * @return the size of each page
-     */
-    public long getSize() {
-        return size;
     }
 
     /**
@@ -84,6 +75,15 @@ public class Pageable {
      */
     public long getPage() {
         return page;
+    }
+
+    /**
+     * Returns the size of each page
+     *
+     * @return the size of each page
+     */
+    public long getSize() {
+        return size;
     }
 
     /**
@@ -101,7 +101,7 @@ public class Pageable {
      * @return The next pageable.
      */
     public Pageable next() {
-        return new Pageable(this.size, (page + 1), this.sorts);
+        return new Pageable((page + 1), this.size, this.sorts);
     }
 
     @Override
@@ -118,14 +118,14 @@ public class Pageable {
 
     @Override
     public int hashCode() {
-        return Objects.hash(size, page, sorts);
+        return Objects.hash(page, size, sorts);
     }
 
     @Override
     public String toString() {
         return "Pageable{" +
-                "size=" + size +
-                ", page=" + page +
+                "page=" + page +
+                ", size=" + size +
                 '}';
     }
 
@@ -195,7 +195,7 @@ public class Pageable {
             throw new IllegalArgumentException("size: " + size);
         }
         Objects.requireNonNull(sorts, "sorts is required");
-        return new Pageable(size, page, StreamSupport.stream(sorts.spliterator(), false)
+        return new Pageable(page, size, StreamSupport.stream(sorts.spliterator(), false)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toUnmodifiableList()));
     }

--- a/api/src/test/java/jakarta/data/repository/PageableTest.java
+++ b/api/src/test/java/jakarta/data/repository/PageableTest.java
@@ -35,8 +35,8 @@ class PageableTest {
         Pageable pageable = Pageable.of(2, 6);
 
         assertSoftly(softly -> {
-            softly.assertThat(pageable.getSize()).isEqualTo(6L);
             softly.assertThat(pageable.getPage()).isEqualTo(2L);
+            softly.assertThat(pageable.getSize()).isEqualTo(6L);
         });
     }
 
@@ -46,8 +46,8 @@ class PageableTest {
         Pageable pageable = Pageable.size(50);
 
         assertSoftly(softly -> {
-            softly.assertThat(pageable.getSize()).isEqualTo(50L);
             softly.assertThat(pageable.getPage()).isEqualTo(1L);
+            softly.assertThat(pageable.getSize()).isEqualTo(50L);
         });
     }
 
@@ -58,8 +58,8 @@ class PageableTest {
         Pageable next = pageable.next();
 
         assertSoftly(softly -> {
-            softly.assertThat(pageable.getSize()).isEqualTo(1L);
             softly.assertThat(pageable.getPage()).isEqualTo(2L);
+            softly.assertThat(pageable.getSize()).isEqualTo(1L);
             softly.assertThat(next.getPage()).isEqualTo(3L);
             softly.assertThat(next.getSize()).isEqualTo(1L);
         });
@@ -71,8 +71,8 @@ class PageableTest {
         Pageable pageable = Pageable.page(5);
 
         assertSoftly(softly -> {
-            softly.assertThat(pageable.getSize()).isEqualTo(10L);
             softly.assertThat(pageable.getPage()).isEqualTo(5L);
+            softly.assertThat(pageable.getSize()).isEqualTo(10L);
         });
     }
 
@@ -121,8 +121,8 @@ class PageableTest {
     public void shouldNotModifySortOnNextPage() {
         Pageable pageable = Pageable.of(1L, 3L, Sort.asc("name"), Sort.desc("age"));
         Pageable next = pageable.next();
-        Assertions.assertEquals(3L, pageable.getSize());
         Assertions.assertEquals(1L, pageable.getPage());
+        Assertions.assertEquals(3L, pageable.getSize());
         assertThat(pageable.getSorts())
                 .hasSize(2)
                 .contains(Sort.asc("name"), Sort.desc("age"));


### PR DESCRIPTION
… to match those of the overload of() methods

Pursuant to our Jakarta Data meeting on 11/2, this PR addresses my concern over the order of the page and size variables in the constructor and overloaded of() methords.

Everything was successfully tested and compiled in my local branch.
