### PR TITLE
Inconsistent Pageable factory methods

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Pageable.java
+++ b/api/src/main/java/jakarta/data/repository/Pageable.java
@@ -199,7 +199,7 @@ public interface Pageable {
      * @param pageNumber The page number
      * @return a new instance of <code>Pageable</code>. This method never returns <code>null</code>.
      */
-    Pageable newPage(long pageNumber);
+    Pageable page(long pageNumber);
 
     /**
      * <p>Creates a new <code>Pageable</code> instance representing the same
@@ -208,7 +208,7 @@ public interface Pageable {
      * @param maxPageSize the number of query results in a full page.
      * @return a new instance of <code>Pageable</code>. This method never returns <code>null</code>.
      */
-    Pageable newSize(int maxPageSize);
+    Pageable size(int maxPageSize);
 
     /**
      * <p>Creates a new <code>Pageable</code> instance representing the same

--- a/api/src/main/java/jakarta/data/repository/Pagination.java
+++ b/api/src/main/java/jakarta/data/repository/Pagination.java
@@ -148,12 +148,12 @@ final class Pagination implements Pageable {
     }
 
     @Override
-    public Pageable newPage(long pageNumber) {
+    public Pageable page(long pageNumber) {
         return new Pagination(pageNumber, size, sorts, mode, cursor);
     }
 
     @Override
-    public Pageable newSize(int maxPageSize) {
+    public Pageable size(int maxPageSize) {
         return new Pagination(page, maxPageSize, sorts, mode, cursor);
     }
 

--- a/api/src/test/java/jakarta/data/repository/KeysetPageableTest.java
+++ b/api/src/test/java/jakarta/data/repository/KeysetPageableTest.java
@@ -66,7 +66,7 @@ class KeysetPageableTest {
     @Test
     @DisplayName("Should include keyset values in previous Pageable")
     void shouldCreatePageableBeforeKeyset() {
-        Pageable pageable = Pageable.ofSize(30).sortBy(Sort.desc("yearBorn"), Sort.asc("ssn")).beforeKeyset(1991, "123-45-6789").newPage(10);
+        Pageable pageable = Pageable.ofSize(30).sortBy(Sort.desc("yearBorn"), Sort.asc("ssn")).beforeKeyset(1991, "123-45-6789").page(10);
 
         assertSoftly(softly -> {
             softly.assertThat(pageable.size()).isEqualTo(30);
@@ -144,7 +144,7 @@ class KeysetPageableTest {
         Pageable pageable25p1s0a1 = Pageable.ofSize(25).afterKeyset("keyval1", '2', 3);
         Pageable pageable25p1s0b1 = Pageable.ofSize(25).beforeKeyset("keyval1", '2', 3);
         Pageable pageable25p1s0a1match = Pageable.ofSize(25).afterKeysetCursor(new KeysetCursor("keyval1", '2', 3));
-        Pageable pageable25p2s0a1 = Pageable.ofPage(2).newSize(25).afterKeysetCursor(new KeysetCursor("keyval1", '2', 3));
+        Pageable pageable25p2s0a1 = Pageable.ofPage(2).size(25).afterKeysetCursor(new KeysetCursor("keyval1", '2', 3));
         Pageable pageable25p1s1a1 = Pageable.ofSize(25).sortBy(Sort.desc("d"), Sort.asc("a"), Sort.asc("id")).afterKeyset("keyval1", '2', 3);
         Pageable pageable25p1s2a1 = Pageable.ofSize(25).sortBy(Sort.desc("d"), Sort.asc("a"), Sort.desc("id")).afterKeyset("keyval1", '2', 3);
         Pageable pageable25p1s0a2 = Pageable.ofSize(25).afterKeyset("keyval2", '2', 3);
@@ -203,7 +203,7 @@ class KeysetPageableTest {
     @DisplayName("Keyset should be replaced on new instance of Pageable")
     public void shouldReplaceKeyset() {
         Pageable p1 = Pageable.ofSize(30).sortBy(Sort.asc("lastName"), Sort.asc("firstName"), Sort.asc("id"))
-                                         .afterKeyset("last1", "fname1", 100).newPage(12);
+                                         .afterKeyset("last1", "fname1", 100).page(12);
         Pageable p2 = p1.beforeKeyset("lname2", "fname2", 200);
 
         assertSoftly(softly -> {

--- a/api/src/test/java/jakarta/data/repository/PageableTest.java
+++ b/api/src/test/java/jakarta/data/repository/PageableTest.java
@@ -33,7 +33,7 @@ class PageableTest {
     @Test
     @DisplayName("Should correctly paginate")
     void shouldCreatePageable() {
-        Pageable pageable = Pageable.ofPage(2).newSize(6);
+        Pageable pageable = Pageable.ofPage(2).size(6);
 
         assertSoftly(softly -> {
             softly.assertThat(pageable.page()).isEqualTo(2L);
@@ -55,7 +55,7 @@ class PageableTest {
     @Test
     @DisplayName("Should navigate next")
     void shouldNext() {
-        Pageable pageable = Pageable.ofSize(1).newPage(2);
+        Pageable pageable = Pageable.ofSize(1).page(2);
         Pageable next = pageable.next();
 
         assertSoftly(softly -> {
@@ -95,8 +95,8 @@ class PageableTest {
         Pageable p1 = Pageable.ofPage(1);
         assertThatIllegalArgumentException().isThrownBy(() -> Pageable.ofPage(0));
         assertThatIllegalArgumentException().isThrownBy(() -> Pageable.ofPage(-1));
-        assertThatIllegalArgumentException().isThrownBy(() -> p1.newSize(-1));
-        assertThatIllegalArgumentException().isThrownBy(() -> p1.newSize(0));
+        assertThatIllegalArgumentException().isThrownBy(() -> p1.size(-1));
+        assertThatIllegalArgumentException().isThrownBy(() -> p1.size(0));
         assertThatIllegalArgumentException().isThrownBy(() -> Pageable.ofSize(0));
         assertThatIllegalArgumentException().isThrownBy(() -> Pageable.ofSize(-1));
     }
@@ -155,8 +155,8 @@ class PageableTest {
     @Test
     @DisplayName("Page number should be replaced on new instance of Pageable")
     public void shouldReplacePage() {
-        Pageable p6 = Pageable.ofSize(75).newPage(6).sortBy(Sort.desc("price"));
-        Pageable p7 = p6.newPage(7);
+        Pageable p6 = Pageable.ofSize(75).page(6).sortBy(Sort.desc("price"));
+        Pageable p7 = p6.page(7);
 
         assertSoftly(softly -> {
             softly.assertThat(p7.page()).isEqualTo(7L);
@@ -171,8 +171,8 @@ class PageableTest {
     @Test
     @DisplayName("Size should be replaced on new instance of Pageable")
     public void shouldReplaceSize() {
-        Pageable s90 = Pageable.ofPage(4).newSize(90);
-        Pageable s80 = s90.newSize(80);
+        Pageable s90 = Pageable.ofPage(4).size(90);
+        Pageable s80 = s90.size(80);
 
         assertSoftly(softly -> {
             softly.assertThat(s80.size()).isEqualTo(80);


### PR DESCRIPTION
Signed-off-by: Otavio Santana <otaviopolianasantana@gmail.com>

Update API to use:

```java
Pageable pageable = Pageable.size(50)
            .page(5)
            .sort(Sort.asc("lastName"), Sort.asc("firstName), Sort.asc("id"))
            .afterKeyset(lname, fname, id);
```

I checked in `Pageable` and `Limit` both use the `of` as a prefix on the method factory on the majority.

Ref: https://github.com/jakartaee/data/issues/67