### PR TITLE
Use record-style accessors for API

### DIFF
--- a/api/src/main/java/jakarta/data/repository/KeysetAwareSlice.java
+++ b/api/src/main/java/jakarta/data/repository/KeysetAwareSlice.java
@@ -71,7 +71,7 @@ public interface KeysetAwareSlice<T> extends Slice<T> {
      * previous page is requested) by assigning a page number of <code>1</code>
      * to such pages. This means that there can be multiple consecutive pages
      * numbered <code>1</code> and that
-     * <code>currentPage.previousPageable().next().getPage()</code>
+     * <code>currentPage.previousPageable().next().page()</code>
      * cannot be relied upon to return a page number that is equal to the
      * current page number.</p>
      *

--- a/api/src/main/java/jakarta/data/repository/KeysetPageable.java
+++ b/api/src/main/java/jakarta/data/repository/KeysetPageable.java
@@ -195,14 +195,14 @@ public interface KeysetPageable extends Pageable {
      *
      * @return the keyset values.
      */
-    Cursor getCursor();
+    Cursor cursor();
 
     /**
      * Returns the direction of keyset pagination.
      *
      * @return the direction of keyset pagination.
      */
-    Mode getMode();
+    Mode mode();
 
     /**
      * Raises an error because traversal of pages with keyset pagination can
@@ -225,7 +225,7 @@ public interface KeysetPageable extends Pageable {
      * @return a new instance of <code>KeysetPageable</code>. This method never returns <code>null</code>.
      */
     @Override
-    KeysetPageable page(long pageNumber);
+    KeysetPageable newPage(long pageNumber);
 
     /**
      * <p>Creates a new <code>KeysetPageable</code> instance representing the same
@@ -235,7 +235,7 @@ public interface KeysetPageable extends Pageable {
      * @return a new instance of <code>KeysetPageable</code>. This method never returns <code>null</code>.
      */
     @Override
-    KeysetPageable size(int maxPageSize);
+    KeysetPageable newSize(int maxPageSize);
 
     /**
      * <p>Creates a new <code>KeysetPageable</code> instance representing the same

--- a/api/src/main/java/jakarta/data/repository/KeysetPagination.java
+++ b/api/src/main/java/jakarta/data/repository/KeysetPagination.java
@@ -55,12 +55,12 @@ final class KeysetPagination extends Pagination implements KeysetPageable {
     }
 
     @Override
-    public Cursor getCursor() {
+    public Cursor cursor() {
         return cursor;
     }
 
     @Override
-    public Mode getMode() {
+    public Mode mode() {
         return mode;
     }
 
@@ -76,12 +76,12 @@ final class KeysetPagination extends Pagination implements KeysetPageable {
     }
 
     @Override
-    public KeysetPageable page(long pageNumber) {
+    public KeysetPageable newPage(long pageNumber) {
         return new KeysetPagination(pageNumber, size, sorts, mode, cursor);
     }
 
     @Override
-    public KeysetPageable size(int maxPageSize) {
+    public KeysetPageable newSize(int maxPageSize) {
         return new KeysetPagination(page, maxPageSize, sorts, mode, cursor);
     }
 
@@ -107,7 +107,7 @@ final class KeysetPagination extends Pagination implements KeysetPageable {
                 .append(", mode=").append(mode)
                 .append(", ").append(cursor.size()).append(" keys");
         for (Sort sort : sorts) {
-            s.append(", ").append(sort.getProperty()).append(sort.isAscending() ? " ASC" : " DESC");
+            s.append(", ").append(sort.property()).append(sort.isAscending() ? " ASC" : " DESC");
         }
         return s.append("}").toString();
     }

--- a/api/src/main/java/jakarta/data/repository/Page.java
+++ b/api/src/main/java/jakarta/data/repository/Page.java
@@ -29,11 +29,11 @@ public interface Page<T> extends Slice<T> {
      * Returns the total amount of elements.
      * @return the total amount of elements
      */
-    long getTotalElements();
+    long totalElements();
 
     /**
      * Returns the total number of pages.
      * @return the total number of pages
      */
-    long getTotalPages();
+    long totalPages();
 }

--- a/api/src/main/java/jakarta/data/repository/Pageable.java
+++ b/api/src/main/java/jakarta/data/repository/Pageable.java
@@ -147,21 +147,21 @@ public interface Pageable {
      *
      * @return the page to be returned.
      */
-    long getPage();
+    long page();
 
     /**
      * Returns the requested size of each page
      *
      * @return the requested size of each page
      */
-    int getSize();
+    int size();
 
     /**
      * Return the order collection if it was specified on this <code>Pageable</code>, otherwise an empty list.
      *
-     * @return the order collection
+     * @return the order collection; will never be {@literal null}.
      */
-    List<Sort> getSorts();
+    List<Sort> sorts();
 
     /**
      * Returns the <code>Pageable</code> requesting the next page.
@@ -177,7 +177,7 @@ public interface Pageable {
      * @param pageNumber The page number
      * @return a new instance of <code>Pageable</code>. This method never returns <code>null</code>.
      */
-    Pageable page(long pageNumber);
+    Pageable newPage(long pageNumber);
 
     /**
      * <p>Creates a new <code>Pageable</code> instance representing the same
@@ -186,7 +186,7 @@ public interface Pageable {
      * @param maxPageSize the number of query results in a full page.
      * @return a new instance of <code>Pageable</code>. This method never returns <code>null</code>.
      */
-    Pageable size(int maxPageSize);
+    Pageable newSize(int maxPageSize);
 
     /**
      * <p>Creates a new <code>Pageable</code> instance representing the same

--- a/api/src/main/java/jakarta/data/repository/Pagination.java
+++ b/api/src/main/java/jakarta/data/repository/Pagination.java
@@ -96,33 +96,33 @@ class Pagination implements Pageable {
                 .append("Pageable{page=").append(page)
                 .append(", size=").append(size);
         for (Sort sort : sorts) {
-            s.append(", ").append(sort.getProperty()).append(sort.isAscending() ? " ASC" : " DESC");
+            s.append(", ").append(sort.property()).append(sort.isAscending() ? " ASC" : " DESC");
         }
         return s.append("}").toString();
     }
 
     @Override
-    public long getPage() {
+    public long page() {
         return page;
     }
 
     @Override
-    public int getSize() {
+    public int size() {
         return size;
     }
 
     @Override
-    public List<Sort> getSorts() {
+    public List<Sort> sorts() {
         return sorts;
     }
 
     @Override
-    public Pageable page(long pageNumber) {
+    public Pageable newPage(long pageNumber) {
         return new Pagination(pageNumber, size, sorts);
     }
 
     @Override
-    public Pageable size(int maxPageSize) {
+    public Pageable newSize(int maxPageSize) {
         return new Pagination(page, maxPageSize, sorts);
     }
 

--- a/api/src/main/java/jakarta/data/repository/Query.java
+++ b/api/src/main/java/jakarta/data/repository/Query.java
@@ -40,8 +40,8 @@ public @interface Query {
     /**
      * <p>Defines an additional query that counts the number of elements that are
      * returned by the {@link #value() primary} query. This is used to compute
-     * the {@link Page#getTotalElements() total elements}
-     * and {@link Page#getTotalPages() total pages}
+     * the {@link Page#totalElements() total elements}
+     * and {@link Page#totalPages() total pages}
      * for paginated repository queries that are annotated with
      * <code>@Query</code> and return a {@link Page} or <code>KeysetAwarePage</code>.
      * Slices do not use a counting query.</p> TODO use link instead of code above once #52 is merged.

--- a/api/src/main/java/jakarta/data/repository/Slice.java
+++ b/api/src/main/java/jakarta/data/repository/Slice.java
@@ -31,7 +31,7 @@ public interface Slice<T> extends Streamable<T> {
      *
      * @return the page content as {@link List}; will never be {@literal null}.
      */
-    List<T> getContent();
+    List<T> content();
 
     /**
      * Returns whether the {@link Slice} has content at all.
@@ -45,14 +45,14 @@ public interface Slice<T> extends Streamable<T> {
      *
      * @return the number of elements currently on this Slice.
      */
-    int getNumberOfElements();
+    int numberOfElements();
 
     /**
      * Returns the current {@link Pageable}
      *
      * @return the current Pageable; will never be {@literal null}.
      */
-    Pageable getPageable();
+    Pageable pageable();
 
     /**
      * Returns the next {@link Pageable#next()}, or <code>null</code> if it is known that there is no next page.

--- a/api/src/main/java/jakarta/data/repository/Sort.java
+++ b/api/src/main/java/jakarta/data/repository/Sort.java
@@ -63,7 +63,7 @@ public final class Sort {
     /**
      * @return The property name to order by; will never be {@literal null}.
      */
-    public String getProperty() {
+    public String property() {
         return this.property;
     }
 

--- a/api/src/test/java/jakarta/data/repository/KeysetPageableTest.java
+++ b/api/src/test/java/jakarta/data/repository/KeysetPageableTest.java
@@ -36,13 +36,13 @@ class KeysetPageableTest {
         KeysetPageable pageable = Pageable.ofSize(20).afterKeyset("First", 2L, 3);
 
         assertSoftly(softly -> {
-            softly.assertThat(pageable.getSize()).isEqualTo(20);
-            softly.assertThat(pageable.getPage()).isEqualTo(1L);
-            softly.assertThat(pageable.getMode()).isEqualTo(KeysetPageable.Mode.NEXT);
-            softly.assertThat(pageable.getCursor().size()).isEqualTo(3);
-            softly.assertThat(pageable.getCursor().getKeysetElement(0)).isEqualTo("First");
-            softly.assertThat(pageable.getCursor().getKeysetElement(1)).isEqualTo(2L);
-            softly.assertThat(pageable.getCursor().getKeysetElement(2)).isEqualTo(3);
+            softly.assertThat(pageable.size()).isEqualTo(20);
+            softly.assertThat(pageable.page()).isEqualTo(1L);
+            softly.assertThat(pageable.mode()).isEqualTo(KeysetPageable.Mode.NEXT);
+            softly.assertThat(pageable.cursor().size()).isEqualTo(3);
+            softly.assertThat(pageable.cursor().getKeysetElement(0)).isEqualTo("First");
+            softly.assertThat(pageable.cursor().getKeysetElement(1)).isEqualTo(2L);
+            softly.assertThat(pageable.cursor().getKeysetElement(2)).isEqualTo(3);
         });
     }
 
@@ -53,29 +53,29 @@ class KeysetPageableTest {
         KeysetPageable pageable = Pageable.ofSize(35).sortBy(Sort.asc("name"), Sort.asc("id")).afterKeysetCursor(cursor);
 
         assertSoftly(softly -> {
-            softly.assertThat(pageable.getSize()).isEqualTo(35);
-            softly.assertThat(pageable.getPage()).isEqualTo(1L);
-            softly.assertThat(pageable.getSorts()).isEqualTo(List.of(Sort.asc("name"), Sort.asc("id")));
-            softly.assertThat(pageable.getMode()).isEqualTo(KeysetPageable.Mode.NEXT);
-            softly.assertThat(pageable.getCursor().size()).isEqualTo(2);
-            softly.assertThat(pageable.getCursor().getKeysetElement(0)).isEqualTo("me");
-            softly.assertThat(pageable.getCursor().getKeysetElement(1)).isEqualTo(200);
+            softly.assertThat(pageable.size()).isEqualTo(35);
+            softly.assertThat(pageable.page()).isEqualTo(1L);
+            softly.assertThat(pageable.sorts()).isEqualTo(List.of(Sort.asc("name"), Sort.asc("id")));
+            softly.assertThat(pageable.mode()).isEqualTo(KeysetPageable.Mode.NEXT);
+            softly.assertThat(pageable.cursor().size()).isEqualTo(2);
+            softly.assertThat(pageable.cursor().getKeysetElement(0)).isEqualTo("me");
+            softly.assertThat(pageable.cursor().getKeysetElement(1)).isEqualTo(200);
         });
     }
 
     @Test
     @DisplayName("Should include keyset values in previous KeysetPageable")
     void shouldCreateKeysetPageableBeforeKeyset() {
-        KeysetPageable pageable = Pageable.ofSize(30).sortBy(Sort.desc("yearBorn"), Sort.asc("ssn")).beforeKeyset(1991, "123-45-6789").page(10);
+        KeysetPageable pageable = Pageable.ofSize(30).sortBy(Sort.desc("yearBorn"), Sort.asc("ssn")).beforeKeyset(1991, "123-45-6789").newPage(10);
 
         assertSoftly(softly -> {
-            softly.assertThat(pageable.getSize()).isEqualTo(30);
-            softly.assertThat(pageable.getPage()).isEqualTo(10L);
-            softly.assertThat(pageable.getSorts()).isEqualTo(List.of(Sort.desc("yearBorn"), Sort.asc("ssn")));
-            softly.assertThat(pageable.getMode()).isEqualTo(KeysetPageable.Mode.PREVIOUS);
-            softly.assertThat(pageable.getCursor().size()).isEqualTo(2);
-            softly.assertThat(pageable.getCursor().getKeysetElement(0)).isEqualTo(1991);
-            softly.assertThat(pageable.getCursor().getKeysetElement(1)).isEqualTo("123-45-6789");
+            softly.assertThat(pageable.size()).isEqualTo(30);
+            softly.assertThat(pageable.page()).isEqualTo(10L);
+            softly.assertThat(pageable.sorts()).isEqualTo(List.of(Sort.desc("yearBorn"), Sort.asc("ssn")));
+            softly.assertThat(pageable.mode()).isEqualTo(KeysetPageable.Mode.PREVIOUS);
+            softly.assertThat(pageable.cursor().size()).isEqualTo(2);
+            softly.assertThat(pageable.cursor().getKeysetElement(0)).isEqualTo(1991);
+            softly.assertThat(pageable.cursor().getKeysetElement(1)).isEqualTo("123-45-6789");
         });
     }
 
@@ -86,16 +86,16 @@ class KeysetPageableTest {
         KeysetPageable pageable = Pageable.ofPage(8).beforeKeysetCursor(cursor);
 
         assertSoftly(softly -> {
-            softly.assertThat(pageable.getSize()).isEqualTo(10);
-            softly.assertThat(pageable.getPage()).isEqualTo(8L);
-            softly.assertThat(pageable.getSorts()).isEqualTo(Collections.EMPTY_LIST);
-            softly.assertThat(pageable.getMode()).isEqualTo(KeysetPageable.Mode.PREVIOUS);
-            softly.assertThat(pageable.getCursor().size()).isEqualTo(5);
-            softly.assertThat(pageable.getCursor().getKeysetElement(0)).isEqualTo(900L);
-            softly.assertThat(pageable.getCursor().getKeysetElement(1)).isEqualTo(300);
-            softly.assertThat(pageable.getCursor().getKeysetElement(2)).isEqualTo("testing");
-            softly.assertThat(pageable.getCursor().getKeysetElement(3)).isEqualTo(120);
-            softly.assertThat(pageable.getCursor().getKeysetElement(4)).isEqualTo('T');
+            softly.assertThat(pageable.size()).isEqualTo(10);
+            softly.assertThat(pageable.page()).isEqualTo(8L);
+            softly.assertThat(pageable.sorts()).isEqualTo(Collections.EMPTY_LIST);
+            softly.assertThat(pageable.mode()).isEqualTo(KeysetPageable.Mode.PREVIOUS);
+            softly.assertThat(pageable.cursor().size()).isEqualTo(5);
+            softly.assertThat(pageable.cursor().getKeysetElement(0)).isEqualTo(900L);
+            softly.assertThat(pageable.cursor().getKeysetElement(1)).isEqualTo(300);
+            softly.assertThat(pageable.cursor().getKeysetElement(2)).isEqualTo("testing");
+            softly.assertThat(pageable.cursor().getKeysetElement(3)).isEqualTo(120);
+            softly.assertThat(pageable.cursor().getKeysetElement(4)).isEqualTo('T');
         });
     }
 
@@ -144,7 +144,7 @@ class KeysetPageableTest {
         KeysetPageable pageable25p1s0a1 = Pageable.ofSize(25).afterKeyset("keyval1", '2', 3);
         KeysetPageable pageable25p1s0b1 = Pageable.ofSize(25).beforeKeyset("keyval1", '2', 3);
         KeysetPageable pageable25p1s0a1match = Pageable.ofSize(25).afterKeysetCursor(new KeysetPagination.CursorImpl("keyval1", '2', 3));
-        KeysetPageable pageable25p2s0a1 = Pageable.ofPage(2).size(25).afterKeysetCursor(new KeysetPagination.CursorImpl("keyval1", '2', 3));
+        KeysetPageable pageable25p2s0a1 = Pageable.ofPage(2).newSize(25).afterKeysetCursor(new KeysetPagination.CursorImpl("keyval1", '2', 3));
         KeysetPageable pageable25p1s1a1 = Pageable.ofSize(25).sortBy(Sort.desc("d"), Sort.asc("a"), Sort.asc("id")).afterKeyset("keyval1", '2', 3);
         KeysetPageable pageable25p1s2a1 = Pageable.ofSize(25).sortBy(Sort.desc("d"), Sort.asc("a"), Sort.desc("id")).afterKeyset("keyval1", '2', 3);
         KeysetPageable pageable25p1s0a2 = Pageable.ofSize(25).afterKeyset("keyval2", '2', 3);
@@ -174,8 +174,8 @@ class KeysetPageableTest {
             softly.assertThat(cursor1.equals(cursor4)).isFalse(); // different classes
             softly.assertThat(cursor4.equals(cursor1)).isFalse(); // different classes
 
-            softly.assertThat(pageable25p1s0a1.getCursor()).isEqualTo(cursor1);
-            softly.assertThat(pageable25p1s0a1match.getCursor()).isEqualTo(cursor1);
+            softly.assertThat(pageable25p1s0a1.cursor()).isEqualTo(cursor1);
+            softly.assertThat(pageable25p1s0a1match.cursor()).isEqualTo(cursor1);
 
             softly.assertThat(pageable25p1s0a1.equals(pageable25p1s0a1)).isTrue();
             softly.assertThat(pageable25p1s0a1.equals(null)).isFalse();
@@ -203,26 +203,26 @@ class KeysetPageableTest {
     @DisplayName("Keyset should be replaced on new instance of KeysetPageable")
     public void shouldReplaceKeyset() {
         KeysetPageable p1 = Pageable.ofSize(30).sortBy(Sort.asc("lastName"), Sort.asc("firstName"), Sort.asc("id"))
-                                    .afterKeyset("last1", "fname1", 100).page(12);
+                                    .afterKeyset("last1", "fname1", 100).newPage(12);
         KeysetPageable p2 = p1.beforeKeyset("lname2", "fname2", 200);
 
         assertSoftly(softly -> {
-            softly.assertThat(p1.getMode()).isEqualTo(KeysetPageable.Mode.NEXT);
-            softly.assertThat(p1.getCursor().getKeysetElement(0)).isEqualTo("last1");
-            softly.assertThat(p1.getCursor().getKeysetElement(1)).isEqualTo("fname1");
-            softly.assertThat(p1.getCursor().getKeysetElement(2)).isEqualTo(100);
+            softly.assertThat(p1.mode()).isEqualTo(KeysetPageable.Mode.NEXT);
+            softly.assertThat(p1.cursor().getKeysetElement(0)).isEqualTo("last1");
+            softly.assertThat(p1.cursor().getKeysetElement(1)).isEqualTo("fname1");
+            softly.assertThat(p1.cursor().getKeysetElement(2)).isEqualTo(100);
 
-            softly.assertThat(p2.getMode()).isEqualTo(KeysetPageable.Mode.PREVIOUS);
-            softly.assertThat(p2.getCursor().getKeysetElement(0)).isEqualTo("lname2");
-            softly.assertThat(p2.getCursor().getKeysetElement(1)).isEqualTo("fname2");
-            softly.assertThat(p2.getCursor().getKeysetElement(2)).isEqualTo(200);
+            softly.assertThat(p2.mode()).isEqualTo(KeysetPageable.Mode.PREVIOUS);
+            softly.assertThat(p2.cursor().getKeysetElement(0)).isEqualTo("lname2");
+            softly.assertThat(p2.cursor().getKeysetElement(1)).isEqualTo("fname2");
+            softly.assertThat(p2.cursor().getKeysetElement(2)).isEqualTo(200);
 
-            softly.assertThat(p1.getSorts()).isEqualTo(List.of(Sort.asc("lastName"), Sort.asc("firstName"), Sort.asc("id")));
-            softly.assertThat(p2.getSorts()).isEqualTo(List.of(Sort.asc("lastName"), Sort.asc("firstName"), Sort.asc("id")));
-            softly.assertThat(p1.getPage()).isEqualTo(12L);
-            softly.assertThat(p2.getPage()).isEqualTo(12L);
-            softly.assertThat(p1.getSize()).isEqualTo(30);
-            softly.assertThat(p2.getSize()).isEqualTo(30);
+            softly.assertThat(p1.sorts()).isEqualTo(List.of(Sort.asc("lastName"), Sort.asc("firstName"), Sort.asc("id")));
+            softly.assertThat(p2.sorts()).isEqualTo(List.of(Sort.asc("lastName"), Sort.asc("firstName"), Sort.asc("id")));
+            softly.assertThat(p1.page()).isEqualTo(12L);
+            softly.assertThat(p2.page()).isEqualTo(12L);
+            softly.assertThat(p1.size()).isEqualTo(30);
+            softly.assertThat(p2.size()).isEqualTo(30);
         });
     }
 }

--- a/api/src/test/java/jakarta/data/repository/PageableTest.java
+++ b/api/src/test/java/jakarta/data/repository/PageableTest.java
@@ -33,11 +33,11 @@ class PageableTest {
     @Test
     @DisplayName("Should correctly paginate")
     void shouldCreatePageable() {
-        Pageable pageable = Pageable.ofPage(2).size(6);
+        Pageable pageable = Pageable.ofPage(2).newSize(6);
 
         assertSoftly(softly -> {
-            softly.assertThat(pageable.getPage()).isEqualTo(2L);
-            softly.assertThat(pageable.getSize()).isEqualTo(6);
+            softly.assertThat(pageable.page()).isEqualTo(2L);
+            softly.assertThat(pageable.size()).isEqualTo(6);
         });
     }
 
@@ -47,22 +47,22 @@ class PageableTest {
         Pageable pageable = Pageable.ofSize(50);
 
         assertSoftly(softly -> {
-            softly.assertThat(pageable.getPage()).isEqualTo(1L);
-            softly.assertThat(pageable.getSize()).isEqualTo(50);
+            softly.assertThat(pageable.page()).isEqualTo(1L);
+            softly.assertThat(pageable.size()).isEqualTo(50);
         });
     }
 
     @Test
     @DisplayName("Should navigate next")
     void shouldNext() {
-        Pageable pageable = Pageable.ofSize(1).page(2);
+        Pageable pageable = Pageable.ofSize(1).newPage(2);
         Pageable next = pageable.next();
 
         assertSoftly(softly -> {
-            softly.assertThat(pageable.getPage()).isEqualTo(2L);
-            softly.assertThat(pageable.getSize()).isEqualTo(1);
-            softly.assertThat(next.getPage()).isEqualTo(3L);
-            softly.assertThat(next.getSize()).isEqualTo(1);
+            softly.assertThat(pageable.page()).isEqualTo(2L);
+            softly.assertThat(pageable.size()).isEqualTo(1);
+            softly.assertThat(next.page()).isEqualTo(3L);
+            softly.assertThat(next.size()).isEqualTo(1);
         });
     }
 
@@ -72,8 +72,8 @@ class PageableTest {
         Pageable pageable = Pageable.ofPage(5);
 
         assertSoftly(softly -> {
-            softly.assertThat(pageable.getPage()).isEqualTo(5L);
-            softly.assertThat(pageable.getSize()).isEqualTo(10);
+            softly.assertThat(pageable.page()).isEqualTo(5L);
+            softly.assertThat(pageable.size()).isEqualTo(10);
         });
     }
 
@@ -95,8 +95,8 @@ class PageableTest {
         Pageable p1 = Pageable.ofPage(1);
         assertThatIllegalArgumentException().isThrownBy(() -> Pageable.ofPage(0));
         assertThatIllegalArgumentException().isThrownBy(() -> Pageable.ofPage(-1));
-        assertThatIllegalArgumentException().isThrownBy(() -> p1.size(-1));
-        assertThatIllegalArgumentException().isThrownBy(() -> p1.size(0));
+        assertThatIllegalArgumentException().isThrownBy(() -> p1.newSize(-1));
+        assertThatIllegalArgumentException().isThrownBy(() -> p1.newSize(0));
         assertThatIllegalArgumentException().isThrownBy(() -> Pageable.ofSize(0));
         assertThatIllegalArgumentException().isThrownBy(() -> Pageable.ofSize(-1));
     }
@@ -106,12 +106,12 @@ class PageableTest {
         Pageable p = Pageable.ofSize(2).sortBy(Sort.asc("Id"));
 
         assertSoftly(softly -> {
-            softly.assertThat(p.getSorts()).isEqualTo(List.of(Sort.asc("Id")));
-            softly.assertThat(p.sortBy().getSorts()).isEqualTo(Collections.EMPTY_LIST);
-            softly.assertThat(p.sortBy((Iterable<Sort>) null).getSorts()).isEqualTo(Collections.EMPTY_LIST);
-            softly.assertThat(p.sortBy((Sort[]) null).getSorts()).isEqualTo(Collections.EMPTY_LIST);
-            softly.assertThat(p.sortBy(new Sort[0]).getSorts()).isEqualTo(Collections.EMPTY_LIST);
-            softly.assertThat(p.sortBy(List.of()).getSorts()).isEqualTo(Collections.EMPTY_LIST);
+            softly.assertThat(p.sorts()).isEqualTo(List.of(Sort.asc("Id")));
+            softly.assertThat(p.sortBy().sorts()).isEqualTo(Collections.EMPTY_LIST);
+            softly.assertThat(p.sortBy((Iterable<Sort>) null).sorts()).isEqualTo(Collections.EMPTY_LIST);
+            softly.assertThat(p.sortBy((Sort[]) null).sorts()).isEqualTo(Collections.EMPTY_LIST);
+            softly.assertThat(p.sortBy(new Sort[0]).sorts()).isEqualTo(Collections.EMPTY_LIST);
+            softly.assertThat(p.sortBy(List.of()).sorts()).isEqualTo(Collections.EMPTY_LIST);
         });
     }
 
@@ -119,9 +119,9 @@ class PageableTest {
     public void shouldCreatePageableSort() {
         Pageable pageable = Pageable.ofSize(3).sortBy(Sort.asc("name"));
         Assertions.assertNotNull(pageable);
-        Assertions.assertEquals(1L, pageable.getPage());
-        Assertions.assertEquals(3, pageable.getSize());
-        assertThat(pageable.getSorts())
+        Assertions.assertEquals(1L, pageable.page());
+        Assertions.assertEquals(3, pageable.size());
+        assertThat(pageable.sorts())
                 .hasSize(1)
                 .contains(Sort.asc("name"));
     }
@@ -129,7 +129,7 @@ class PageableTest {
     @Test
     public void shouldNotModifySort() {
         Pageable pageable = Pageable.ofSize(3).sortBy(Sort.asc("name"));
-        List<Sort> sorts = pageable.getSorts();
+        List<Sort> sorts = pageable.sorts();
         Assertions.assertThrows(UnsupportedOperationException.class, sorts::clear);
 
     }
@@ -138,15 +138,15 @@ class PageableTest {
     public void shouldNotModifySortOnNextPage() {
         Pageable pageable = Pageable.ofSize(3).sortBy(Sort.asc("name"), Sort.desc("age"));
         Pageable next = pageable.next();
-        Assertions.assertEquals(1L, pageable.getPage());
-        Assertions.assertEquals(3, pageable.getSize());
-        assertThat(pageable.getSorts())
+        Assertions.assertEquals(1L, pageable.page());
+        Assertions.assertEquals(3, pageable.size());
+        assertThat(pageable.sorts())
                 .hasSize(2)
                 .contains(Sort.asc("name"), Sort.desc("age"));
-        Assertions.assertEquals(2L, next.getPage());
-        Assertions.assertEquals(3, next.getSize());
+        Assertions.assertEquals(2L, next.page());
+        Assertions.assertEquals(3, next.size());
 
-        assertThat(next.getSorts())
+        assertThat(next.sorts())
                 .hasSize(2)
                 .contains(Sort.asc("name"), Sort.desc("age"));
 
@@ -155,30 +155,30 @@ class PageableTest {
     @Test
     @DisplayName("Page number should be replaced on new instance of Pageable")
     public void shouldReplacePage() {
-        Pageable p6 = Pageable.ofSize(75).page(6).sortBy(Sort.desc("price"));
-        Pageable p7 = p6.page(7);
+        Pageable p6 = Pageable.ofSize(75).newPage(6).sortBy(Sort.desc("price"));
+        Pageable p7 = p6.newPage(7);
 
         assertSoftly(softly -> {
-            softly.assertThat(p7.getPage()).isEqualTo(7L);
-            softly.assertThat(p6.getPage()).isEqualTo(6L);
-            softly.assertThat(p7.getSize()).isEqualTo(75);
-            softly.assertThat(p6.getSize()).isEqualTo(75);
-            softly.assertThat(p7.getSorts()).isEqualTo(List.of(Sort.desc("price")));
-            softly.assertThat(p6.getSorts()).isEqualTo(List.of(Sort.desc("price")));
+            softly.assertThat(p7.page()).isEqualTo(7L);
+            softly.assertThat(p6.page()).isEqualTo(6L);
+            softly.assertThat(p7.size()).isEqualTo(75);
+            softly.assertThat(p6.size()).isEqualTo(75);
+            softly.assertThat(p7.sorts()).isEqualTo(List.of(Sort.desc("price")));
+            softly.assertThat(p6.sorts()).isEqualTo(List.of(Sort.desc("price")));
         });
     }
 
     @Test
     @DisplayName("Size should be replaced on new instance of Pageable")
     public void shouldReplaceSize() {
-        Pageable s90 = Pageable.ofPage(4).size(90);
-        Pageable s80 = s90.size(80);
+        Pageable s90 = Pageable.ofPage(4).newSize(90);
+        Pageable s80 = s90.newSize(80);
 
         assertSoftly(softly -> {
-            softly.assertThat(s80.getSize()).isEqualTo(80);
-            softly.assertThat(s90.getSize()).isEqualTo(90);
-            softly.assertThat(s90.getPage()).isEqualTo(4L);
-            softly.assertThat(s80.getPage()).isEqualTo(4L);
+            softly.assertThat(s80.size()).isEqualTo(80);
+            softly.assertThat(s90.size()).isEqualTo(90);
+            softly.assertThat(s90.page()).isEqualTo(4L);
+            softly.assertThat(s80.page()).isEqualTo(4L);
         });
     }
 
@@ -189,12 +189,12 @@ class PageableTest {
         Pageable p2 = p1.sortBy(Sort.asc("firstName"), Sort.asc("lastName"));
 
         assertSoftly(softly -> {
-            softly.assertThat(p1.getSorts()).isEqualTo(List.of(Sort.desc("lastName"), Sort.asc("firstName")));
-            softly.assertThat(p2.getSorts()).isEqualTo(List.of(Sort.asc("firstName"), Sort.asc("lastName")));
-            softly.assertThat(p1.getPage()).isEqualTo(1L);
-            softly.assertThat(p2.getPage()).isEqualTo(1L);
-            softly.assertThat(p1.getSize()).isEqualTo(55);
-            softly.assertThat(p2.getSize()).isEqualTo(55);
+            softly.assertThat(p1.sorts()).isEqualTo(List.of(Sort.desc("lastName"), Sort.asc("firstName")));
+            softly.assertThat(p2.sorts()).isEqualTo(List.of(Sort.asc("firstName"), Sort.asc("lastName")));
+            softly.assertThat(p1.page()).isEqualTo(1L);
+            softly.assertThat(p2.page()).isEqualTo(1L);
+            softly.assertThat(p1.size()).isEqualTo(55);
+            softly.assertThat(p2.size()).isEqualTo(55);
         });
     }
 }

--- a/api/src/test/java/jakarta/data/repository/SortTest.java
+++ b/api/src/test/java/jakarta/data/repository/SortTest.java
@@ -41,7 +41,7 @@ class SortTest {
 
         assertSoftly(softly -> {
             softly.assertThat(order).isNotNull();
-            softly.assertThat(order.getProperty()).isEqualTo(NAME);
+            softly.assertThat(order.property()).isEqualTo(NAME);
             softly.assertThat(order.isAscending()).isTrue();
             softly.assertThat(order.isDescending()).isFalse();
         });
@@ -54,7 +54,7 @@ class SortTest {
 
         assertSoftly(softly -> {
             softly.assertThat(order).isNotNull();
-            softly.assertThat(order.getProperty()).isEqualTo(NAME);
+            softly.assertThat(order.property()).isEqualTo(NAME);
             softly.assertThat(order.isAscending()).isFalse();
             softly.assertThat(order.isDescending()).isTrue();
         });
@@ -67,7 +67,7 @@ class SortTest {
 
         assertSoftly(softly -> {
             softly.assertThat(order).isNotNull();
-            softly.assertThat(order.getProperty()).isEqualTo(NAME);
+            softly.assertThat(order.property()).isEqualTo(NAME);
             softly.assertThat(order.isAscending()).isTrue();
             softly.assertThat(order.isDescending()).isFalse();
         });
@@ -80,7 +80,7 @@ class SortTest {
 
         assertSoftly(softly -> {
             softly.assertThat(order).isNotNull();
-            softly.assertThat(order.getProperty()).isEqualTo(NAME);
+            softly.assertThat(order.property()).isEqualTo(NAME);
             softly.assertThat(order.isAscending()).isFalse();
             softly.assertThat(order.isDescending()).isTrue();
         });


### PR DESCRIPTION
Alters the API to use record-style accessors. To avoid confusion the `page(int)` and `size(int)` methods are renamed `newPage(int)` and `newSize(int)` respectively. Fixes #70