### PR TITLE
Write unit tests for TCK Frameworks

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/framework/junit/anno/Assertion.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/junit/anno/Assertion.java
@@ -30,5 +30,5 @@ import java.lang.annotation.RetentionPolicy;
 public @interface Assertion {
     String id();
 
-    String strategy();
+    String strategy() default "";
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/junit/extensions/AssertionNameGenerator.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/junit/extensions/AssertionNameGenerator.java
@@ -15,82 +15,74 @@
  */
 package ee.jakarta.tck.data.framework.junit.extensions;
 
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.util.Arrays;
-
 import org.junit.jupiter.api.DisplayNameGenerator;
 
 import ee.jakarta.tck.data.framework.junit.anno.Assertion;
-import ee.jakarta.tck.data.framework.junit.anno.Core;
-import ee.jakarta.tck.data.framework.junit.anno.Full;
 import ee.jakarta.tck.data.framework.junit.anno.Standalone;
-import ee.jakarta.tck.data.framework.junit.anno.Web;
 
 /**
  * This custom JUnit name generator will append the {@code @Assertion.id}
- * if one exists to the name of the test at runtime.
+ * if one exists to the name of the test method at runtime.
  * 
- * We will also append the platform the test ran on by using a combination of
- * annotations and system properties. 
+ * This custom JUnit name generator will also append the platform 
+ * the test ran on by using the system property jakarta.tck.platform. 
  * 
  * @see ee.jakarta.tck.data.framework.junit.anno.Assertion
- * @see ee.jakarta.tck.data.framework.junit.anno
+ * @see ee.jakarta.tck.data.framework.junit.anno.Standalone
  */
-public class AssertionNameGenerator extends DisplayNameGenerator.Standard implements DisplayNameGenerator {
+public class AssertionNameGenerator extends DisplayNameGenerator.Simple implements DisplayNameGenerator {
     
     /**
      * Optional property that can be provided by test runners to append the platform to the method name.
      * This is useful if an test aggregator is being used to run multiple platforms. 
      * Having the platform name appended to the test will help distinguish the multiple runs.
      */
-    private static final String platform = System.getProperty("jakarta.tck.platform");
+    public static final String platformProperty = "jakarta.tck.platform";
     
     @Override
-    public String generateDisplayNameForClass(Class<?> testClass) {  
+    public String generateDisplayNameForClass(Class<?> testClass) {
         //If user provided a platform, then use that
+        String platform = System.getProperty(platformProperty);
         if(platform != null && !platform.isEmpty()) {
             return testClass.getSimpleName() + "#" + platform.replace("#", "");
         }
         
-        //Otherwise, use the annotation on the class
-        return testClass.getSimpleName() + getPlatform(testClass);
+        //If standalone test is going to be deployed to a server make it clear
+        boolean isStandalone = Boolean.getBoolean(StandaloneExtension.isStandaloneProperty);
+        if(testClass.isAnnotationPresent(Standalone.class) && !isStandalone) {
+            return testClass.getSimpleName() + "#Deployed";
+        }
+        
+        //Otherwise, use the super class
+        return super.generateDisplayNameForClass(testClass);
     }
     
     @Override
     public String generateDisplayNameForNestedClass(Class<?> nestedClass) {
         //If user provided a platform, then use that
+        String platform = System.getProperty(platformProperty);
         if(platform != null && !platform.isEmpty()) {
             return nestedClass.getSimpleName() + "#" + platform.replace("#", "");
         }
         
-        //Otherwise, use the annotation on the class
-        return nestedClass.getSimpleName() + getPlatform(nestedClass);
+        //If standalone test is going to be deployed to a server make it clear
+        boolean isStandalone = Boolean.getBoolean(StandaloneExtension.isStandaloneProperty);
+        if(nestedClass.isAnnotationPresent(Standalone.class) && !isStandalone) {
+            return nestedClass.getSimpleName() + "#Deployed";
+        }
+        
+        //Otherwise, use the super class
+        return super.generateDisplayNameForNestedClass(nestedClass);
     }
     
     @Override
     public String generateDisplayNameForMethod(Class<?> testClass, Method testMethod) {
-        String standardDisplayName = super.generateDisplayNameForMethod(testClass, testMethod);
+        
         Assertion instance = testMethod.getAnnotation(Assertion.class);
         if(instance != null) {
             return testMethod.getName() + "@Assertion.id:" + instance.id();
         }
-        return standardDisplayName;
-    }
-    
-    private String getPlatform(Class<?> testClass) {
-        //If the test is annotated with Standalone, but we are going to deploy the test on a server.
-        if (testClass.isAnnotationPresent(Standalone.class) && !Boolean.getBoolean(StandaloneExtension.isStandaloneProperty)) {
-            return "#DeployedStandalone";
-        }
-        
-        //Otherwise, use the annoation from the class
-        for(Class<? extends Annotation> annotation : Arrays.asList(Standalone.class, Core.class, Web.class, Full.class)) {
-            if(testClass.isAnnotationPresent(annotation)) {
-                return "#" + annotation.getSimpleName();
-            }
-        }
-        
-        return ""; //Otherwise, ignore the platform
+        return super.generateDisplayNameForMethod(testClass, testMethod);
     }
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/signature/DataSignatureTestRunner.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/signature/DataSignatureTestRunner.java
@@ -68,8 +68,10 @@ public class DataSignatureTestRunner extends SigTestEE {
         return new String[] { "jakarta.data", "jakarta.data.repository" };
     }
 
+
     /**
      * Returns the classpath for the packages we are interested in.
+     * @return the classpath as a colon (:) delimited string
      */
     protected String getClasspath() {
         final String defined = System.getProperty("signature.sigTestClasspath");

--- a/tck/src/test/java/ee/jakarta/tck/data/framework/arquillian/extensions/TCKArchiveProcessorTest.java
+++ b/tck/src/test/java/ee/jakarta/tck/data/framework/arquillian/extensions/TCKArchiveProcessorTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.framework.arquillian.extensions;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.impl.base.path.BasicPath;
+import org.junit.jupiter.api.Test;
+
+import ee.jakarta.tck.data.framework.junit.anno.Core;
+import ee.jakarta.tck.data.framework.junit.anno.Full;
+import ee.jakarta.tck.data.framework.junit.anno.Signature;
+import ee.jakarta.tck.data.framework.junit.anno.Web;
+
+/**
+ * Tests to ensure we correctly append framework classes to archives that are deployed using Arquillian
+ */
+public class TCKArchiveProcessorTest {
+    private static final TCKArchiveProcessor processor = new TCKArchiveProcessor();
+    
+    @Core
+    private static class TestCoreClass {}
+    
+    @Test
+    public void processorShouldAlwaysAppendAnnotationsAndExtensions() {
+        JavaArchive testJar = ShrinkWrap.create(JavaArchive.class);
+        assertTrue(testJar.getContent().isEmpty());
+        
+        processor.process(testJar, new TestClass(TestCoreClass.class));
+        assertFalse(testJar.getContent().isEmpty());
+        
+        // Should append Anno and Extension packages
+        assertTrue(testJar.getContent().containsKey(new BasicPath("/ee/jakarta/tck/data/framework/junit/anno")));    
+        assertTrue(testJar.getContent().containsKey(new BasicPath("/ee/jakarta/tck/data/framework/junit/extensions")));
+        
+        //Should not append servlet or signature packages
+        assertFalse(testJar.getContent().containsKey(new BasicPath("/ee/jakarta/tck/data/framework/servlet")));
+        assertFalse(testJar.getContent().containsKey(new BasicPath("/ee/jakarta/tck/data/framework/signature")));
+    }
+    
+    @Web
+    private static class TestWebClass {}
+    
+    @Test
+    public void processorShouldAppendServletFrameworkForWebArchives() {
+        WebArchive testWAR = ShrinkWrap.create(WebArchive.class);
+        assertTrue(testWAR.getContent().isEmpty());
+        
+        processor.process(testWAR, new TestClass(TestWebClass.class));
+        assertFalse(testWAR.getContent().isEmpty());
+        
+        // Should append Anno, Extension, and Servlet packages
+        assertTrue(testWAR.getContent().containsKey(new BasicPath("/WEB-INF/classes/ee/jakarta/tck/data/framework/junit/anno")));      
+        assertTrue(testWAR.getContent().containsKey(new BasicPath("/WEB-INF/classes/ee/jakarta/tck/data/framework/junit/extensions")));      
+        assertTrue(testWAR.getContent().containsKey(new BasicPath("/WEB-INF/classes/ee/jakarta/tck/data/framework/servlet")));    
+        
+        // Should not append signature packages
+        assertFalse(testWAR.getContent().containsKey(new BasicPath("/WEB-INF/classes/ee/jakarta/tck/data/framework/signature")));
+    }
+    
+    @Signature
+    @Full
+    private static class TestSignatureClass {}
+    
+    @Test
+    public void processorShouldAppendSignatureFrameworkForSignatureArchvies() {
+        WebArchive testWAR = ShrinkWrap.create(WebArchive.class);
+        assertTrue(testWAR.getContent().isEmpty());
+        
+        processor.process(testWAR, new TestClass(TestSignatureClass.class));
+        assertFalse(testWAR.getContent().isEmpty());
+        
+        // Should append Anno, Extension, and Servlet packages
+        assertTrue(testWAR.getContent().containsKey(new BasicPath("/WEB-INF/classes/ee/jakarta/tck/data/framework/junit/anno")));      
+        assertTrue(testWAR.getContent().containsKey(new BasicPath("/WEB-INF/classes/ee/jakarta/tck/data/framework/junit/extensions")));      
+        assertTrue(testWAR.getContent().containsKey(new BasicPath("/WEB-INF/classes/ee/jakarta/tck/data/framework/servlet"))); 
+        assertTrue(testWAR.getContent().containsKey(new BasicPath("/WEB-INF/classes/ee/jakarta/tck/data/framework/signature")));
+    }
+    
+}

--- a/tck/src/test/java/ee/jakarta/tck/data/framework/junit/extensions/AssertionNameGeneratorTest.java
+++ b/tck/src/test/java/ee/jakarta/tck/data/framework/junit/extensions/AssertionNameGeneratorTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.framework.junit.extensions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.DisplayNameGenerator.Simple;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import ee.jakarta.tck.data.framework.junit.anno.Assertion;
+import ee.jakarta.tck.data.framework.junit.anno.Core;
+import ee.jakarta.tck.data.framework.junit.anno.Standalone;
+import ee.jakarta.tck.data.framework.junit.anno.Web;
+
+/**
+ * This custom JUnit name generator will append the {@code @Assertion.id}
+ * if one exists to the name of the test at runtime.
+ * 
+ * We will also append the platform the test ran on by using a combination of
+ * annotations and system properties. 
+ * 
+ * @see ee.jakarta.tck.data.framework.junit.anno.Assertion
+ * @see ee.jakarta.tck.data.framework.junit.anno
+ */
+public class AssertionNameGeneratorTest {
+    
+    @Web
+    public static class TestClass {
+        
+        @Assertion(id = "1.0")
+        public void testMethod() {
+            //Does nothing
+        }
+        
+        public void testSimpleMethod() {
+            //Does nothing
+        }
+        
+        public static class NestedSimpleTestClass {
+            public void testSimpleMethodInNestedClass() {
+                //Does nothing
+            }
+        }
+        
+        @Core
+        public static class NestedCoreTestClass {
+            
+            @Assertion(id = "2.0")
+            public void testMethodInNestedClass() {
+                //Does nothing
+            }
+        }
+        
+        @Standalone
+        public static class NestedStandaloneTestClass {
+            
+            @Assertion(id = "3.0")
+            public void TestMethodInNestedClass() {
+                //Does nothing
+            }
+        }
+    }
+    
+    @ParameterizedTest
+    @ValueSource(strings =  { "standalone", "core", "web", "full", "something" })
+    public void testGenerateDisplayNameForClassWithPlatform(String platform) {
+        for(boolean isStandalone : Set.of(true, false)) {
+            AssertionNameGenerator generator = createNewAssertionNameGenerator(platform, isStandalone);
+
+            String expectedClassName = TestClass.class.getSimpleName() + "#" + platform;
+            String actualClassName = generator.generateDisplayNameForClass(TestClass.class);
+            assertEquals(expectedClassName, actualClassName);
+        }
+    }
+    
+    @ParameterizedTest
+    @NullAndEmptySource
+    public void testGenerateDisplayNameForClassWithoutPlatform(String platform) {
+        Simple simpleGenerator = new DisplayNameGenerator.Simple();
+        AssertionNameGenerator generator;
+        String expectedClassName, actualClassName;
+        
+        //On Server
+        generator = createNewAssertionNameGenerator(platform, false);
+
+        expectedClassName = simpleGenerator.generateDisplayNameForClass(TestClass.class);
+        actualClassName = generator.generateDisplayNameForClass(TestClass.class);
+        assertEquals(expectedClassName, actualClassName);
+        
+        expectedClassName = TestClass.NestedStandaloneTestClass.class.getSimpleName() + "#Deployed";
+        actualClassName = generator.generateDisplayNameForClass(TestClass.NestedStandaloneTestClass.class);
+        assertEquals(expectedClassName, actualClassName);
+        
+        //Standalone
+        generator = createNewAssertionNameGenerator(platform, true);
+
+        expectedClassName = simpleGenerator.generateDisplayNameForClass(TestClass.class);
+        actualClassName = generator.generateDisplayNameForClass(TestClass.class);
+        assertEquals(expectedClassName, actualClassName);
+        
+        expectedClassName = simpleGenerator.generateDisplayNameForClass(TestClass.NestedStandaloneTestClass.class);
+        actualClassName = generator.generateDisplayNameForClass(TestClass.NestedStandaloneTestClass.class);
+        assertEquals(expectedClassName, actualClassName);
+    }
+    
+    @ParameterizedTest
+    @ValueSource(strings =  { "standalone", "core", "web", "full", "something" })
+    public void testGenerateDisplayNameForNestedClassWithPlatform(String platform) {
+        for(boolean isStandalone : Set.of(true, false)) {
+            AssertionNameGenerator generator = createNewAssertionNameGenerator(platform, isStandalone);
+
+            String expectedClassName = TestClass.NestedCoreTestClass.class.getSimpleName() + "#" + platform;
+            String actualClassName = generator.generateDisplayNameForNestedClass(TestClass.NestedCoreTestClass.class);
+            assertEquals(expectedClassName, actualClassName);
+        }
+    }
+    
+    @ParameterizedTest
+    @NullAndEmptySource
+    public void testGenerateDisplayNameForNestedClassWithoutPlatform(String platform) {
+        Simple simpleGenerator = new DisplayNameGenerator.Simple();
+        AssertionNameGenerator generator;
+        String expectedClassName, actualClassName;
+        
+        //On Server
+        generator = createNewAssertionNameGenerator(platform, false);
+
+        expectedClassName = simpleGenerator.generateDisplayNameForNestedClass(TestClass.NestedCoreTestClass.class);
+        actualClassName = generator.generateDisplayNameForNestedClass(TestClass.NestedCoreTestClass.class);
+        assertEquals(expectedClassName, actualClassName);
+        
+        expectedClassName = TestClass.NestedStandaloneTestClass.class.getSimpleName() + "#Deployed";
+        actualClassName = generator.generateDisplayNameForNestedClass(TestClass.NestedStandaloneTestClass.class);
+        assertEquals(expectedClassName, actualClassName);
+        
+        //Standalone
+        generator = createNewAssertionNameGenerator(platform, true);
+
+        expectedClassName = simpleGenerator.generateDisplayNameForNestedClass(TestClass.NestedCoreTestClass.class);
+        actualClassName = generator.generateDisplayNameForNestedClass(TestClass.NestedCoreTestClass.class);
+        assertEquals(expectedClassName, actualClassName);
+        
+        expectedClassName = simpleGenerator.generateDisplayNameForNestedClass(TestClass.NestedStandaloneTestClass.class);
+        actualClassName = generator.generateDisplayNameForNestedClass(TestClass.NestedStandaloneTestClass.class);
+        assertEquals(expectedClassName, actualClassName);
+    }
+    
+    @ParameterizedTest
+    @ValueSource(strings =  { "standalone", "core", "web", "full", "something" })
+    public void testGenerateDisplayNameForMethod(String platform) throws NoSuchMethodException, SecurityException {
+        for(boolean isStandalone : Set.of(true, false)) {
+            AssertionNameGenerator generator = createNewAssertionNameGenerator(platform, isStandalone);
+            
+            String expectedMethodName = "testMethod@Assertion.id:1.0";
+            String actualMethodName = generator.generateDisplayNameForMethod(TestClass.class, TestClass.class.getMethod("testMethod"));
+            assertEquals(expectedMethodName, actualMethodName);
+            
+            String expectedNestedMethodName = "testMethodInNestedClass@Assertion.id:2.0";
+            String actualNestedMethodName = generator.generateDisplayNameForMethod(TestClass.NestedCoreTestClass.class, TestClass.NestedCoreTestClass.class.getMethod("testMethodInNestedClass"));
+            assertEquals(expectedNestedMethodName, actualNestedMethodName);   
+        }
+    }
+    
+    private AssertionNameGenerator createNewAssertionNameGenerator(String platform, boolean isStandalone) {
+        if (platform == null) {
+            System.clearProperty(AssertionNameGenerator.platformProperty);
+        } else {
+            System.setProperty(AssertionNameGenerator.platformProperty, platform);    
+        }
+        
+        System.setProperty(StandaloneExtension.isStandaloneProperty, Boolean.toString(isStandalone));
+        return new AssertionNameGenerator();
+    }
+}

--- a/tck/src/test/java/ee/jakarta/tck/data/framework/servlet/URLBuilderTest.java
+++ b/tck/src/test/java/ee/jakarta/tck/data/framework/servlet/URLBuilderTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.framework.servlet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.junit.jupiter.api.Test;
+
+public class URLBuilderTest {
+    
+    @Test
+    public void testAppendPath() throws MalformedURLException {
+        URL baseURL = new URL("http://localhost:80/");
+        
+        URL expectedURL = new URL("http://localhost:80/my/custom/url");
+        URL actualURL = URLBuilder.fromURL(baseURL).withPath("my").withPath("custom").withPath("url").build();
+        assertEquals(expectedURL, actualURL);
+        
+        actualURL = URLBuilder.fromURL(baseURL).withPath("my", "custom", "url").build();
+        assertEquals(expectedURL, actualURL);
+        
+        actualURL = URLBuilder.fromURL(baseURL).withPath("my").withPath("custom", "url").build();
+        assertEquals(expectedURL, actualURL);
+        
+        baseURL = new URL("http://localhost:80/my/");
+        actualURL = URLBuilder.fromURL(baseURL).withPath("custom").withPath("url").build();
+        assertEquals(expectedURL, actualURL);
+        
+        actualURL = URLBuilder.fromURL(baseURL).withPath("custom", "url").build();
+        assertEquals(expectedURL, actualURL);
+    }
+    
+    @Test
+    public void testAppendQueries() throws MalformedURLException {
+        URL baseURL = new URL("http://localhost:80/myServlet/");
+        
+        URL expectedURL = new URL("http://localhost:80/myServlet?myKey=myValue");
+        URL actualURL = URLBuilder.fromURL(baseURL).withQuery("myKey", "myValue").build();
+        assertEquals(expectedURL, actualURL);
+        
+        expectedURL = new URL("http://localhost:80/myServlet?myKey=myValue&myKey2=myValue2");
+        actualURL = URLBuilder.fromURL(baseURL).withQuery("myKey", "myValue").withQuery("myKey2", "myValue2").build();
+        assertEquals(expectedURL, actualURL);
+        
+        baseURL = new URL("http://localhost:80/myServlet?myKey=myValue");
+        actualURL = URLBuilder.fromURL(baseURL).withQuery("myKey2", "myValue2").build();
+        assertEquals(expectedURL, actualURL);
+        
+        expectedURL = new URL("http://localhost:80/myServlet?myKey=myValue");
+        actualURL = URLBuilder.fromURL(baseURL).withQuery("myKey", "myValue").build();
+        assertEquals(expectedURL, actualURL);
+    }
+    
+    @Test
+    public void testAppendComplexQueryAndPath() throws MalformedURLException {
+        URL baseURL = new URL("http://localhost:80/myServlet?myKey=myValue");
+        
+        URL expectedURL = new URL("http://localhost:80/myServlet/with/custom/path?myKey=myValue&anotherKey=anotherValue");
+        URL actualURL = URLBuilder.fromURL(baseURL).withPath("with", "custom", "path").withQuery("anotherKey", "anotherValue").build();
+        assertEquals(expectedURL, actualURL);
+    }
+
+}


### PR DESCRIPTION
Introduce unit tests to verify behavior of the `ee.jakarta.tck.data.framework.*` packages.

We want to verify the following: 
- TCKArchiveProcessor correctly adds framework packages based on archive type and test class annotations.
- AssertionNameGenerator correctly modifies test classes with the platform, and test methods with an assertion ID
- URLBuilder correctly constructs a URL with given paths and queries. 

This testing relieved some edge cases that I had to fix.