### PR TITLE
switch to Cursor class

### DIFF
--- a/api/src/main/java/jakarta/data/repository/KeysetPageable.java
+++ b/api/src/main/java/jakarta/data/repository/KeysetPageable.java
@@ -144,7 +144,24 @@ public class KeysetPageable extends Pageable {
      * Represents keyset values, which can be a starting point for
      * requesting a next or previous page.
      */
-    public interface Cursor {
+    public static class Cursor {
+        /**
+         * Keyset values.
+         */
+        protected final Object[] keyset;
+
+        /**
+         * Constructs a keyset cursor with the specified values.
+         *
+         * @param keyset keyset values.
+         * @throws IllegalArgumentException if no keyset values are provided.
+         */
+        public Cursor(Object... keyset) {
+            this.keyset = keyset;
+            if (keyset == null || keyset.length == 0)
+                throw new IllegalArgumentException("No keyset values were provided.");
+        }
+
         /**
          * Returns whether or not the keyset values of this instance
          * are equal to those of the supplied instance.
@@ -153,7 +170,11 @@ public class KeysetPageable extends Pageable {
          * @return true or false.
          */
         @Override
-        public boolean equals(Object o);
+        public boolean equals(Object o) {
+            return this == o || o != null
+                    && o.getClass() == getClass()
+                    && Arrays.equals(keyset, ((Cursor) o).keyset);
+        }
 
         /**
          * Returns the keyset value at the specified position.
@@ -163,7 +184,9 @@ public class KeysetPageable extends Pageable {
          * @throws IndexOutOfBoundsException if the index is negative
          *         or greater than or equal to the {@link #size}.
          */
-        public Object getKeysetElement(int index);
+        public Object getKeysetElement(int index) {
+            return keyset[index];
+        }
 
         /**
          * Returns a hash code based on the keyset values.
@@ -171,14 +194,18 @@ public class KeysetPageable extends Pageable {
          * @return a hash code based on the keyset values.
          */
         @Override
-        public int hashCode();
+        public int hashCode() {
+            return Arrays.hashCode(keyset);
+        }
 
         /**
          * Returns the number of values in the keyset.
          *
          * @return the number of values in the keyset.
          */
-        public int size();
+        public int size() {
+            return keyset.length;
+        }
 
         /**
          * String representation of the keyset cursor, including the number of
@@ -187,55 +214,10 @@ public class KeysetPageable extends Pageable {
          * @return String representation of the keyset cursor.
          */
         @Override
-        public String toString();
-    }
-
-    /**
-     * Built-in implementation of Cursor.
-     */
-    static final class CursorImpl implements Cursor {
-        /**
-         * Keyset values.
-         */
-        private final Object[] keyset;
-
-        /**
-         * Constructs a keyset cursor with the specified values.
-         *
-         * @param keyset keyset values.
-         * @throws IllegalArgumentException if no keyset values are provided.
-         */
-        CursorImpl(Object... keyset) {
-            this.keyset = keyset;
-            if (keyset == null || keyset.length == 0)
-                throw new IllegalArgumentException("No keyset values were provided.");
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            return this == o || o != null
-                    && o.getClass() == getClass()
-                    && Arrays.equals(keyset, ((CursorImpl) o).keyset);
-        }
-
-        public Object getKeysetElement(int index) {
-            return keyset[index];
-        }
-
-        @Override
-        public int hashCode() {
-            return Arrays.hashCode(keyset);
-        }
-
-        public int size() {
-            return keyset.length;
-        }
-
-        @Override
         public String toString() {
             return new StringBuilder(27).append("Cursor@").append(Integer.toHexString(hashCode()))
-                            .append(" with ").append(keyset.length).append(" keys")
-                            .toString();
+                    .append(" with ").append(keyset.length).append(" keys")
+                    .toString();
         }
     }
 

--- a/api/src/main/java/jakarta/data/repository/Pageable.java
+++ b/api/src/main/java/jakarta/data/repository/Pageable.java
@@ -82,7 +82,7 @@ public class Pageable {
      * @throws IllegalArgumentException if no keyset values are provided.
      */
     public KeysetPageable afterKeyset(Object... keyset) {
-        return new KeysetPageable(this, KeysetPageable.Mode.NEXT, new KeysetPageable.CursorImpl(keyset));
+        return new KeysetPageable(this, KeysetPageable.Mode.NEXT, new KeysetPageable.Cursor(keyset));
     }
 
     /**
@@ -97,7 +97,7 @@ public class Pageable {
      * @throws IllegalArgumentException if no keyset values are provided.
      */
     public KeysetPageable beforeKeyset(Object... keyset) {
-        return new KeysetPageable(this, KeysetPageable.Mode.PREVIOUS, new KeysetPageable.CursorImpl(keyset));
+        return new KeysetPageable(this, KeysetPageable.Mode.PREVIOUS, new KeysetPageable.Cursor(keyset));
     }
 
     /**

--- a/api/src/test/java/jakarta/data/repository/KeysetPageableTest.java
+++ b/api/src/test/java/jakarta/data/repository/KeysetPageableTest.java
@@ -31,6 +31,21 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 class KeysetPageableTest {
 
     @Test
+    @DisplayName("Should create a cursor for the specified values")
+    void shouldCreateCursor() {
+        KeysetPageable.Cursor cursor1 = new KeysetPageable.Cursor(1);
+        KeysetPageable.Cursor cursor2 = new KeysetPageable.Cursor(2, "two");
+
+        assertSoftly(softly -> {
+            softly.assertThat(cursor1.size()).isEqualTo(1);
+            softly.assertThat(cursor1.getKeysetElement(0)).isEqualTo(1);
+            softly.assertThat(cursor2.size()).isEqualTo(2);
+            softly.assertThat(cursor2.getKeysetElement(0)).isEqualTo(2);
+            softly.assertThat(cursor2.getKeysetElement(1)).isEqualTo("two");
+        });
+    }
+
+    @Test
     @DisplayName("Should include keyset values in next KeysetPageable")
     void shouldCreateKeysetPageableAfterKeyset() {
         KeysetPageable pageable = Pageable.size(20).afterKeyset("First", 2L, 3);
@@ -49,7 +64,7 @@ class KeysetPageableTest {
     @Test
     @DisplayName("Should include keyset values in next KeysetPageable from Cursor")
     void shouldCreateKeysetPageableAfterKeysetCursor() {
-        KeysetPageable.Cursor cursor = new KeysetPageable.CursorImpl("me", 200);
+        KeysetPageable.Cursor cursor = new KeysetPageable.Cursor("me", 200);
         KeysetPageable pageable = Pageable.of(1, 35, Sort.asc("name"), Sort.asc("id")).afterKeysetCursor(cursor);
 
         assertSoftly(softly -> {
@@ -82,7 +97,7 @@ class KeysetPageableTest {
     @Test
     @DisplayName("Should include keyset values in previous KeysetPageable from Cursor")
     void shouldCreateKeysetPageableBeforeKeysetCursor() {
-        KeysetPageable.Cursor cursor = new KeysetPageable.CursorImpl(900L, 300, "testing", 120, 'T');
+        KeysetPageable.Cursor cursor = new KeysetPageable.Cursor(900L, 300, "testing", 120, 'T');
         KeysetPageable pageable = Pageable.page(8).beforeKeysetCursor(cursor);
 
         assertSoftly(softly -> {
@@ -147,27 +162,16 @@ class KeysetPageableTest {
     void shouldBeEqualWithSameKeysetValues() {
         KeysetPageable pageable25p1s0a1 = Pageable.size(25).afterKeyset("keyval1", '2', 3);
         KeysetPageable pageable25p1s0b1 = Pageable.size(25).beforeKeyset("keyval1", '2', 3);
-        KeysetPageable pageable25p1s0a1match = Pageable.of(1, 25).afterKeysetCursor(new KeysetPageable.CursorImpl("keyval1", '2', 3));
-        KeysetPageable pageable25p2s0a1 = Pageable.of(2, 25).afterKeysetCursor(new KeysetPageable.CursorImpl("keyval1", '2', 3));
+        KeysetPageable pageable25p1s0a1match = Pageable.of(1, 25).afterKeysetCursor(new KeysetPageable.Cursor("keyval1", '2', 3));
+        KeysetPageable pageable25p2s0a1 = Pageable.of(2, 25).afterKeysetCursor(new KeysetPageable.Cursor("keyval1", '2', 3));
         KeysetPageable pageable25p1s1a1 = Pageable.of(1, 25, Sort.desc("d"), Sort.asc("a"), Sort.asc("id")).afterKeyset("keyval1", '2', 3);
         KeysetPageable pageable25p1s2a1 = Pageable.of(1, 25, Sort.desc("d"), Sort.asc("a"), Sort.desc("id")).afterKeyset("keyval1", '2', 3);
         KeysetPageable pageable25p1s0a2 = Pageable.size(25).afterKeyset("keyval2", '2', 3);
 
-        KeysetPageable.Cursor cursor1 = new KeysetPageable.CursorImpl("keyval1", '2', 3);
-        KeysetPageable.Cursor cursor2 = new KeysetPageable.CursorImpl("keyval2", '2', 3);
-        KeysetPageable.Cursor cursor3 = new KeysetPageable.CursorImpl("keyval1", '2');
-        KeysetPageable.Cursor cursor4 = new KeysetPageable.Cursor() {
-            private final Object[] keyset = new Object[] { "keyval1", '2', 3 };
-
-            @Override
-            public Object getKeysetElement(int index) {
-                return keyset[index];
-            }
-
-            @Override
-            public int size() {
-                return keyset.length;
-            }
+        KeysetPageable.Cursor cursor1 = new KeysetPageable.Cursor("keyval1", '2', 3);
+        KeysetPageable.Cursor cursor2 = new KeysetPageable.Cursor("keyval2", '2', 3);
+        KeysetPageable.Cursor cursor3 = new KeysetPageable.Cursor("keyval1", '2');
+        KeysetPageable.Cursor cursor4 = new KeysetPageable.Cursor("keyval1", '2', 3) {
         };
 
         assertSoftly(softly -> {


### PR DESCRIPTION
This pull is opened in response to a [review comment](https://github.com/jakartaee/data/pull/52#pullrequestreview-1165337102) from @keilw about switching the `Cursor` interface to a class.  It needs to be agreed upon with @beikov whether to cancel this pull without changes because the interface is preferable or whether to merge the pull and switch to a class.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>