### PR TITLE
Pageable as an interface

### DIFF
--- a/api/src/main/java/jakarta/data/repository/KeysetPagination.java
+++ b/api/src/main/java/jakarta/data/repository/KeysetPagination.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data.repository;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Built-in implementation of KeysetPageable.
+ */
+class KeysetPagination extends Pagination implements KeysetPageable {
+
+    private final Cursor cursor;
+    private final Mode mode;
+
+    KeysetPagination(long pageNumber, int maxPageSize, List<Sort> sorts, Mode mode, Cursor cursor) {
+        super(pageNumber, maxPageSize, sorts);
+
+        if (cursor == null || cursor.size() == 0)
+            throw new IllegalArgumentException("No keyset values were provided.");
+
+        this.cursor = cursor;
+        this.mode = mode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        KeysetPagination p;
+        return this == o || o != null
+                && o.getClass() == getClass()
+                && (p = (KeysetPagination) o).size == size
+                && p.page == page
+                && p.mode == mode
+                && p.cursor.equals(cursor)
+                && p.sorts.equals(sorts);
+    }
+
+    @Override
+    public Cursor getCursor() {
+        return cursor;
+    }
+
+    @Override
+    public Mode getMode() {
+        return mode;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(size, page, sorts, mode, cursor);
+    }
+
+    @Override
+    public KeysetPageable next() {
+        throw new UnsupportedOperationException("Not supported for keyset pagination. Instead use afterKeyset or afterKeysetCursor " +
+                                                "to provide the next keyset values or obtain the nextPageable from a KeysetAwareSlice.");
+    }
+
+    @Override
+    public KeysetPageable page(long pageNumber) {
+        return new KeysetPagination(pageNumber, size, sorts, mode, cursor);
+    }
+
+    @Override
+    public KeysetPageable size(int maxPageSize) {
+        return new KeysetPagination(page, maxPageSize, sorts, mode, cursor);
+    }
+
+    @Override
+    public KeysetPageable sortBy(Iterable<Sort> sorts) {
+        List<Sort> sortList = sorts == null
+                ? Collections.emptyList()
+                : StreamSupport.stream(sorts.spliterator(), false).collect(Collectors.toUnmodifiableList());
+        return new KeysetPagination(page, size, sortList, mode, cursor);
+    }
+
+    @Override
+    public KeysetPageable sortBy(Sort... sorts) {
+        List<Sort> sortList = sorts == null ? Collections.emptyList() : List.of(sorts);
+        return new KeysetPagination(page, size, sortList, mode, cursor);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder s = new StringBuilder(150)
+                .append("KeysetPageable{page=").append(page)
+                .append(", size=").append(size)
+                .append(", mode=").append(mode)
+                .append(", ").append(cursor.size()).append(" keys");
+        for (Sort sort : sorts) {
+            s.append(", ").append(sort.getProperty()).append(sort.isAscending() ? " ASC" : " DESC");
+        }
+        return s.append("}").toString();
+    }
+
+    /**
+     * Built-in implementation of Cursor.
+     */
+    static final class CursorImpl implements Cursor {
+        /**
+         * Keyset values.
+         */
+        private final Object[] keyset;
+
+        /**
+         * Constructs a keyset cursor with the specified values.
+         *
+         * @param keyset keyset values.
+         * @throws IllegalArgumentException if no keyset values are provided.
+         */
+        CursorImpl(Object... keyset) {
+            this.keyset = keyset;
+            if (keyset == null || keyset.length == 0)
+                throw new IllegalArgumentException("No keyset values were provided.");
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return this == o || o != null
+                    && o.getClass() == getClass()
+                    && Arrays.equals(keyset, ((CursorImpl) o).keyset);
+        }
+
+        public Object getKeysetElement(int index) {
+            return keyset[index];
+        }
+
+        @Override
+        public int hashCode() {
+            return Arrays.hashCode(keyset);
+        }
+
+        public int size() {
+            return keyset.length;
+        }
+
+        @Override
+        public String toString() {
+            return new StringBuilder(27).append("Cursor@").append(Integer.toHexString(hashCode()))
+                            .append(" with ").append(keyset.length).append(" keys")
+                            .toString();
+        }
+    }
+}

--- a/api/src/main/java/jakarta/data/repository/Pageable.java
+++ b/api/src/main/java/jakarta/data/repository/Pageable.java
@@ -19,9 +19,6 @@ package jakarta.data.repository;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import jakarta.data.repository.KeysetPageable.Cursor;
 
@@ -38,7 +35,7 @@ import jakarta.data.repository.KeysetPageable.Cursor;
  * Person[] findByAgeBetween(int minAge, int maxAge, Pageable pagination);
  *
  * ...
- * for (Pageable p = Pageable.of(1, 100); p != null; p = page.length == 0 ? null : p.next()) {
+ * for (Pageable p = Pageable.ofSize(100); p != null; p = page.length == 0 ? null : p.next()) {
  *   page = people.findByAgeBetween(35, 59, p);
  *   ...
  * }
@@ -54,225 +51,179 @@ import jakarta.data.repository.KeysetPageable.Cursor;
  *     with the <code>First</code> keyword.</li>
  * </ul>
  */
-public class Pageable {
-
-    private static final long DEFAULT_SIZE = 10;
-
-    final long page;
-
-    final long size;
-
-    final List<Sort> sorts;
-
-    Pageable(long page, long size, List<Sort> sorts) {
-        this.page = page;
-        this.size = size;
-        this.sorts = sorts;
-    }
+public interface Pageable {
 
     /**
-     * <p>Requests {@link KeysetPageable keyset pagination} in the forward direction,
-     * starting after the specified keyset values.</p>
+     * Creates a new <code>Pageable</code> with the given page number and with a default size of 10.
      *
-     * @param keyset keyset values, the order and number of which must match the
-     *        {@link OrderBy} annotations, {@link Sort} parameters, or
-     *        <code>OrderBy</code> name pattern of the repository method to which
-     *        this pagination will be supplied.
-     * @return forward keyset pagination.
-     * @throws IllegalArgumentException if no keyset values are provided.
+     * @param pageNumber The page number.
+     * @return a new instance of <code>Pageable</code>.
+     * @throws IllegalArgumentException when the page number is negative or zero.
      */
-    public KeysetPageable afterKeyset(Object... keyset) {
-        return new KeysetPageable(this, KeysetPageable.Mode.NEXT, new KeysetPageable.CursorImpl(keyset));
-    }
-
-    /**
-     * <p>Requests {@link KeysetPageable keyset pagination} in the reverse direction,
-     * starting after the specified keyset values.</p>
-     *
-     * @param keyset keyset values, the order and number of which must match the
-     *        {@link OrderBy} annotations, {@link Sort} parameters, or
-     *        <code>OrderBy</code> name pattern of the repository method to which
-     *        this pagination will be supplied.
-     * @return reverse keyset pagination.
-     * @throws IllegalArgumentException if no keyset values are provided.
-     */
-    public KeysetPageable beforeKeyset(Object... keyset) {
-        return new KeysetPageable(this, KeysetPageable.Mode.PREVIOUS, new KeysetPageable.CursorImpl(keyset));
-    }
-
-    /**
-     * <p>Requests {@link KeysetPageable keyset pagination} in the forward direction,
-     * starting after the specified keyset values.</p>
-     *
-     * @param keysetCursor cursor with keyset values, the order and number of which must match the
-     *        {@link OrderBy} annotations, {@link Sort} parameters, or
-     *        <code>OrderBy</code> name pattern of the repository method to which
-     *        this pagination will be supplied.
-     * @return forward keyset pagination.
-     * @throws IllegalArgumentException if no keyset values are provided.
-     */
-    public KeysetPageable afterKeysetCursor(Cursor keysetCursor) {
-        return new KeysetPageable(this, KeysetPageable.Mode.NEXT, keysetCursor);
-    }
-
-    /**
-     * <p>Requests {@link KeysetPageable keyset pagination} in the reverse direction,
-     * starting after the specified keyset values.</p>
-     *
-     * @param keysetCursor cursor with keyset values, the order and number of which must match the
-     *        {@link OrderBy} annotations, {@link Sort} parameters, or
-     *        <code>OrderBy</code> name pattern of the repository method to which
-     *        this pagination will be supplied.
-     * @return reverse keyset pagination.
-     * @throws IllegalArgumentException if no keyset values are provided.
-     */
-    public KeysetPageable beforeKeysetCursor(Cursor keysetCursor) {
-        return new KeysetPageable(this, KeysetPageable.Mode.PREVIOUS, keysetCursor);
-    }
-
-    /**
-     * Returns the page to be returned.
-     *
-     * @return the page to be returned.
-     */
-    public long getPage() {
-        return page;
-    }
-
-    /**
-     * Returns the size of each page
-     *
-     * @return the size of each page
-     */
-    public long getSize() {
-        return size;
-    }
-
-    /**
-     * Return the order collection if it was specified on this <code>Pageable</code>, otherwise an empty list.
-     *
-     * @return the order collection
-     */
-    public List<Sort> getSorts() {
-        return sorts;
-    }
-
-    /**
-     * Returns the Pageable requesting the next Page.
-     *
-     * @return The next pageable.
-     */
-    public Pageable next() {
-        return new Pageable((page + 1), this.size, this.sorts);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Pageable pageable = (Pageable) o;
-        return size == pageable.size && page == pageable.page && sorts.equals(pageable.sorts);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(page, size, sorts);
-    }
-
-    @Override
-    public String toString() {
-        StringBuilder s = new StringBuilder(100)
-                .append("Pageable{page=").append(page)
-                .append(", size=").append(size);
-        for (Sort sort : sorts) {
-            s.append(", ").append(sort.getProperty()).append(sort.isAscending() ? " ASC" : " DESC");
-        }
-        return s.append("}").toString();
-    }
-
-    /**
-     * Creates a new Pageable at the given page with a default size of 10.
-     *
-     * @param page The page
-     * @return The pageable
-     */
-    public static Pageable page(long page) {
-        return of(page, DEFAULT_SIZE);
-    }
-
-    /**
-     * Creates a new Pageable at the given size and page
-     *
-     * @param page The page
-     * @param size The size
-     * @return The pageable
-     * @throws IllegalArgumentException when page or size are negative or zero
-     */
-    public static Pageable of(long page, long size) {
-        return of(page, size, Collections.emptyList());
-    }
-
-    /**
-     * Creates a new Pageable at the given size, page and Sort
-     *
-     * @param page The page
-     * @param size The size
-     * @param sort the sort
-     * @return The pageable
-     * @throws IllegalArgumentException when page or size are negative or zero
-     */
-    public static Pageable of(long page, long size, Sort sort) {
-        Objects.requireNonNull(sort, "sort is required");
-        return of(page, size, Collections.singletonList(sort));
-    }
-
-    /**
-     * Creates a new Pageable at the given size, page and Sort
-     *
-     * @param page  The page
-     * @param size  The size
-     * @param sorts the sorts
-     * @return The pageable
-     * @throws IllegalArgumentException when page or size are negative or zero
-     */
-    public static Pageable of(long page, long size, Sort... sorts) {
-        return of(page, size, List.of(sorts));
-    }
-
-    /**
-     * Creates a new Pageable at the given size, page and Sort
-     *
-     * @param page  The page
-     * @param size  The size
-     * @param sorts the sorts
-     * @return The pageable
-     * @throws IllegalArgumentException when page or size are negative
-     * @throws NullPointerException     when sorts is null
-     */
-    public static Pageable of(long page, long size, Iterable<Sort> sorts) {
-        if (page < 1) {
-            throw new IllegalArgumentException("page: " + page);
-        } else if (size < 1) {
-            throw new IllegalArgumentException("size: " + size);
-        }
-        Objects.requireNonNull(sorts, "sorts is required");
-        return new Pageable(page, size, StreamSupport.stream(sorts.spliterator(), false)
-                .filter(Objects::nonNull)
-                .collect(Collectors.toUnmodifiableList()));
+    public static Pageable ofPage(long pageNumber) {
+        return new Pagination(pageNumber, 10, Collections.emptyList());
     }
 
     /**
      * Creates a new <code>Pageable</code> for requesting pages of the
      * specified size, starting with the first page number, which is 1.
      *
-     * @param pageSize number of query results in a full page.
-     * @return The pageable.
+     * @param maxPageSize The number of query results in a full page.
+     * @return a new instance of <code>Pageable</code>.
+     * @throws IllegalArgumentException when maximum page size is negative or zero.
      */
-    public static Pageable size(long pageSize) {
-        return of(1, pageSize);
+    public static Pageable ofSize(int maxPageSize) {
+        return new Pagination(1, maxPageSize, Collections.emptyList());
     }
+
+    /**
+     * <p>Requests {@link KeysetPageable keyset pagination} in the forward direction,
+     * starting after the specified keyset values.</p>
+     *
+     * @param keyset keyset values, the order and number of which must match the
+     *        {@link OrderBy} annotations, {@link Sort} parameters, or
+     *        <code>OrderBy</code> name pattern of the repository method to which
+     *        this pagination will be supplied.
+     * @return a new instance of <code>KeysetPageable</code> with forward keyset pagination.
+     * @throws IllegalArgumentException if no keyset values are provided.
+     */
+    public KeysetPageable afterKeyset(Object... keyset);
+
+    /**
+     * <p>Requests {@link KeysetPageable keyset pagination} in the reverse direction,
+     * starting after the specified keyset values.</p>
+     *
+     * @param keyset keyset values, the order and number of which must match the
+     *        {@link OrderBy} annotations, {@link Sort} parameters, or
+     *        <code>OrderBy</code> name pattern of the repository method to which
+     *        this pagination will be supplied.
+     * @return a new instance of <code>KeysetPageable</code> with reverse keyset pagination.
+     * @throws IllegalArgumentException if no keyset values are provided.
+     */
+    public KeysetPageable beforeKeyset(Object... keyset);
+
+    /**
+     * <p>Requests {@link KeysetPageable keyset pagination} in the forward direction,
+     * starting after the specified keyset values.</p>
+     *
+     * @param keysetCursor cursor with keyset values, the order and number of which must match the
+     *        {@link OrderBy} annotations, {@link Sort} parameters, or
+     *        <code>OrderBy</code> name pattern of the repository method to which
+     *        this pagination will be supplied.
+     * @return a new instance of <code>KeysetPageable</code> with forward keyset pagination.
+     * @throws IllegalArgumentException if no keyset values are provided.
+     */
+    public KeysetPageable afterKeysetCursor(Cursor keysetCursor);
+
+    /**
+     * <p>Requests {@link KeysetPageable keyset pagination} in the reverse direction,
+     * starting after the specified keyset values.</p>
+     *
+     * @param keysetCursor cursor with keyset values, the order and number of which must match the
+     *        {@link OrderBy} annotations, {@link Sort} parameters, or
+     *        <code>OrderBy</code> name pattern of the repository method to which
+     *        this pagination will be supplied.
+     * @return a new instance of <code>KeysetPageable</code> with reverse keyset pagination.
+     * @throws IllegalArgumentException if no keyset values are provided.
+     */
+    public KeysetPageable beforeKeysetCursor(Cursor keysetCursor);
+
+    /**
+     * Compares with another instance to determine if both represent the same
+     * pagination information.
+     *
+     * @return true if both instances are of the same class and
+     *         represent the same pagination information. Otherwise false.
+     */
+    @Override
+    public boolean equals(Object o);
+
+    /**
+     * Returns the page to be returned.
+     *
+     * @return the page to be returned.
+     */
+    public long getPage();
+
+    /**
+     * Returns the requested size of each page
+     *
+     * @return the requested size of each page
+     */
+    public int getSize();
+
+    /**
+     * Return the order collection if it was specified on this <code>Pageable</code>, otherwise an empty list.
+     *
+     * @return the order collection
+     */
+    public List<Sort> getSorts();
+
+    /**
+     * Returns the <code>Pageable</code> requesting the next page.
+     *
+     * @return The next pageable.
+     */
+    public Pageable next();
+
+    /**
+     * <p>Creates a new <code>Pageable</code> instance representing the same
+     * pagination information, except with the specified page number.</p>
+     *
+     * @param pageNumber The page number
+     * @return a new instance of <code>Pageable</code>.
+     */
+    public Pageable page(long pageNumber);
+
+    /**
+     * <p>Creates a new <code>Pageable</code> instance representing the same
+     * pagination information, except with the specified maximum page size.</p>
+     *
+     * @param maxPageSize the number of query results in a full page.
+     * @return a new instance of <code>Pageable</code>.
+     */
+    public Pageable size(int maxPageSize);
+
+    /**
+     * <p>Creates a new <code>Pageable</code> instance representing the same
+     * pagination information, except using the specified sort criteria.
+     * The order of precedence of sort criteria is the order of the
+     * {@link Iterable} that is supplied to this method.</p>
+     *
+     * <p>A repository method will fail if a sort criteria is specified on a
+     * <code>Pageable</code> in combination with any of:</p>
+     * <ul>
+     * <li>an <code>OrderBy</code> keyword</li>
+     * <li>an {@link OrderBy} annotation</li>
+     * <li>a {@link Query} annotation that contains an <code>ORDER BY</code> clause.</li>
+     * <li>{@link Sort} parameters that are specified independently of
+     *     <code>Pageable</code> on a repository method</li>
+     * </ul>
+     *
+     * @param sorts sort criteria to use.
+     * @return a new instance of <code>Pageable</code>.
+     */
+    public Pageable sortBy(Iterable<Sort> sorts);
+
+    /**
+     * <p>Creates a new <code>Pageable</code> instance representing the same
+     * pagination information, except using the specified sort criteria.
+     * The order of precedence of sort criteria is the order in which the
+     * {@link Sort} parameters to this method are listed.</p>
+     *
+     * <p>A repository method will fail if a sort criteria is specified on a
+     * <code>Pageable</code> in combination with any of:</p>
+     * <ul>
+     * <li>an <code>OrderBy</code> keyword</li>
+     * <li>an {@link OrderBy} annotation</li>
+     * <li>a {@link Query} annotation that contains an <code>ORDER BY</code> clause.</li>
+     * <li>{@link Sort} parameters that are specified independently of
+     *     <code>Pageable</code> on a repository method</li>
+     * </ul>
+     *
+     * @param sorts sort criteria to use. This method can be invoked without parameters
+     *        to request a <code>Pageable</code> that does not specify sort criteria.
+     * @return a new instance of <code>Pageable</code>.
+     */
+    public Pageable sortBy(Sort... sorts);
 }

--- a/api/src/main/java/jakarta/data/repository/Pagination.java
+++ b/api/src/main/java/jakarta/data/repository/Pagination.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data.repository;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import jakarta.data.repository.KeysetPageable.Cursor;
+
+/**
+ * Built-in implementation of Pageable.
+ */
+class Pagination implements Pageable {
+
+    final long page;
+
+    final int size;
+
+    final List<Sort> sorts;
+
+    Pagination(long pageNumber, int maxPageSize, List<Sort> sorts) {
+        if (pageNumber < 1) {
+            throw new IllegalArgumentException("pageNumber: " + pageNumber);
+        } else if (maxPageSize < 1) {
+            throw new IllegalArgumentException("maxPageSize: " + maxPageSize);
+        }
+
+        this.page = pageNumber;
+        this.size = maxPageSize;
+        this.sorts = sorts;
+    }
+
+    @Override
+    public KeysetPageable afterKeyset(Object... keyset) {
+        return new KeysetPagination(page, size, sorts, KeysetPageable.Mode.NEXT, new KeysetPagination.CursorImpl(keyset));
+    }
+
+    @Override
+    public KeysetPageable beforeKeyset(Object... keyset) {
+        return new KeysetPagination(page, size, sorts, KeysetPageable.Mode.PREVIOUS, new KeysetPagination.CursorImpl(keyset));
+    }
+
+    @Override
+    public KeysetPageable afterKeysetCursor(Cursor keysetCursor) {
+        return new KeysetPagination(page, size, sorts, KeysetPageable.Mode.NEXT, keysetCursor);
+    }
+
+    @Override
+    public KeysetPageable beforeKeysetCursor(Cursor keysetCursor) {
+        return new KeysetPagination(page, size, sorts, KeysetPageable.Mode.PREVIOUS, keysetCursor);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Pagination pageable = (Pagination) o;
+        return size == pageable.size && page == pageable.page && sorts.equals(pageable.sorts);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(page, size, sorts);
+    }
+
+    @Override
+    public Pageable next() {
+        return new Pagination((page + 1), this.size, this.sorts);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder s = new StringBuilder(100)
+                .append("Pageable{page=").append(page)
+                .append(", size=").append(size);
+        for (Sort sort : sorts) {
+            s.append(", ").append(sort.getProperty()).append(sort.isAscending() ? " ASC" : " DESC");
+        }
+        return s.append("}").toString();
+    }
+
+    @Override
+    public long getPage() {
+        return page;
+    }
+
+    @Override
+    public int getSize() {
+        return size;
+    }
+
+    @Override
+    public List<Sort> getSorts() {
+        return sorts;
+    }
+
+    @Override
+    public Pageable page(long pageNumber) {
+        return new Pagination(pageNumber, size, sorts);
+    }
+
+    @Override
+    public Pageable size(int maxPageSize) {
+        return new Pagination(page, maxPageSize, sorts);
+    }
+
+    @Override
+    public Pageable sortBy(Iterable<Sort> sorts) {
+        List<Sort> sortList = sorts == null
+                ? Collections.emptyList()
+                : StreamSupport.stream(sorts.spliterator(), false).collect(Collectors.toUnmodifiableList());
+        return new Pagination(page, size, sortList);
+    }
+
+    @Override
+    public Pageable sortBy(Sort... sorts) {
+        return new Pagination(page, size, sorts == null ? Collections.emptyList() : List.of(sorts));
+    }
+}

--- a/api/src/main/java/jakarta/data/repository/Repository.java
+++ b/api/src/main/java/jakarta/data/repository/Repository.java
@@ -372,20 +372,35 @@ import java.lang.annotation.Target;
  *           String pattern, Pageable pagination);
  * ...
  * page1 = products.findByNameLikeOrderByAmountSoldDescNameAsc(
- *                  "%phone%", Pageable.size(20));
+ *                  "%phone%", Pageable.ofSize(20));
  * </pre>
  *
- * <h3>Sorting</h3>
+ * <h3>Sorting at Runtime</h3>
  *
- * <p>You can dynamically supply sorting criteria by adding one or more
- * {@link Sort} parameters (or <code>Sort...</code>)
+ * <p>When using pagination, you can dynamically supply sorting criteria
+ * via the {@link Pageable#sortBy(Sort...)} and {@link Pageable#sortBy(Iterable)}
+ * methods. For example,</p>
+ *
+ * <pre>
+ * Product[] findByNameLike(String pattern, Pageable pagination);
+ *
+ * ...
+ * Pageable pagination = Pageable.ofSize(25).sortBy(
+ *                           Sort.desc("price"),
+ *                           Sort.asc("name"));
+ * page1 = products.findByNameLikeAndPriceBetween(
+ *                 namePattern, minPrice, maxPrice, pagination);
+ * </pre>
+ *
+ * <p>To supply sorting criteria dynamically without using pagination,
+ * add one or more {@link Sort} parameters (or <code>Sort...</code>)
  * to a repository find method. For example,</p>
  *
  * <pre>
  * Product[] findByNameLike(String pattern, Limit max, Sort... sortBy);
  *
  * ...
- * page1 = products.findByNameLike(namePattern, Pageable.of(1, 25),
+ * page1 = products.findByNameLike(namePattern, Limit.of(25),
  *                                 Sort.desc("price"),
  *                                 Sort.desc("amountSold"),
  *                                 Sort.asc("name"));

--- a/api/src/test/java/jakarta/data/repository/KeysetPageableTest.java
+++ b/api/src/test/java/jakarta/data/repository/KeysetPageableTest.java
@@ -33,10 +33,10 @@ class KeysetPageableTest {
     @Test
     @DisplayName("Should include keyset values in next KeysetPageable")
     void shouldCreateKeysetPageableAfterKeyset() {
-        KeysetPageable pageable = Pageable.size(20).afterKeyset("First", 2L, 3);
+        KeysetPageable pageable = Pageable.ofSize(20).afterKeyset("First", 2L, 3);
 
         assertSoftly(softly -> {
-            softly.assertThat(pageable.getSize()).isEqualTo(20L);
+            softly.assertThat(pageable.getSize()).isEqualTo(20);
             softly.assertThat(pageable.getPage()).isEqualTo(1L);
             softly.assertThat(pageable.getMode()).isEqualTo(KeysetPageable.Mode.NEXT);
             softly.assertThat(pageable.getCursor().size()).isEqualTo(3);
@@ -49,11 +49,11 @@ class KeysetPageableTest {
     @Test
     @DisplayName("Should include keyset values in next KeysetPageable from Cursor")
     void shouldCreateKeysetPageableAfterKeysetCursor() {
-        KeysetPageable.Cursor cursor = new KeysetPageable.CursorImpl("me", 200);
-        KeysetPageable pageable = Pageable.of(1, 35, Sort.asc("name"), Sort.asc("id")).afterKeysetCursor(cursor);
+        KeysetPageable.Cursor cursor = new KeysetPagination.CursorImpl("me", 200);
+        KeysetPageable pageable = Pageable.ofSize(35).sortBy(Sort.asc("name"), Sort.asc("id")).afterKeysetCursor(cursor);
 
         assertSoftly(softly -> {
-            softly.assertThat(pageable.getSize()).isEqualTo(35L);
+            softly.assertThat(pageable.getSize()).isEqualTo(35);
             softly.assertThat(pageable.getPage()).isEqualTo(1L);
             softly.assertThat(pageable.getSorts()).isEqualTo(List.of(Sort.asc("name"), Sort.asc("id")));
             softly.assertThat(pageable.getMode()).isEqualTo(KeysetPageable.Mode.NEXT);
@@ -66,10 +66,10 @@ class KeysetPageableTest {
     @Test
     @DisplayName("Should include keyset values in previous KeysetPageable")
     void shouldCreateKeysetPageableBeforeKeyset() {
-        KeysetPageable pageable = Pageable.of(10, 30, Sort.desc("yearBorn"), Sort.asc("ssn")).beforeKeyset(1991, "123-45-6789");
+        KeysetPageable pageable = Pageable.ofSize(30).sortBy(Sort.desc("yearBorn"), Sort.asc("ssn")).beforeKeyset(1991, "123-45-6789").page(10);
 
         assertSoftly(softly -> {
-            softly.assertThat(pageable.getSize()).isEqualTo(30L);
+            softly.assertThat(pageable.getSize()).isEqualTo(30);
             softly.assertThat(pageable.getPage()).isEqualTo(10L);
             softly.assertThat(pageable.getSorts()).isEqualTo(List.of(Sort.desc("yearBorn"), Sort.asc("ssn")));
             softly.assertThat(pageable.getMode()).isEqualTo(KeysetPageable.Mode.PREVIOUS);
@@ -82,8 +82,8 @@ class KeysetPageableTest {
     @Test
     @DisplayName("Should include keyset values in previous KeysetPageable from Cursor")
     void shouldCreateKeysetPageableBeforeKeysetCursor() {
-        KeysetPageable.Cursor cursor = new KeysetPageable.CursorImpl(900L, 300, "testing", 120, 'T');
-        KeysetPageable pageable = Pageable.page(8).beforeKeysetCursor(cursor);
+        KeysetPageable.Cursor cursor = new KeysetPagination.CursorImpl(900L, 300, "testing", 120, 'T');
+        KeysetPageable pageable = Pageable.ofPage(8).beforeKeysetCursor(cursor);
 
         assertSoftly(softly -> {
             softly.assertThat(pageable.getSize()).isEqualTo(10);
@@ -102,11 +102,11 @@ class KeysetPageableTest {
     @Test
     @DisplayName("Should be usable in a hashing structure")
     void shouldHash() {
-        KeysetPageable pageable1 = Pageable.of(1, 15, Sort.desc("yearHired"), Sort.asc("lastName"), Sort.asc("id"))
-                                           .afterKeyset(1, '1', "1");
-        KeysetPageable pageable2a = Pageable.size(15).afterKeyset(2, '2', "2");
-        KeysetPageable pageable2b = Pageable.size(15).beforeKeyset(2, '2', "2");
-        KeysetPageable pageable2c = Pageable.size(15).beforeKeyset(2, '2', "2");
+        KeysetPageable pageable1 = Pageable.ofSize(15).afterKeyset(1, '1', "1")
+                                           .sortBy(Sort.desc("yearHired"), Sort.asc("lastName"), Sort.asc("id"));
+        KeysetPageable pageable2a = Pageable.ofSize(15).afterKeyset(2, '2', "2");
+        KeysetPageable pageable2b = Pageable.ofSize(15).beforeKeyset(2, '2', "2");
+        KeysetPageable pageable2c = Pageable.ofSize(15).beforeKeyset(2, '2', "2");
         Map<KeysetPageable, Integer> map = new HashMap<>();
 
         assertSoftly(softly -> {
@@ -126,14 +126,14 @@ class KeysetPageableTest {
     @Test
     @DisplayName("Should be displayable as String with toString")
     void shouldKeysetPageableDisplayAsString() {
-        KeysetPageable pageable = Pageable.size(200).afterKeyset("value1", 1);
+        KeysetPageable pageable = Pageable.ofSize(200).afterKeyset("value1", 1);
 
         assertSoftly(softly -> {
             softly.assertThat(pageable.toString())
                   .isEqualTo("KeysetPageable{page=1, size=200, mode=NEXT, 2 keys}");
         });
 
-        KeysetPageable pageableWithSorts = Pageable.of(1, 100, Sort.desc("name"), Sort.asc("id"))
+        KeysetPageable pageableWithSorts = Pageable.ofSize(100).sortBy(Sort.desc("name"), Sort.asc("id"))
                                                    .beforeKeyset("Item1", 3456);
 
         assertSoftly(softly -> {
@@ -145,18 +145,18 @@ class KeysetPageableTest {
     @Test
     @DisplayName("Should return true from equals if keyset values and other properties are equal")
     void shouldBeEqualWithSameKeysetValues() {
-        KeysetPageable pageable25p1s0a1 = Pageable.size(25).afterKeyset("keyval1", '2', 3);
-        KeysetPageable pageable25p1s0b1 = Pageable.size(25).beforeKeyset("keyval1", '2', 3);
-        KeysetPageable pageable25p1s0a1match = Pageable.of(1, 25).afterKeysetCursor(new KeysetPageable.CursorImpl("keyval1", '2', 3));
-        KeysetPageable pageable25p2s0a1 = Pageable.of(2, 25).afterKeysetCursor(new KeysetPageable.CursorImpl("keyval1", '2', 3));
-        KeysetPageable pageable25p1s1a1 = Pageable.of(1, 25, Sort.desc("d"), Sort.asc("a"), Sort.asc("id")).afterKeyset("keyval1", '2', 3);
-        KeysetPageable pageable25p1s2a1 = Pageable.of(1, 25, Sort.desc("d"), Sort.asc("a"), Sort.desc("id")).afterKeyset("keyval1", '2', 3);
-        KeysetPageable pageable25p1s0a2 = Pageable.size(25).afterKeyset("keyval2", '2', 3);
+        KeysetPageable pageable25p1s0a1 = Pageable.ofSize(25).afterKeyset("keyval1", '2', 3);
+        KeysetPageable pageable25p1s0b1 = Pageable.ofSize(25).beforeKeyset("keyval1", '2', 3);
+        KeysetPageable pageable25p1s0a1match = Pageable.ofSize(25).afterKeysetCursor(new KeysetPagination.CursorImpl("keyval1", '2', 3));
+        KeysetPageable pageable25p2s0a1 = Pageable.ofPage(2).size(25).afterKeysetCursor(new KeysetPagination.CursorImpl("keyval1", '2', 3));
+        KeysetPageable pageable25p1s1a1 = Pageable.ofSize(25).sortBy(Sort.desc("d"), Sort.asc("a"), Sort.asc("id")).afterKeyset("keyval1", '2', 3);
+        KeysetPageable pageable25p1s2a1 = Pageable.ofSize(25).sortBy(Sort.desc("d"), Sort.asc("a"), Sort.desc("id")).afterKeyset("keyval1", '2', 3);
+        KeysetPageable pageable25p1s0a2 = Pageable.ofSize(25).afterKeyset("keyval2", '2', 3);
 
-        KeysetPageable.Cursor cursor1 = new KeysetPageable.CursorImpl("keyval1", '2', 3);
-        KeysetPageable.Cursor cursor2 = new KeysetPageable.CursorImpl("keyval2", '2', 3);
-        KeysetPageable.Cursor cursor3 = new KeysetPageable.CursorImpl("keyval1", '2');
-        KeysetPageable.Cursor cursor4 = new KeysetPageable.Cursor() {
+        KeysetPageable.Cursor cursor1 = new KeysetPagination.CursorImpl("keyval1", '2', 3);
+        KeysetPageable.Cursor cursor2 = new KeysetPagination.CursorImpl("keyval2", '2', 3);
+        KeysetPageable.Cursor cursor3 = new KeysetPagination.CursorImpl("keyval1", '2');
+        KeysetPageable.Cursor cursor4 = new KeysetPagination.Cursor() {
             private final Object[] keyset = new Object[] { "keyval1", '2', 3 };
 
             @Override
@@ -189,19 +189,45 @@ class KeysetPageableTest {
             softly.assertThat(pageable25p1s0a1.equals(pageable25p1s1a1)).isFalse(); // with vs without sorting
             softly.assertThat(pageable25p1s2a1.equals(pageable25p1s1a1)).isFalse(); // different sorting
             softly.assertThat(pageable25p1s0a1.equals(pageable25p1s0a2)).isFalse(); // different keyset value
-            softly.assertThat(pageable25p1s0a1.equals(Pageable.of(1, 25))).isFalse(); // KeysetPageable vs Pageable
-            softly.assertThat(Pageable.of(1, 25).equals(pageable25p1s0a1)).isFalse(); // Pageable vs KeysetPageable
+            softly.assertThat(pageable25p1s0a1.equals(Pageable.ofSize(25))).isFalse(); // KeysetPageable vs Pageable
+            softly.assertThat(Pageable.ofSize(25).equals(pageable25p1s0a1)).isFalse(); // Pageable vs KeysetPageable
         });
     }
 
     @Test
     @DisplayName("Should raise IllegalArgumentException when keyset values are absent")
     void shouldRaiseErrorForMissingKeysetValues() {
-        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.size(60).afterKeyset(null));
-        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.size(70).afterKeyset(new Object[0]));
-        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.size(80).beforeKeyset(null));
-        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.size(90).beforeKeyset(new Object[0]));
+        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.ofSize(60).afterKeyset(null));
+        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.ofSize(70).afterKeyset(new Object[0]));
+        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.ofSize(80).beforeKeyset(null));
+        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.ofSize(90).beforeKeyset(new Object[0]));
     }
 
+    @Test
+    @DisplayName("Keyset should be replaced on new instance of KeysetPageable")
+    public void shouldReplaceKeyset() {
+        KeysetPageable p1 = Pageable.ofSize(30).sortBy(Sort.asc("lastName"), Sort.asc("firstName"), Sort.asc("id"))
+                                    .afterKeyset("last1", "fname1", 100).page(12);
+        KeysetPageable p2 = p1.beforeKeyset("lname2", "fname2", 200);
+
+        assertSoftly(softly -> {
+            softly.assertThat(p1.getMode()).isEqualTo(KeysetPageable.Mode.NEXT);
+            softly.assertThat(p1.getCursor().getKeysetElement(0)).isEqualTo("last1");
+            softly.assertThat(p1.getCursor().getKeysetElement(1)).isEqualTo("fname1");
+            softly.assertThat(p1.getCursor().getKeysetElement(2)).isEqualTo(100);
+
+            softly.assertThat(p2.getMode()).isEqualTo(KeysetPageable.Mode.PREVIOUS);
+            softly.assertThat(p2.getCursor().getKeysetElement(0)).isEqualTo("lname2");
+            softly.assertThat(p2.getCursor().getKeysetElement(1)).isEqualTo("fname2");
+            softly.assertThat(p2.getCursor().getKeysetElement(2)).isEqualTo(200);
+
+            softly.assertThat(p1.getSorts()).isEqualTo(List.of(Sort.asc("lastName"), Sort.asc("firstName"), Sort.asc("id")));
+            softly.assertThat(p2.getSorts()).isEqualTo(List.of(Sort.asc("lastName"), Sort.asc("firstName"), Sort.asc("id")));
+            softly.assertThat(p1.getPage()).isEqualTo(12L);
+            softly.assertThat(p2.getPage()).isEqualTo(12L);
+            softly.assertThat(p1.getSize()).isEqualTo(30);
+            softly.assertThat(p2.getSize()).isEqualTo(30);
+        });
+    }
 }
 

--- a/api/src/test/java/jakarta/data/repository/PageableTest.java
+++ b/api/src/test/java/jakarta/data/repository/PageableTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,47 +33,47 @@ class PageableTest {
     @Test
     @DisplayName("Should correctly paginate")
     void shouldCreatePageable() {
-        Pageable pageable = Pageable.of(2, 6);
+        Pageable pageable = Pageable.ofPage(2).size(6);
 
         assertSoftly(softly -> {
             softly.assertThat(pageable.getPage()).isEqualTo(2L);
-            softly.assertThat(pageable.getSize()).isEqualTo(6L);
+            softly.assertThat(pageable.getSize()).isEqualTo(6);
         });
     }
 
     @Test
     @DisplayName("Should create pageable with size")
     void shouldCreatePageableWithSize() {
-        Pageable pageable = Pageable.size(50);
+        Pageable pageable = Pageable.ofSize(50);
 
         assertSoftly(softly -> {
             softly.assertThat(pageable.getPage()).isEqualTo(1L);
-            softly.assertThat(pageable.getSize()).isEqualTo(50L);
+            softly.assertThat(pageable.getSize()).isEqualTo(50);
         });
     }
 
     @Test
     @DisplayName("Should navigate next")
     void shouldNext() {
-        Pageable pageable = Pageable.of(2, 1);
+        Pageable pageable = Pageable.ofSize(1).page(2);
         Pageable next = pageable.next();
 
         assertSoftly(softly -> {
             softly.assertThat(pageable.getPage()).isEqualTo(2L);
-            softly.assertThat(pageable.getSize()).isEqualTo(1L);
+            softly.assertThat(pageable.getSize()).isEqualTo(1);
             softly.assertThat(next.getPage()).isEqualTo(3L);
-            softly.assertThat(next.getSize()).isEqualTo(1L);
+            softly.assertThat(next.getSize()).isEqualTo(1);
         });
     }
 
     @Test
     @DisplayName("Should create a new Pageable at the given page with a default size of 10")
     void shouldCreatePage() {
-        Pageable pageable = Pageable.page(5);
+        Pageable pageable = Pageable.ofPage(5);
 
         assertSoftly(softly -> {
             softly.assertThat(pageable.getPage()).isEqualTo(5L);
-            softly.assertThat(pageable.getSize()).isEqualTo(10L);
+            softly.assertThat(pageable.getSize()).isEqualTo(10);
         });
     }
 
@@ -81,12 +82,12 @@ class PageableTest {
     void shouldPageableDisplayAsString() {
 
         assertSoftly(softly -> {
-            softly.assertThat(Pageable.size(60).toString())
+            softly.assertThat(Pageable.ofSize(60).toString())
                   .isEqualTo("Pageable{page=1, size=60}");
         });
 
         assertSoftly(softly -> {
-            softly.assertThat(Pageable.of(1, 80, Sort.desc("yearBorn"), Sort.asc("monthBorn"), Sort.asc("id")).toString())
+            softly.assertThat(Pageable.ofSize(80).sortBy(Sort.desc("yearBorn"), Sort.asc("monthBorn"), Sort.asc("id")).toString())
                   .isEqualTo("Pageable{page=1, size=80, yearBorn DESC, monthBorn ASC, id ASC}");
         });
     }
@@ -94,31 +95,35 @@ class PageableTest {
     @Test
     @DisplayName("Should throw IllegalArgumentException when page is not present")
     void shouldReturnErrorWhenThereIsIllegalArgument() {
-        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.page(0));
-        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.page(-1));
-        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.of(1, -1));
-        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.of(1, 0));
-        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.size(0));
-        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.size(-1));
+        Pageable p1 = Pageable.ofPage(1);
+        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.ofPage(0));
+        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.ofPage(-1));
+        assertThatIllegalArgumentException().isThrownBy(() -> p1.size(-1));
+        assertThatIllegalArgumentException().isThrownBy(() -> p1.size(0));
+        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.ofSize(0));
+        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.ofSize(-1));
     }
 
     @Test
-    public void shouldReturnNPEWhenSortIsNull() {
-        Assertions.assertThrows(NullPointerException.class, () ->
-                Pageable.of(1L, 2L, (Sort) null));
-        Assertions.assertThrows(NullPointerException.class, () ->
-                Pageable.of(1L, 2L, (Iterable<Sort>) null));
+    public void shouldHaveEmptySortListWhenSortIsNullOrEmpty() {
+        Pageable p = Pageable.ofSize(2).sortBy(Sort.asc("Id"));
 
-        Assertions.assertThrows(NullPointerException.class, () ->
-                Pageable.of(1L, 2L, Sort.asc("name"), null));
+        assertSoftly(softly -> {
+            softly.assertThat(p.getSorts()).isEqualTo(List.of(Sort.asc("Id")));
+            softly.assertThat(p.sortBy().getSorts()).isEqualTo(Collections.EMPTY_LIST);
+            softly.assertThat(p.sortBy((Iterable<Sort>) null).getSorts()).isEqualTo(Collections.EMPTY_LIST);
+            softly.assertThat(p.sortBy((Sort[]) null).getSorts()).isEqualTo(Collections.EMPTY_LIST);
+            softly.assertThat(p.sortBy(new Sort[0]).getSorts()).isEqualTo(Collections.EMPTY_LIST);
+            softly.assertThat(p.sortBy(List.of()).getSorts()).isEqualTo(Collections.EMPTY_LIST);
+        });
     }
 
     @Test
     public void shouldCreatePageableSort() {
-        Pageable pageable = Pageable.of(1L, 3L, Sort.asc("name"));
+        Pageable pageable = Pageable.ofSize(3).sortBy(Sort.asc("name"));
         Assertions.assertNotNull(pageable);
         Assertions.assertEquals(1L, pageable.getPage());
-        Assertions.assertEquals(3L, pageable.getSize());
+        Assertions.assertEquals(3, pageable.getSize());
         assertThat(pageable.getSorts())
                 .hasSize(1)
                 .contains(Sort.asc("name"));
@@ -126,7 +131,7 @@ class PageableTest {
 
     @Test
     public void shouldNotModifySort() {
-        Pageable pageable = Pageable.of(1L, 3L, Sort.asc("name"));
+        Pageable pageable = Pageable.ofSize(3).sortBy(Sort.asc("name"));
         List<Sort> sorts = pageable.getSorts();
         Assertions.assertThrows(UnsupportedOperationException.class, ()-> sorts.clear());
 
@@ -134,20 +139,66 @@ class PageableTest {
 
     @Test
     public void shouldNotModifySortOnNextPage() {
-        Pageable pageable = Pageable.of(1L, 3L, Sort.asc("name"), Sort.desc("age"));
+        Pageable pageable = Pageable.ofSize(3).sortBy(Sort.asc("name"), Sort.desc("age"));
         Pageable next = pageable.next();
         Assertions.assertEquals(1L, pageable.getPage());
-        Assertions.assertEquals(3L, pageable.getSize());
+        Assertions.assertEquals(3, pageable.getSize());
         assertThat(pageable.getSorts())
                 .hasSize(2)
                 .contains(Sort.asc("name"), Sort.desc("age"));
         Assertions.assertEquals(2L, next.getPage());
-        Assertions.assertEquals(3L, next.getSize());
+        Assertions.assertEquals(3, next.getSize());
 
         assertThat(next.getSorts())
                 .hasSize(2)
                 .contains(Sort.asc("name"), Sort.desc("age"));
 
+    }
+
+    @Test
+    @DisplayName("Page number should be replaced on new instance of Pageable")
+    public void shouldReplacePage() {
+        Pageable p6 = Pageable.ofSize(75).page(6).sortBy(Sort.desc("price"));
+        Pageable p7 = p6.page(7);
+
+        assertSoftly(softly -> {
+            softly.assertThat(p7.getPage()).isEqualTo(7L);
+            softly.assertThat(p6.getPage()).isEqualTo(6L);
+            softly.assertThat(p7.getSize()).isEqualTo(75);
+            softly.assertThat(p6.getSize()).isEqualTo(75);
+            softly.assertThat(p7.getSorts()).isEqualTo(List.of(Sort.desc("price")));
+            softly.assertThat(p6.getSorts()).isEqualTo(List.of(Sort.desc("price")));
+        });
+    }
+
+    @Test
+    @DisplayName("Size should be replaced on new instance of Pageable")
+    public void shouldReplaceSize() {
+        Pageable s90 = Pageable.ofPage(4).size(90);
+        Pageable s80 = s90.size(80);
+
+        assertSoftly(softly -> {
+            softly.assertThat(s80.getSize()).isEqualTo(80);
+            softly.assertThat(s90.getSize()).isEqualTo(90);
+            softly.assertThat(s90.getPage()).isEqualTo(4L);
+            softly.assertThat(s80.getPage()).isEqualTo(4L);
+        });
+    }
+
+    @Test
+    @DisplayName("Sorts should be replaced on new instance of Pageable")
+    public void shouldReplaceSorts() {
+        Pageable p1 = Pageable.ofSize(55).sortBy(Sort.desc("lastName"), Sort.asc("firstName"));
+        Pageable p2 = p1.sortBy(Sort.asc("firstName"), Sort.asc("lastName"));
+
+        assertSoftly(softly -> {
+            softly.assertThat(p1.getSorts()).isEqualTo(List.of(Sort.desc("lastName"), Sort.asc("firstName")));
+            softly.assertThat(p2.getSorts()).isEqualTo(List.of(Sort.asc("firstName"), Sort.asc("lastName")));
+            softly.assertThat(p1.getPage()).isEqualTo(1L);
+            softly.assertThat(p2.getPage()).isEqualTo(1L);
+            softly.assertThat(p1.getSize()).isEqualTo(55);
+            softly.assertThat(p2.getSize()).isEqualTo(55);
+        });
     }
 }
 

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -256,7 +256,7 @@ public interface ProductRepository extends CrudRepository<Product, Long> {
 
   List<Product> findByName(String name, Pageable pageable);
 
-  List<Product> findByNameLike(String pattern, Limit max, Sort sort);
+  List<Product> findByNameLike(String pattern, Limit max, Sort... sorts);
 
 }
 ----
@@ -268,12 +268,12 @@ You can define simple sorting expressions by using property names.
 Sort name = Sort.asc("name");
 ----
 
-You can combine sorting with start and size by using property names.
+You can combine sorting with a starting page and maximum page size by using property names.
 
 [source,java]
 ----
-Pageable pageable = Pageable.of(1, 20);
-first20 = products.findByNameLike(name, pageable, Sort.desc("price"));
+Pageable pageable = Pageable.ofSize(20).page(1).sortBy(Sort.desc("price"));
+first20 = products.findByNameLike(name, pageable);
 
 ----
 
@@ -296,7 +296,7 @@ You can obtain the next page with,
 
 [source,java]
 ----
-for (Pageable p = Pageable.size(50); p != null; ) {
+for (Pageable p = Pageable.ofSize(50); p != null; ) {
   page = customers.findByZipcodeOrderByLastNameAscFirstNameAscIdAsc(55901, p);
   ...
   p = page.nextPageable();
@@ -308,7 +308,7 @@ Or you can obtain the next (or previous) page relative to a known entity,
 [source,java]
 ----
 Customer c = ...
-KeysetPageable p = Pageable.size(50).afterKeyset(c.lastName, c.firstName, c.id);
+KeysetPageable p = Pageable.ofSize(50).afterKeyset(c.lastName, c.firstName, c.id);
 page = customers.findByZipcodeOrderByLastNameAscFirstNameAscIdAsc(55902, p);
 ----
 
@@ -376,7 +376,7 @@ Example traversal of pages:
 
 [source,java]
 ----
-for (Pageable p = Pageable.of(1, 25, Sort.desc("yearBorn"), Sort.asc("name"), Sort.asc("id"));
+for (Pageable p = Pageable.size(25).sortBy(Sort.desc("yearBorn"), Sort.asc("name"), Sort.asc("id")));
      p != null; ) {
   page = customers.withAveragePurchaseAbove(50.0f, p);
   ...


### PR DESCRIPTION
This pull converts Pageable and KeysetPageable into interfaces, with static ofSize and ofPage methods for obtaining the implementation from the Jakarta Data spec, following the pattern discussed with @graemerocher in #65 and possibly also addressing some concerns on naming that were independently raised by @keilw in #67.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>