### PR TITLE
Add alias method at Pageable

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Pageable.java
+++ b/api/src/main/java/jakarta/data/repository/Pageable.java
@@ -19,6 +19,7 @@ package jakarta.data.repository;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * <p>This class represents pagination information.</p>
@@ -252,6 +253,54 @@ public interface Pageable {
      * @return a new instance of <code>Pageable</code>. This method never returns <code>null</code>.
      */
     Pageable sortBy(Sort... sorts);
+
+    /**
+     * <p>Creates a new <code>Pageable</code> instance representing the same
+     * pagination information, except using the specified sort criteria.
+     * The order of precedence of sort criteria is the order of the
+     * {@link Iterable} that is supplied to this method.</p>
+     *
+     * <p>A repository method will fail if a sort criteria is specified on a
+     * <code>Pageable</code> in combination with any of:</p>
+     * <ul>
+     * <li>an <code>OrderBy</code> keyword</li>
+     * <li>an {@link OrderBy} annotation</li>
+     * <li>a {@link Query} annotation that contains an <code>ORDER BY</code> clause.</li>
+     * <li>{@link Sort} parameters that are specified independently of
+     *     <code>Pageable</code> on a repository method</li>
+     * </ul>
+     *
+     * @param name sort ascending criteria to use.
+     * @return a new instance of <code>Pageable</code>. This method never returns <code>null</code>.
+     */
+    default Pageable asc(String name) {
+        Objects.requireNonNull(name, "name is required");
+        return sortBy(Sort.asc(name));
+    }
+
+    /**
+     * <p>Creates a new <code>Pageable</code> instance representing the same
+     * pagination information, except using the specified sort criteria.
+     * The order of precedence of sort criteria is the order of the
+     * {@link Iterable} that is supplied to this method.</p>
+     *
+     * <p>A repository method will fail if a sort criteria is specified on a
+     * <code>Pageable</code> in combination with any of:</p>
+     * <ul>
+     * <li>an <code>OrderBy</code> keyword</li>
+     * <li>an {@link OrderBy} annotation</li>
+     * <li>a {@link Query} annotation that contains an <code>ORDER BY</code> clause.</li>
+     * <li>{@link Sort} parameters that are specified independently of
+     *     <code>Pageable</code> on a repository method</li>
+     * </ul>
+     *
+     * @param name sort descending criteria to use.
+     * @return a new instance of <code>Pageable</code>. This method never returns <code>null</code>.
+     */
+    default Pageable desc(String name) {
+        Objects.requireNonNull(name, "name is required");
+        return sortBy(Sort.desc(name));
+    }
 
     /**
      * The type of pagination, which can be offset pagination or

--- a/api/src/test/java/jakarta/data/repository/PageableTest.java
+++ b/api/src/test/java/jakarta/data/repository/PageableTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PageableTest {
 
@@ -196,6 +197,30 @@ class PageableTest {
             softly.assertThat(p1.size()).isEqualTo(55);
             softly.assertThat(p2.size()).isEqualTo(55);
         });
+    }
+
+    @Test
+    public void shouldUseAscAlias() {
+        Pageable pageable = Pageable.ofSize(55).asc("name");
+        Assertions.assertNotNull(pageable);
+        assertSoftly(softly -> {
+            softly.assertThat(pageable.sorts()).hasSize(1).contains(Sort.asc("name"));
+            softly.assertThat(pageable.page()).isEqualTo(1L);
+            softly.assertThat(pageable.size()).isEqualTo(55);
+        });
+        assertThrows(NullPointerException.class, () -> Pageable.ofSize(55).asc(null));
+    }
+
+    @Test
+    public void shouldUseDescAlias() {
+        Pageable pageable = Pageable.ofSize(55).desc("name");
+        Assertions.assertNotNull(pageable);
+        assertSoftly(softly -> {
+            softly.assertThat(pageable.sorts()).hasSize(1).contains(Sort.desc("name"));
+            softly.assertThat(pageable.page()).isEqualTo(1L);
+            softly.assertThat(pageable.size()).isEqualTo(55);
+        });
+        assertThrows(NullPointerException.class, () -> Pageable.ofSize(55).asc(null));
     }
 }
 


### PR DESCRIPTION
I'm implementing the API and sort requires to create a ```Sort```

Does it make sense to have an alias?
It would reduce the cognitive load to use the API.

So: 

```java
Pageable pageable = Pageable.ofSize(55).asc("name").desc("age");;
```

Instead of: 
```java
Pageable pageable = Pageable.ofSize(55).sortBy(Sort.asc("name"), Sort.desc("age"));
```
