### PR TITLE
Define error for when database cannot do keyset pagination

### DIFF
--- a/api/src/main/java/jakarta/data/repository/KeysetAwareSlice.java
+++ b/api/src/main/java/jakarta/data/repository/KeysetAwareSlice.java
@@ -113,6 +113,13 @@ package jakarta.data.repository;
  * count of pages are not accurate when keyset pagination is used and should
  * not be relied upon.</p>
  *
+ * <h2>Database Support for Keyset Pagination</h2>
+ *
+ * <p>A repository method with return type of <code>KeysetAwareSlice</code> or
+ * {@link KeysetAwarePage} must raise {@link UnsupportedOperationException}
+ * if the database is incapable of keyset pagination.
+ * </p>
+ *
  * @param <T> the type of elements in this slice 
  */
 public interface KeysetAwareSlice<T> extends Slice<T> {

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -350,7 +350,7 @@ Other types of updates to data, however, will cause duplicate or missed results.
 
 ==== Restrictions on use of Keyset Pagination
 
-* The repository method signature must return `KeysetAwareSlice` or `KeysetAwarePage`.
+* The repository method signature must return `KeysetAwareSlice` or `KeysetAwarePage`. A repository method with return type of `KeysetAwareSlice` or `KeysetAwarePage` must raise `UnsupportedOperationException` if the database is incapable of keyset pagination.
 * The repository method signature must accept a `Pageable` parameter.
 * Sort criteria must be provided and should be minimal.
 * The combination of provided sort criteria must uniquely identify each entity.


### PR DESCRIPTION
Specification should define that UnsupportedOperationException be raised when a repository method is requested to perform keyset pagination but the underlying database is incapable of it.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>