### PR TITLE
Add TCK Distribution module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -337,5 +337,6 @@
         <module>api</module>
         <module>spec</module>
         <module>tck</module>
+        <module>tck-dist</module>
     </modules>
 </project>

--- a/tck-dist/pom.xml
+++ b/tck-dist/pom.xml
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ~ Copyright (c) 2022 Contributors to the Eclipse Foundation ~ ~ This 
+ program and the accompanying materials are made available under the ~ terms 
+ of the Eclipse Public License v. 2.0, which is available at ~ http://www.eclipse.org/legal/epl-2.0. 
+ ~ ~ This Source Code may also be made available under the following Secondary 
+ ~ Licenses when the conditions for such availability set forth in the ~ Eclipse 
+ Public License v. 2.0 are satisfied: GNU General Public License, ~ version 
+ 2 with the GNU Classpath Exception, which is available at ~ https://www.gnu.org/software/classpath/license.html. 
+ ~ ~ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0 -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+ <modelVersion>4.0.0</modelVersion>
+
+ <parent>
+  <groupId>jakarta.data</groupId>
+  <artifactId>jakarta-data-parent</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+ </parent>
+
+ <artifactId>jakarta-data-tck-dist</artifactId>
+ <name>Jakarta Data Technology Compatibility Kit Distribution</name>
+ <description>Jakarta Data :: TCK Distribution</description>
+
+ <licenses>
+  <license>
+   <name>Eclipse Public License 2.0</name>
+   <url>https://projects.eclipse.org/license/epl-2.0</url>
+   <distribution>repo</distribution>
+  </license>
+  <license>
+   <name>GNU General Public License, version 2 with the GNU Classpath Exception</name>
+   <url>https://projects.eclipse.org/license/secondary-gpl-2.0-cp</url>
+   <distribution>repo</distribution>
+  </license>
+ </licenses>
+
+ <properties>
+  <jakarta.data.tck.version>${project.version}</jakarta.data.tck.version>
+
+  <maven.site.skip>true</maven.site.skip>
+  <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
+  <asciidoctorj.version>2.5.3</asciidoctorj.version>
+  <asciidoctorj.pdf.version>1.6.2</asciidoctorj.pdf.version>
+  <jruby.version>9.2.20.1</jruby.version>
+ </properties>
+
+ <dependencies>
+  <dependency>
+   <groupId>jakarta.data</groupId>
+   <artifactId>jakarta-data-tck</artifactId>
+   <version>${jakarta.data.tck.version}</version>
+  </dependency>
+ </dependencies>
+
+ <build>
+  <plugins>
+   <!-- Skip checking for Apache license in this sub-module since it needs 
+    to use EPL/GPL -->
+   <plugin>
+    <groupId>org.apache.rat</groupId>
+    <artifactId>apache-rat-plugin</artifactId>
+    <version>${apache.rat.version}</version>
+    <configuration>
+     <skip>true</skip>
+    </configuration>
+   </plugin>
+
+   <!-- Load TCK dependency location as variable -->
+   <plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-dependency-plugin</artifactId>
+    <version>3.3.0</version>
+    <executions>
+     <execution>
+      <phase>initialize</phase>
+      <goals>
+       <goal>properties</goal>
+      </goals>
+     </execution>
+    </executions>
+   </plugin>
+
+   <!-- Automatically generate a list of excluded tests and test counts -->
+   <plugin>
+    <groupId>org.codehaus.mojo</groupId>
+    <artifactId>exec-maven-plugin</artifactId>
+    <version>3.1.0</version>
+    <executions>
+     <execution>
+      <id>generate-asciidoc</id>
+      <phase>process-classes</phase>
+      <goals>
+       <goal>java</goal>
+      </goals>
+     </execution>
+    </executions>
+    <configuration>
+     <mainClass>ee.jakarta.tck.data.metadata.CollectMetaData</mainClass>
+     <arguments>
+      <argument>true</argument>
+      <argument>${jakarta.data:jakarta-data-tck:jar}</argument>
+      <argument>${project.basedir}/src/main/asciidoc/sections/generated</argument>
+     </arguments>
+    </configuration>
+   </plugin>
+
+   <!-- Aciidoctor will create the html and pdf distributions of the user-guide -->
+   <plugin>
+    <groupId>org.asciidoctor</groupId>
+    <artifactId>asciidoctor-maven-plugin</artifactId>
+    <version>${asciidoctor.maven.plugin.version}</version>
+    <dependencies>
+     <dependency>
+      <groupId>org.jruby</groupId>
+      <artifactId>jruby-complete</artifactId>
+      <version>${jruby.version}</version>
+     </dependency>
+     <dependency>
+      <groupId>org.asciidoctor</groupId>
+      <artifactId>asciidoctorj</artifactId>
+      <version>${asciidoctorj.version}</version>
+     </dependency>
+     <dependency>
+      <groupId>org.asciidoctor</groupId>
+      <artifactId>asciidoctorj-pdf</artifactId>
+      <version>${asciidoctorj.pdf.version}</version>
+     </dependency>
+    </dependencies>
+    <executions>
+     <execution>
+      <id>asciidoc-to-html</id>
+      <phase>prepare-package</phase>
+      <goals>
+       <goal>process-asciidoc</goal>
+      </goals>
+      <configuration>
+       <backend>html5</backend>
+       <outputFile>${project.build.directory}/generated-docs/data-tck-reference-guide-${jakarta.data.tck.version}.html</outputFile>
+      </configuration>
+     </execution>
+     <execution>
+      <id>asciidoc-to-pdf</id>
+      <phase>prepare-package</phase>
+      <goals>
+       <goal>process-asciidoc</goal>
+      </goals>
+      <configuration>
+       <backend>pdf</backend>
+       <outputFile>${project.build.directory}/generated-docs/data-tck-reference-guide-${jakarta.data.tck.version}.pdf</outputFile>
+      </configuration>
+     </execution>
+    </executions>
+    <configuration>
+     <toc>left</toc>
+     <sourceDocumentName>data-tck-reference-guide.adoc</sourceDocumentName>
+     <sourceHighlighter>coderay</sourceHighlighter>
+     <skip>${maven.adoc.skip}</skip>
+    </configuration>
+   </plugin>
+
+   <!-- Assembly plugin to collect everything into a single distribution -->
+   <plugin>
+    <artifactId>maven-assembly-plugin</artifactId>
+    <executions>
+     <execution>
+      <id>distribution</id>
+      <phase>package</phase>
+      <goals>
+       <goal>single</goal>
+      </goals>
+      <configuration>
+       <descriptors>
+        <descriptor>src/main/assembly/assembly.xml</descriptor>
+       </descriptors>
+       <finalName>data-tck-${jakarta.data.tck.version}</finalName>
+      </configuration>
+     </execution>
+    </executions>
+   </plugin>
+  </plugins>
+ </build>
+</project>

--- a/tck-dist/src/main/EFTL.txt
+++ b/tck-dist/src/main/EFTL.txt
@@ -1,0 +1,43 @@
+Eclipse Foundation Technology Compatibility Kit License - v 1.0
+Copyright (c) 2018, Eclipse Foundation, Inc. and its licensors.
+
+Redistribution and use in binary form is permitted provided that the following conditions are met:
+    1. Use of the Technology Compatibility Kit accompanying this license ( the “TCK”) and its documentation is permitted
+    solely for the purpose of testing compatibility of an implementation (the “Product”) of a specification
+    (the “Specification”) made available by the Eclipse Foundation, Inc. (“Eclipse”).
+    2. Only those modifications expressly permitted by the TCK and its documentation are permitted. Except in these
+    limited circumstances, no modifications to the TCK are permitted under this license.
+    3. A Product will be deemed to be “compatible” with the Specification if it fully and completely meets and satisfies
+    all requirements of the TCK.
+    4. Before any claim of compatibility (or any similar claim suggesting compatibility) is made based on the TCK, the
+    testing party must:
+        a. use the TCK to demonstrate that the Product fully and completely meets and satisfies all requirements of the TCK;
+        b. make TCK test results showing full and complete satisfaction of all requirements of the TCK publicly
+        available on the testing party’s website and send a link to such test results to Eclipse at tck@eclipse.org; and
+        c. comply with any requirements stated in the Specification with regard to subsetting, supersetting, modifying
+        or extending the Specification in any Product claimed to be compatible with the Specification.
+    5. The test results must be continuously available and the link must be live for at least as long as the Product is
+    available in the marketplace.
+    6. The TCK may not be used as a basis for any statements of partial compatibility. The TCK may only be used as a
+    basis for true, factual statements of full compatibility of Products that fully meet and satisfy all requirements
+    of the TCK.
+    7. A determination that a Product is compatible with the TCK does not, in itself, give rise to the right to use any
+    name, mark, logo associated with the TCK, Eclipse, or Eclipse’s contributors or licensors.
+    8. Upon the request of Eclipse, a tester will retract any statements of compatibility (or any similar claim
+    suggesting compatibility) which Eclipse reasonably determines to be false or misleading or in violation of the
+    terms of this license.
+    9. Redistribution of the TCK must be under this Eclipse Foundation Technology Compatibility Kit License and must
+    reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+    10. Neither the name, trademarks or logos of Eclipse, nor the names, trademarks or logos of its contributors or
+    licensors may be used to endorse or promote products tested with this software without specific prior written permission.
+    11. The source code for the TCK accompanying this license is available from Eclipse.
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THIS SOFTWARE IS PROVIDED ON AN “AS IS” BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
+NON- INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. TO THE EXTENT PERMITTED BY APPLICABLE LAW,
+NEITHER THE COPYRIGHT OWNER OR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.

--- a/tck-dist/src/main/artifacts/artifact-install.sh
+++ b/tck-dist/src/main/artifacts/artifact-install.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+## A sample script to install the artifact directory contents into a local maven repository
+
+if [[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+  VERSION="$1"
+else
+  VERSION="1.0.0-SNAPSHOT" # TODO update upon release
+fi
+
+# Parent pom
+mvn org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file \
+-Dfile=jakarta-data-parent-"$VERSION".pom \
+-DgroupId=jakarta.data \
+-DartifactId=jakarta-data-parent \
+-Dversion="$VERSION" \
+-Dpackaging=pom
+
+# Jakarta Data TCK Installed Library
+mvn org.apache.maven.plugins:maven-install-plugin:3.0.0-M1:install-file \
+-Dfile=jakarta-data-tck-"$VERSION".jar

--- a/tck-dist/src/main/asciidoc/data-tck-reference-guide.adoc
+++ b/tck-dist/src/main/asciidoc/data-tck-reference-guide.adoc
@@ -1,0 +1,51 @@
+= Jakarta Data TCK Reference Guide
+:author: Kyle Aure
+:email: NONE
+:revnumber: 1.0
+:toc:
+:sectnums:
+
+:APIShortName: Data
+:APILongName: Jakarta Data
+:APIVersion: 1.0.0
+
+:APISpecSite: https://jakarta.ee/specifications/data/
+:APIEclipseSite: https://projects.eclipse.org/projects/ee4j.data
+:APIGitSite: https://github.com/jakartaee/data
+
+:TCKTestPlatform: JUnit5
+:SigPluginGAV: org.netbeans.tools:sigtest-maven-plugin:1.6
+
+:JavaVersion1: 11
+:JavaVersion2: 17
+
+:TCKProcess: 1.3
+:TCKProcessDoc: https://jakarta.ee/committees/specification/tckprocess
+
+include::sections/01preface.adoc[]
+
+include::sections/02changes.adoc[]
+
+include::sections/03compatibility.adoc[]
+
+include::sections/04prereq.adoc[]
+
+include::sections/05inventory.adoc[]
+
+include::sections/06requirements.adoc[]
+
+include::sections/07create-runner.adoc[]
+
+include::sections/08example-runner.adoc[]
+
+include::sections/09running.adoc[]
+
+include::sections/10signature.adoc[]
+
+include::sections/11challenge.adoc[]
+
+include::sections/12certification.adoc[]
+
+include::sections/13rules.adoc[]
+
+include::sections/14links.adoc[]

--- a/tck-dist/src/main/asciidoc/data-tck-reference-guide.adoc
+++ b/tck-dist/src/main/asciidoc/data-tck-reference-guide.adoc
@@ -16,7 +16,7 @@
 :TCKTestPlatform: JUnit5
 :SigPluginGAV: org.netbeans.tools:sigtest-maven-plugin:1.6
 
-:JavaVersion1: 11
+:JavaVersion1: 21
 :JavaVersion2: 17
 
 :TCKProcess: 1.3

--- a/tck-dist/src/main/asciidoc/sections/01preface.adoc
+++ b/tck-dist/src/main/asciidoc/sections/01preface.adoc
@@ -36,7 +36,7 @@ Assertions will occur both on the client and server sides.
 
 === Terminology - "Core Profile" vs "Web Profile" vs "Full Profile"
 
-The Jakarta EE platform defines increasing sets of specifications that create the core, web, and full profiles.
+The Jakarta EE platform defines sets of specifications that create the core, web, and full profiles.
 // TODO update this if Jakarta Data ends up being in something other than core profile
 The {APILongName} TCK can run against each of these profiles since {APILongName} is a Core Profile specification.
 

--- a/tck-dist/src/main/asciidoc/sections/01preface.adoc
+++ b/tck-dist/src/main/asciidoc/sections/01preface.adoc
@@ -23,7 +23,7 @@ The {APILongName} specification has a subset of tests that can run in "SE mode" 
 
 === Terminology - "Standalone TCK"
 
-The community will sometimes refer to this TCK as the "standalone" {APIShortName} TCK.  This usage comes from the fact that {APILongName} is part of the Jakarta EE Platform, which has a platform-level TCK, which we are distinguishing this "standalone" TCK.  
+The community will sometimes refer to this TCK as the "standalone" {APIShortName} TCK.  This usage comes from the fact that {APILongName} is part of the Jakarta EE Platform, which has a platform-level TCK from which we are distinguishing this "standalone" TCK.  
 
 This terminology is confusing, since the term "standalone" is overloaded to also mean that this TCK can be run in SE Mode which it can.
 A better term would be `Specification TCK`, but that terminology is not yet being used.

--- a/tck-dist/src/main/asciidoc/sections/01preface.adoc
+++ b/tck-dist/src/main/asciidoc/sections/01preface.adoc
@@ -1,0 +1,53 @@
+== Preface
+
+This guide describes how to download, install, configure, and run the Technology Compatibility Kit (TCK) used to verify the compatibility of an implementation of the {APILongName} specification.  
+
+The specification describes the job specification language, Java programming model, and runtime environment for {APILongName} applications.
+
+=== Licensing
+
+The {APILongName} TCK is provided under the https://www.eclipse.org/legal/tck.php[*Eclipse Foundation Technology Compatibility Kit License - v 1.0*].
+
+=== Who Should Use This Guide
+
+This guide will assist in running the test suite, which verifies implementation compatibility for:
+
+* Implementer of {APILongName}.
+
+=== Terminology - "SE mode" vs. "EE mode"
+
+The term "EE mode" when talking about the {APILongName} TCK distinguishes the requirements specifically for implementers running the TCK to certify against a Jakarta EE platform.
+In contrast, the term "SE mode" distinguishes the requirements specifically for implementers running the TCK against a standalone implementation of the {APILongName} specification.
+
+The {APILongName} specification has a subset of tests that can run in "SE mode" without the requirement of running against a Jakarta EE Platform.
+
+=== Terminology - "Standalone TCK"
+
+The community will sometimes refer to this TCK as the "standalone" {APIShortName} TCK.  This usage comes from the fact that {APILongName} is part of the Jakarta EE Platform, which has a platform-level TCK, which we are distinguishing this "standalone" TCK.  
+
+This terminology is confusing, since the term "standalone" is overloaded to also mean that this TCK can be run in SE Mode which it can.
+A better term would be `Specification TCK`, but that terminology is not yet being used.
+
+=== Terminology - "Test Client" vs "Test Server"
+
+When running in EE mode the {APILongName} TCK acts as a `Test Client` that will install test applications onto a Jakarta EE Platform Server.
+The Platform Server will act as a `Test Server` and run tests based on incoming requests from the `Test Client`.
+Assertions will occur both on the client and server sides.
+
+=== Terminology - "Core Profile" vs "Web Profile" vs "Full Profile"
+
+The Jakarta EE platform defines increasing sets of specifications that create the core, web, and full profiles.
+// TODO update this if Jakarta Data ends up being in something other than core profile
+The {APILongName} TCK can run against each of these profiles since {APILongName} is a Core Profile specification.
+
+References:
+
+* Core profile: https://jakarta.ee/specifications/coreprofile/
+* Web profile: https://jakarta.ee/specifications/webprofile/
+* Full profile: https://jakarta.ee/specifications/platform/
+
+=== Before You Read This Guide
+
+Before reading this guide, you should familiarize yourself with {APILongName} {APIVersion} specification, which can be found at {APISpecSite}.
+
+Other useful information and links can be found on the {APIEclipseSite}[eclipse.org project home page for the {APILongName} project] and also at the {APIGitSite}[GitHub repository home for the specification project].

--- a/tck-dist/src/main/asciidoc/sections/02changes.adoc
+++ b/tck-dist/src/main/asciidoc/sections/02changes.adoc
@@ -1,0 +1,3 @@
+== Major TCK Changes
+
+This is the first release of the {APILongName} TCK.

--- a/tck-dist/src/main/asciidoc/sections/03compatibility.adoc
+++ b/tck-dist/src/main/asciidoc/sections/03compatibility.adoc
@@ -1,0 +1,20 @@
+== Certify Compatibility
+
+=== Runtime Tests and Signature Tests Required
+
+To certify compatibility with the entire Jakarta EE Platform (including {APILongName}), you will need to run the TCK against your implementation and pass 100% of both the:
+
+* {TCKTestPlatform} runtime tests
+* Signature tests
+
+The two types of tests are encapsulated in a single execution or configuration.
+This means that the Signature tests will run alongside all other tests and no additional execution or configuration is required.
+
+By "runtime" tests we simply mean tests simulating {APILongName} applications running against the {APIShortName} implementation either in SE Mode or EE Mode.
+These tests verify that the {APIShortName} applications behave according to the details defined in the specification, as validated by the TCK test logic.
+
+=== Java SE level - Java {JavaVersion1} or Java {JavaVersion2}
+
+The Java SE version is important to note, and this version must be used consistently throughout both the {TCKTestPlatform} runtime and Signature tests for a given certification request.
+
+For the current TCK version, this can be done with either Java SE Version {JavaVersion1} or Version {JavaVersion2}.

--- a/tck-dist/src/main/asciidoc/sections/03compatibility.adoc
+++ b/tck-dist/src/main/asciidoc/sections/03compatibility.adoc
@@ -10,7 +10,7 @@ To certify compatibility with the entire Jakarta EE Platform (including {APILong
 The two types of tests are encapsulated in a single execution or configuration.
 This means that the Signature tests will run alongside all other tests and no additional execution or configuration is required.
 
-By "runtime" tests we simply mean tests simulating {APILongName} applications running against the {APIShortName} implementation either in SE Mode or EE Mode.
+By "runtime" tests we simply mean tests simulating {APILongName} applications running against the {APIShortName} implementation either in SE Mode (for Jakarta Data providers) or EE Mode (For Jakarta EE product providers).
 These tests verify that the {APIShortName} applications behave according to the details defined in the specification, as validated by the TCK test logic.
 
 === Java SE level - Java {JavaVersion1} or Java {JavaVersion2}

--- a/tck-dist/src/main/asciidoc/sections/04prereq.adoc
+++ b/tck-dist/src/main/asciidoc/sections/04prereq.adoc
@@ -1,0 +1,20 @@
+== Prerequisites
+
+=== Software To Install
+
+1. **Java/JDK** - Install the JDK you intend to use for this certification request (Java SE Version {JavaVersion1} or Version {JavaVersion2}).
+2. **Maven** - Install Apache Maven 3.6.0 or higher.
+3. **Jakarta EE Platform** (optional) - Jakarta EE Application Server or Container [Glassfish, Open Liberty, JBoss, WebLogic, etc.]
+
+=== Testing Framework
+
+To better understand how this TCK works, knowing what testing frameworks are being utilized is helpful.
+Knowledge of how these frameworks operate and interact will help during the project setup.
+
+1. **Arquillian** - Version 1.7.0.Alpha13 or later - The {APILongName} TCK can run in EE Mode and it uses Arquillian to execute tests within an Arquillian "container" for certifying against an EE Platform. You must configure an https://arquillian.org/guides/developing_a_container_adapter/[Arquillian adapter] for your target runtime.
+2. **JUnit5** - Version 5.9.0 or later - The {APILongName} TCK uses JUnit5 as the entry-point for tests and deployments using Arquillian.
+3. **Signature Test Plugin** - Version 1.6 exactly -  The {APILongName} TCK uses the Signature Test Plugin to verify API signatures used by an implementation and those release by the specification match. 
++
+No action is needed here, but we note that the signature files were built and should be validated with the plugin with group:artifact:version coordinates: **{SigPluginGAV}**, as used by the sample runner included in the TCK zip. 
+This is a more specific direction than in earlier releases of the platform TCK, in which it was left more open for the user to use a compatible tool.
+Since there are small differences in the various signature test tools an exact version is required.

--- a/tck-dist/src/main/asciidoc/sections/04prereq.adoc
+++ b/tck-dist/src/main/asciidoc/sections/04prereq.adoc
@@ -4,7 +4,7 @@
 
 1. **Java/JDK** - Install the JDK you intend to use for this certification request (Java SE Version {JavaVersion1} or Version {JavaVersion2}).
 2. **Maven** - Install Apache Maven 3.6.0 or higher.
-3. **Jakarta EE Platform** (optional) - Jakarta EE Application Server or Container [Glassfish, Open Liberty, JBoss, WebLogic, etc.]
+3. **Jakarta EE Platform** (if running in EE Mode) - Jakarta EE Application Server or Container [Glassfish, Open Liberty, JBoss, WebLogic, etc.]
 
 === Testing Framework
 

--- a/tck-dist/src/main/asciidoc/sections/05inventory.adoc
+++ b/tck-dist/src/main/asciidoc/sections/05inventory.adoc
@@ -14,7 +14,7 @@ Once the TCK is extracted, you'll see the following structure:
 
 [source, txt]
 ----
-concurrency-tck-<version>-dist/
+data-tck-<version>-dist/
   artifacts/
   doc/
   starter/

--- a/tck-dist/src/main/asciidoc/sections/05inventory.adoc
+++ b/tck-dist/src/main/asciidoc/sections/05inventory.adoc
@@ -1,0 +1,77 @@
+== A Guide to the TCK Distribution
+
+This section explains how to obtain the TCK and extract it on your system.
+
+=== Obtaining the Software
+
+The {APILongName} TCK is distributed as a zip file, which contains all the files necessary to use, run, and certify your implementation.
+You can access the current source code from the {APIGitSite}[Git repository].
+
+=== The TCK Environment
+
+The {APILongName} TCK can simply be extracted from the ZIP file.
+Once the TCK is extracted, you'll see the following structure:
+
+[source, txt]
+----
+concurrency-tck-<version>-dist/
+  artifacts/
+  doc/
+  starter/
+  LICENSE
+  README.md
+----
+
+In more detail:
+
+* `artifacts` contains all the test artifacts pertaining to the TCK
+** The TCK test classes and source 
+** The {TCKTestPlatform} configuration file
+** A copy of the SignatureTest file for reference
+** A script to copy the TCK into local maven repository.
+* `doc` contains the documentation for the TCK (i.e. this reference guide)
+* `starter` a very basic starter maven project to get you started.
+
+=== A Quick Tour of the TCK Artifacts
+
+==== What is included
+
+The {APILongName} TCK is a test library that includes four types of packages:
+
+- `ee.jakarta.tck.data.standalone.\*` these are basic API tests, or SPI tests that can run in SE Mode or EE mode.
+- `ee.jakarta.tck.data.core.\*` these are more complex integration tests that must run against at least Core Profile.
+- `ee.jakarta.tck.data.web.\*` these are more complex integration tests that must run against at least Web Profile.
+- `ee.jakarta.tck.data.full.\*` these are more complex integration tests that must run against at least Full Profile.
+- `ee.jakarta.tck.data.framework.\*` these are utility packages that help support the development and execution of the TCK.
+
+Tests that exist at a lower level will run on any level above, for example, all core profile tests will run against web profile.
+Signature tests exist at the standalone level which means they will run in any mode, and any profile.
+
+===== API Signature Files
+
+One signature file exists for both Java {JavaVersion1} and {JavaVersion2}:
+
+1. `artifacts/jakarta.data.sig`
+
+This signature file is for reference only.
+A copy of the signature file is included in the {APILongName} TCK test jar.
+
+==== What is not included
+
+The {APILongName} TCK uses but does not provide the necessary application servers, test frameworks, APIs, SPIs, or implementations required to run.
+It is up to the tester to include those dependencies and set up a test project to run the TCK.
+
+Here is an essential checklist of what you will need per mode, and links to the section that describe how to satisfy these requirements:
+
+SE Mode:
+
+- The {APIShortName} API, JUnit5, and Signature Test Plugin libraries available at runtime | <<Standalone Dependencies>>
+- A logging configuration for TCK logging available at runtime | <<Standalone Logging>>
+
+EE Mode:
+
+- An Application Server to test against | <<Software To Install>>
+- The {APILongName} API, Arquillian SPI, and JUnit5 libraries available to the `Test Client` | <<Test Client Dependencies>>
+- The Arquillian, JUnit5, and Signature Test libraries available to the `Test Server` | <<Test Server Dependencies>>
+- An Arquillian SPI implementation for your Application Server | <<Configure Arquillian>>
+- A logging configuration for TCK logging on `Test Client` and `Test Server` | <<Configure Client and Server Logging>>

--- a/tck-dist/src/main/asciidoc/sections/06requirements.adoc
+++ b/tck-dist/src/main/asciidoc/sections/06requirements.adoc
@@ -1,0 +1,10 @@
+== TCK Test Requirements
+
+There is flexibility regarding how a user could use Maven to configure a TCK execution.
+Therefore, we make a separate, clear note here of the required number of tests needed to be passed in order to claim compliance via this TCK.
+
+=== Expected Output
+
+For the {TCKTestPlatform} runtime tests of the TCK: 
+
+include::generated/runtime-tests.adoc[]

--- a/tck-dist/src/main/asciidoc/sections/07.1se-mode.adoc
+++ b/tck-dist/src/main/asciidoc/sections/07.1se-mode.adoc
@@ -1,0 +1,51 @@
+:starterLoc: ../../starter
+
+=== SE Mode
+
+==== Standalone Dependencies
+
+The runtime will need to be configured with the dependencies necessary to run the TCK.
+
+Example se-pom.xml:
+
+[source, xml]
+----
+include::{starterLoc}/se-pom.xml[tag=runtimeDep]
+----
+
+==== Configure {TCKTestPlatform}
+
+{TCKTestPlatform} needs to be configured to know which packages contain tests to run.
+This test discovery is done automatically by configuring a `dependenciesToScan` element.
+
+In order for your maven project to execute these tests the surefire plugin needs to be configured.
+
+Example se-pom.xml:
+
+[source, xml]
+----
+include::{starterLoc}/se-pom.xml[tags=configJunit5;!logging;!displayName]
+----
+
+The {APILongName} TCK also includes an extension to {TCKTestPlatform} which will automatically modify the test class with the platform it runs on, and test methods with their Assertion IDs if they exist.
+To enable this extension include the following configuration to your surefire plugin:
+
+[source, xml]
+----
+include::{starterLoc}/se-pom.xml[tags=displayName]
+----
+
+==== Standalone Logging
+
+The {APILongName} TCK uses `java.util.logging` for logging debug messages, and to output test results in some cases.
+This is done by pointing the JVM to the logging configuration file using the property.
+An example logging configuration file has been provided under the `/starter` directory. 
+
+To enable logging for the Client side of tests, add a system property to the surefire plugin:
+
+Example se-pom.xml:
+
+[source, xml]
+----
+include::{starterLoc}/se-pom.xml[tags=logging;!ignore]
+----

--- a/tck-dist/src/main/asciidoc/sections/07.2ee-mode.adoc
+++ b/tck-dist/src/main/asciidoc/sections/07.2ee-mode.adoc
@@ -1,0 +1,129 @@
+:starterLoc: ../../starter
+
+=== EE Mode
+
+==== Test Client Dependencies
+
+The entry point to running the TCK will be on the client-side using {TCKTestPlatform}. 
+The Test Client will need to be configured with the dependencies necessary to run the TCK.
+Some of these dependencies will depend on the application server you are using, and 
+comments have been added to this sample describing the customization necessary.
+
+Example ee-pom.xml:
+
+[source, xml]
+----
+include::{starterLoc}/ee-pom.xml[tag=testClientDep]
+----
+
+Each of these Arquillian tests run within the runtime container, with the help of an Arquillian adapter for that runtime implementation (mentioned as a prerequisite).
+
+==== Test Server Dependencies
+
+If the Test Server is running on a separate JVM (recommended), then the Test Server will also need access to JUnit5 and Signature Test Plugin libraries.
+The Test Server dependencies can be copied over during the build phase.
+
+Example ee-pom.xml:
+
+[source, xml]
+----
+include::{starterLoc}/ee-pom.xml[tag=testServerDep]
+----
+
+Using the maven command:
+
+[source, sh]
+----
+$ mvn dependency:copy
+----
+
+==== Configure {TCKTestPlatform}
+
+{TCKTestPlatform} needs to be configured to know which packages contain tests to run.
+This test discovery is done automatically by configuring a `dependenciesToScan` element.
+
+In order for your maven project to execute these tests the surefire plugin needs to be configured.
+
+Example ee-pom.xml:
+
+[source, xml]
+----
+include::{starterLoc}/ee-pom.xml[tags=configJunit5;!arquillian;!logging;!displayName]
+----
+
+The {APILongName} TCK also includes an extension to {TCKTestPlatform} which will automatically modify the test class with the platform it runs on, and test methods with their Assertion IDs if they exist.
+To enable this extension include the following configuration to your surefire plugin:
+
+[source, xml]
+----
+include::{starterLoc}/ee-pom.xml[tags=displayName]
+----
+
+==== Configure Arquillian
+
+Application Servers that implement the Arquillian SPI use a configuration file to define properties, such as hostname, port, username, password, etc.
+These properties will allow Arquillian to connect to the application server, install applications, and get test responses.
+An example Arquillian configuration file has been provided in the `starter/` directory.
+
+It is possible to configure the surefire plugin to past variables to the Arquillian container:
+
+[source, xml]
+----
+include::{starterLoc}/ee-pom.xml[tags=arquillian]
+----
+
+==== Configure Jakarta EE Platform Server
+
+The {APILongName} TCK requires that your Jakarta EE Platform Server has a valid implementation of the {APILongName} API.
+
+The TCK also requires external libraries at runtime that also need to be available on the Application Server's class path.
+
+- org.junit.jupiter:junit-jupiter - For test assertions
+- org.netbeans.tools:sigtest-maven-plugin - For signature testing
+
+Refer back to <<Test Server Dependencies>> for information on how to make to pull and copy these dependencies.
+
+==== Configure Client and Server Logging
+
+The {APILongName} TCK uses `java.util.logging` for logging debug messages, and to output test results in some cases.
+Registered loggers exist both on the Test Client and Test Server meaning you will need to configure both sides to enable logging.
+This is done by pointing the JVM to the logging configuration file using the property.
+An example logging configuration file has been provided under the `/starter` directory. 
+
+To enable logging for the Client side of tests, add a system property to the surefire plugin:
+
+Example ee-pom.xml:
+
+[source, xml]
+----
+include::{starterLoc}/ee-pom.xml[tag=logging]
+----
+
+To enable logging for the Server side of tests, set the same system property on the JVM running your application server.
+
+==== Advanced Arquillian Configuration
+
+Some application servers may have custom deployment descriptors that they would like to include 
+as part of the applications that are being deployed to their server. 
+The custom deployment descriptors can be included in a programmatic way using ShrinkWrap and the Arquillian SPI.
+
+Example ApplicationArchiveProcessor:
+
+[source, java]
+----
+include::{starterLoc}/src/main/java/ee/jakarta/tck/data/example/extension/MyApplicationArchiveProcessor.java[tags=applicationProcessor]
+----
+
+Example LoadableExtension:
+
+[source, java]
+----
+include::{starterLoc}/src/main/java/ee/jakarta/tck/data/example/extension/MyLoadableExtension.java[tags=loadableExtension]
+----
+
+Example META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension:
+
+[source, txt]
+----
+include::{starterLoc}/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension[]
+----

--- a/tck-dist/src/main/asciidoc/sections/07create-runner.adoc
+++ b/tck-dist/src/main/asciidoc/sections/07create-runner.adoc
@@ -1,0 +1,11 @@
+== Set up a TCK runner project
+
+A simple maven project is required to control the lifecycle of the {APILongName} TCK.
+Sample pom.xmls has been provided in this distribution under the /starter/ directory.
+
+* se-pom.xml - is used for standalone testing.
+* ee-pom.xml - is used for Jakarta Platform testing.
+
+include::07.1se-mode.adoc[]
+
+include::07.2ee-mode.adoc[]

--- a/tck-dist/src/main/asciidoc/sections/08example-runner.adoc
+++ b/tck-dist/src/main/asciidoc/sections/08example-runner.adoc
@@ -1,0 +1,15 @@
+== Example runners
+
+This section is dedicated to listing example runners for other implementations to use as a reference on how to configure and use the {APILongName} TCK.
+
+Below are links to projects where the {APILongName} TCK is being used and run successfully: 
+
+[cols="1,1,1"]
+|===
+|Project |Link |Profile(s)
+
+|Open Liberty
+|https://github.com/OpenLiberty/open-liberty/tree/integration/dev/io.openliberty.jakarta.data.1.0_fat_tck
+|standalone, core, and web
+
+|===

--- a/tck-dist/src/main/asciidoc/sections/09running.adoc
+++ b/tck-dist/src/main/asciidoc/sections/09running.adoc
@@ -1,0 +1,15 @@
+== Running the TCK
+
+Once the TCK Runner project is created and configured the {APILongName} TCK is run as part of the maven test lifecycle.
+
+[source, sh]
+----
+$ cd starter
+$ mvn clean test
+----
+
+=== Expected Output
+
+Here is example output when successfully running the starter project:
+
+include::generated/expected-output.adoc[]

--- a/tck-dist/src/main/asciidoc/sections/10signature.adoc
+++ b/tck-dist/src/main/asciidoc/sections/10signature.adoc
@@ -1,0 +1,65 @@
+:signatureREADME: {APIGitSite}/blob/main/tck/src/main/java/ee/jakarta/tck/data/framework/signature/README.md
+
+== Signature Tests
+
+The signature tests validate the integrity of the `jakarta.data` Java "namespace" (or "package prefix") of the {APIShortName} implementation.
+This would be especially important for an implementation packaging its own API JAR in which the API must be validated in its entirety.
+
+For implementations expecting their users to rely on the API released by the {APILongName} specification project (e.g. to Maven Central) 
+the signature tests are also important to validate that improper (non-spec-defined) 
+extensions have not been added to `jakarta.data.\*` packages/classes/etc.
+
+For more information about generating the signature test file, and how the signature test runs read: 
+{signatureREADME}[ee.jakarta.tck.concurrent.framework.signaturetest/README.md]
+
+=== Running signature tests
+
+The {APILongName} TCK will run signature tests within a standalone or deployed application, 
+and not as part of a separate plugin / execution.
+This means that the signature tests will run during the maven `test` phase.
+
+You need to configure your application server with a JVM property `-Djimage.dir=<path-your-server-has-access-to>`.
+This is because, when running the signature tests on JDK 9+ we need to convert the 
+JDK modules back into class files for signature testing.
+
+The signature test plugin we use will also attempt to perform reflective access of classes, methods, and fields.
+Due to the new module system in JDK 9+ special permissions need to be added in order for these tests to run: 
+
+==== with a Security Manager
+
+If you are using a Security Manager add the following permissions to the 
+`sigtest-maven-plugin` on your Jakarta EE Platform server:
+
+[source, txt]
+----
+permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal";
+permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.reflect";
+permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.vm.annotation";
+----
+
+==== with Modules
+
+By default the java.base module only exposes certain classes for reflective access. 
+Therefore, the {APIShortName} TCK test will need access to the `jdk.internal.vm.annotation` class.
+To give the `sigtest-maven-plugin` access to this class set the following JVM properties: 
+
+[source, properties]
+----
+--add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED
+--add-opens java.base/jdk.internal.vm.annotation=ALL-UNNAMED
+----
+
+Some JDKs will mistake the space in the prior JVM properties as delimiters between properties
+In this case use:
+
+[source, properties]
+----
+--add-exports=java.base/jdk.internal.vm.annotation=ALL-UNNAMED
+--add-opens=java.base/jdk.internal.vm.annotation=ALL-UNNAMED
+---- 
+
+=== Expected output
+
+Here is example output when successfully running the signature tests: 
+
+include::generated/expected-sig-output.adoc[]

--- a/tck-dist/src/main/asciidoc/sections/11challenge.adoc
+++ b/tck-dist/src/main/asciidoc/sections/11challenge.adoc
@@ -1,0 +1,32 @@
+:RequestChallenge: {APIGitSite}/issues/new?assignees=&labels=challenge&template=challenge.yml&title=%5BTCK+Challenge%5D%3A+
+:ExistingChallenges: {APIGitSite}/issues?q=is%3Aissue+label%3Achallenge
+
+== TCK Challenges/Appeals Process
+
+The {TCKProcessDoc}[Jakarta EE TCK Process {TCKProcess}] will govern all process details used for challenges to the {APILongName} TCK.
+
+Except from the *Jakarta EE TCK Process {TCKProcess}*:
+
+> Specifications are the sole source of truth and considered overruling to the TCK in all senses. 
+> In the course of implementing a specification and attempting to pass the TCK, 
+> implementations may come to the conclusion that one or more tests or assertions do not conform to the specification, 
+> and therefore MUST be excluded from the certification requirements.
+
+> Requests for tests to be excluded are referred to as Challenges. 
+> This section identifies who can make challenges to the TCK, what challenges to the TCK may be submitted, how these challenges are submitted, 
+> how and to whom challenges are addressed.
+
+=== Filing a Challenge 
+
+The certification of compatibility process is defined within the [underline]#Challenges# section within the *Jakarta EE TCK Process {TCKProcess}*.
+
+Challenges will be tracked via the {ExistingChallenges}[issues section] of the {APILongName} Specification repository.
+
+As a shortcut through the challenge process mentioned in the *Jakarta EE TCK Process {TCKProcess}* you can click {RequestChallenge}[here], 
+though it is recommended that you read through the challenge process to understand it in detail.
+
+=== Successful Challenges
+
+The following tests are exempt from TCK testing due to challenges:
+
+include::generated/successful-challenges.adoc[]

--- a/tck-dist/src/main/asciidoc/sections/12certification.adoc
+++ b/tck-dist/src/main/asciidoc/sections/12certification.adoc
@@ -1,0 +1,25 @@
+:RequestCertification: {APIGitSite}/issues/new?assignees=&labels=certification&template=certification.yml&title=%5BCertification%5D%3A+
+:ExistingCertifications: {APIGitSite}/issues?q=is%3Aissue+label%3Acertification
+
+== Certification of Compatibility
+
+The {TCKProcessDoc}[Jakarta EE TCK Process {TCKProcess}] will define the core process details used to certify compatibility with the {APILongName} specification, 
+through execution of the {APILongName} TCK.
+
+Except from the *Jakarta EE TCK Process {TCKProcess}*:
+
+> Jakarta EE is a self-certification ecosystem.
+If you wish to have your implementation listed on the official https://jakarta.ee implementations page for the given specification, 
+a certification request as defined in this section is required.
+
+=== Filing a Certification Request
+
+The certification of compatibility process is defined within the [underline]#Certification of Compatibility# 
+section within the *Jakarta EE TCK Process {TCKProcess}*.
+
+Certifications will be tracked via the {ExistingCertifications}[issues section] of 
+the {APILongName} Specification repository.
+
+As a shortcut through the certification of compatibility process mentioned in the 
+*Jakarta EE TCK Process {TCKProcess}* you can click {RequestCertification}[here], 
+though it is recommended that you read through the certification process to understand it in detail.

--- a/tck-dist/src/main/asciidoc/sections/13rules.adoc
+++ b/tck-dist/src/main/asciidoc/sections/13rules.adoc
@@ -1,0 +1,67 @@
+== Rules for {APILongName} Products
+
+The following rules apply for each version of an operating system, software component,
+and hardware platform Documented as supporting the Product:
+
+- **Data1** The Product must be able to satisfy all applicable compatibility requirements,
+  including passing all Compatibility Tests, in every Product Configuration and in every combination
+  of Product Configurations, except only as specifically exempted by these Rules.
+  For example, if a Product provides distinct Operating Modes to optimize performance,
+  then that Product must satisfy all applicable compatibility requirements for a Product
+  in each Product Configuration, and combination of Product Configurations, of those Operating Modes.
+
+- **Data1.1** If an Operating Mode controls a Resource necessary for the basic execution of the Test Suite,
+  testing may always use a Product Configuration of that Operating Mode providing that Resource,
+  even if other Product Configurations do not provide that Resource. Notwithstanding such exceptions,
+  each Product must have at least one set of Product Configurations of such Operating Modes
+  that is able to pass all the Compatibility Tests.
+  For example, a Product with an Operating Mode that controls a security policy (i.e., Security Resource)
+  which has one or more Product Configurations that cause Compatibility Tests to fail
+  may be tested using a Product Configuration that allows all Compatibility Tests to pass.
+
+- **Data1.2** A Product Configuration of an Operating Mode that causes the Product to report only
+  version, usage, or diagnostic information is exempted from these compatibility rules.
+
+- **Data1.3** An API Definition Product is exempt from all functional testing requirements defined here,
+  except the signature tests.
+
+- **Data2** Some Compatibility Tests may have properties that may be changed.
+  Properties that can be changed are identified in the configuration interview.
+  Properties that can be changed are identified in the JavaTest Environment (.jte) files in the Test Suite installation.
+  Apart from changing such properties and other allowed modifications described in this User's Guide (if any),
+  no source or binary code for a Compatibility Test may be altered in any way without prior written permission.
+  Any such allowed alterations to the Compatibility Tests will be provided via the Jakarta EE Specification Project website
+  and apply to all vendor compatible implementations.
+
+- **Data3** The testing tools supplied as part of the Test Suite or as updated by the
+  Maintenance Lead must be used to certify compliance.
+
+- **Data4** The Exclude List associated with the Test Suite cannot be modified.
+
+- **Data5** The Maintenance Lead can define exceptions to these Rules.
+  Such exceptions would be made available as above, and will apply to all vendor implementations.
+
+- **Data6** All hardware and software component additions, deletions, and modifications to a
+  Documented supporting hardware/software platform, that are not part of the Product but required
+  for the Product to satisfy the compatibility requirements, must be Documented and available to users of the Product.
+  For example, if a patch to a particular version of a supporting operating system is required for the
+  Product to pass the Compatibility Tests, that patch must be Documented and available to users of the Product.
+
+- **Data7** The Product must contain the full set of public and protected classes and interfaces
+  for all the Libraries. Those classes and interfaces must contain exactly the set of public and
+  protected methods, constructors, and fields defined by the Specifications for those Libraries.
+  No subsetting, supersetting, or modifications of the public and protected API of the Libraries
+  are allowed except only as specifically exempted by these Rules.
+
+- **Data7.1** If a Product includes Technologies in addition to the Technology Under Test,
+  then it must contain the full set of combined public and protected classes and interfaces.
+  The API of the Product must contain the union of the included Technologies.
+  No further modifications to the APIs of the included Technologies are allowed.
+
+- **Data8** Except for tests specifically required by this TCK to be rebuilt (if any),
+  the binary Compatibility Tests supplied as part of the Test Suite or as updated by the
+  Maintenance Lead must be used to certify compliance.
+
+- **Data9** The functional programmatic behavior of any binary class or interface must be
+  that defined by the Specifications.
+  

--- a/tck-dist/src/main/asciidoc/sections/14links.adoc
+++ b/tck-dist/src/main/asciidoc/sections/14links.adoc
@@ -1,0 +1,7 @@
+== Links
+
+* {APILongName} TCK repository - {APIGitSite}/tree/main/tck
+* {APILongName} API repository - {APIGitSite}/tree/main/api
+* {APILongName} specification repository - {APIGitSite}/tree/main/spec
+* {APILongName} project home page - {APIEclipseSite}
+* Arquillian and ShrinkWrap doc: https://arquillian.org/guides/shrinkwrap_introduction/

--- a/tck-dist/src/main/asciidoc/sections/generated/.gitignore
+++ b/tck-dist/src/main/asciidoc/sections/generated/.gitignore
@@ -1,0 +1,4 @@
+runtime-tests.adoc
+successful-challenges.adoc
+expected-sig-output.adoc
+expected-output.adoc

--- a/tck-dist/src/main/assembly/assembly.xml
+++ b/tck-dist/src/main/assembly/assembly.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Copyright (c) 2022 Contributors to the Eclipse Foundation
+ ~
+ ~ This program and the accompanying materials are made available under the
+ ~ terms of the Eclipse Public License v. 2.0, which is available at
+ ~ http://www.eclipse.org/legal/epl-2.0.
+ ~
+ ~ This Source Code may also be made available under the following Secondary
+ ~ Licenses when the conditions for such availability set forth in the
+ ~ Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ ~ version 2 with the GNU Classpath Exception, which is available at
+ ~ https://www.gnu.org/software/classpath/license.html.
+ ~
+ ~ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+  -->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+
+  <id>dist</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+
+  <baseDirectory>data-tck-${jakarta.data.tck.version}</baseDirectory>
+
+  <files>
+    <!-- This is the final EFTL license -->
+    <file>
+      <source>src/main/EFTL.txt</source>
+      <destName>LICENSE</destName>
+    </file>
+    <!-- The readme included in the distribution zip -->
+    <file>
+      <source>src/main/readme/README.md</source>
+      <destName>README.md</destName>
+    </file>
+    <!-- Signature file -->
+    <file>
+      <source>${project.parent.basedir}/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/jakarta.data.sig</source>
+      <outputDirectory>/artifacts</outputDirectory>
+    </file>
+  </files>
+
+  <fileSets>
+    <!-- The artifacts -->
+    <fileSet>
+      <directory>src/main/artifacts/</directory>
+      <outputDirectory>/artifacts</outputDirectory>
+      <includes>
+        <include>**/*.sh</include>
+        <include>**/*.txt</include>
+      </includes>
+    </fileSet>
+    <!-- The docs -->
+    <fileSet>
+      <directory>target/generated-docs</directory>
+      <outputDirectory>/docs</outputDirectory>
+      <includes>
+        <include>**/*.html</include>
+        <include>**/*.pdf</include>
+      </includes>
+    </fileSet>
+    <!-- The starter -->
+    <fileSet>
+      <directory>src/main/starter/</directory>
+      <outputDirectory>/starter</outputDirectory>
+    </fileSet>
+  </fileSets>
+
+  <dependencySets>
+    <dependencySet>
+      <includes>
+        <include>jakarta.data:jakarta-data-tck</include>
+        <include>jakarta.data:jakarta-data-tck:jar:sources</include>
+        <include>jakarta.data:jakarta-data-parent</include>
+      </includes>
+      <useTransitiveDependencies>true</useTransitiveDependencies>
+      <outputDirectory>artifacts</outputDirectory>
+      <useProjectArtifact>false</useProjectArtifact>
+    </dependencySet>
+  </dependencySets>
+</assembly>

--- a/tck-dist/src/main/java/ee/jakarta/tck/data/metadata/CollectMetaData.java
+++ b/tck-dist/src/main/java/ee/jakarta/tck/data/metadata/CollectMetaData.java
@@ -1,0 +1,447 @@
+package ee.jakarta.tck.data.metadata;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.junit.platform.commons.support.HierarchyTraversalMode;
+
+import ee.jakarta.tck.data.framework.junit.anno.Assertion;
+
+/**
+ * This is a utility class that will analyze the TCK and generate documentation for the following information: 
+ * 1. The name of tests that are disabled (due to challenges)
+ * 2. The number of tests that need to pass for certification
+ * 3. Expected JUnit output
+ * 4. Expected Signature test output
+ * 
+ * This will be run automatically each time the tck-dist module is built.
+ * Meaning that we don't need to update our doc each time we add/remove/disable a test. 
+ * 
+ * Files are output to: 
+ *  ${project.basedir}/src/main/asciidoc/generated/
+ *  
+ * File names are:
+ *  expected-output.adoc
+ *  expected-sig-output.adoc
+ *  runtime-tests.adoc
+ *  successful-challenges.adoc
+ */
+public class CollectMetaData {
+    // Constants
+    private static final String FRAMEWORK_PACKAGE_PREFIX = "ee/jakarta/tck/data/framework";
+    
+    private static final String RUNTIME_TESTS_FILE = "runtime-tests.adoc";
+    private static final String CHALLENGED_TESTS_FILE = "successful-challenges.adoc";
+    private static final String SIG_OUTPUT_FILE = "expected-sig-output.adoc";
+    private static final String EXPECTED_OUTPUT_FILE = "expected-output.adoc";
+        
+    // Data holders
+    private static boolean debug = false;
+    private static List<String> apiPackages;
+    private static List<Class<?>> testClasses;
+    private static File adocGeneratedLocation;
+    
+    private CollectMetaData() {
+        //Do nothing
+    }
+    
+    public static void main(String[] args) throws Exception {
+        if(args.length != 3) {
+            throw new RuntimeException("CollectMetaData expected exactly 3 arguments [debug, path-to-tck, output-file-location]");
+        }
+        
+        //Load arguments
+        debug = Boolean.valueOf(args[0]);
+        testClasses = getClassNames(args[1]);
+        adocGeneratedLocation = new File(args[2]);
+        
+        //Check asciidoctor generated folder exists
+        if(!adocGeneratedLocation.exists()) {
+            adocGeneratedLocation.mkdirs();
+        }
+        
+        //Collect test metadata
+        List<TestMetaData> testMetaData = collectMetaData(testClasses);
+        
+        //Write the generated asciidoc files
+        writeTestCounts(testMetaData, new File(adocGeneratedLocation, RUNTIME_TESTS_FILE));
+        writeSuccessfulChallenges(testMetaData, new File(adocGeneratedLocation, CHALLENGED_TESTS_FILE));
+        writeSigOutput(apiPackages, new File(adocGeneratedLocation, SIG_OUTPUT_FILE));
+        writeOutput(testMetaData, new File(adocGeneratedLocation, EXPECTED_OUTPUT_FILE));
+        writeGitIgnore(new File(adocGeneratedLocation, ".gitignore"), RUNTIME_TESTS_FILE, CHALLENGED_TESTS_FILE, SIG_OUTPUT_FILE, EXPECTED_OUTPUT_FILE);
+    }
+
+    /**
+     * Writes generated files to a .gitignore file
+     * 
+     * @param outputLocation - the output file
+     * @param ignoredFiles   - files to ignore 
+     * @throws IOException   - exception if we cannot write to this location
+     */
+    private static void writeGitIgnore(File outputLocation, String... ignoredFiles) throws IOException {
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(outputLocation))) {
+            for(String ignoredFile : ignoredFiles) {
+                writer.write(ignoredFile + System.lineSeparator());
+            }
+        }
+    }
+    
+    /**
+     * Writes example output to the generated adoc folder
+     * 
+     * @param testMetaData   - the test metadata we previously collected
+     * @param outputLocation - the output file
+     * @throws IOException   - exception if we cannot write to this location
+     */
+    private static void writeOutput(List<TestMetaData> testMetaData, File outputLocation) throws IOException {
+        //TODO replace with testblock if we end up using Java 17
+        StringBufferWrapper expectOutputSection = new StringBufferWrapper();
+        
+        expectOutputSection.appendNewLine("[source, txt]");
+        expectOutputSection.appendNewLine("----");
+        expectOutputSection.appendNewLine("$ mvn clean test");
+        expectOutputSection.appendNewLine("...");
+        
+        expectOutputSection.appendNewLine("[INFO] --- maven-surefire-plugin:3.0.0-M7:test (default-test) @ tck.runner ---");
+        expectOutputSection.appendNewLine("[INFO] Using auto detected provider org.apache.maven.surefire.junitplatform.JUnitPlatformProvider");
+        expectOutputSection.appendNewLine("[INFO]");
+        
+        expectOutputSection.appendNewLine("[INFO] -------------------------------------------------------");
+        expectOutputSection.appendNewLine("[INFO]  T E S T S");
+        expectOutputSection.appendNewLine("[INFO] -------------------------------------------------------");
+        
+        for(String testClass : testMetaData.stream().map(metaData -> metaData.testClass).distinct().collect(Collectors.toList())) {
+            List<TestMetaData> theseTests = testMetaData.stream().filter(metaData -> metaData.testClass == testClass).collect(Collectors.toList());
+            long testCount = theseTests.stream().filter(metaData -> !metaData.isDisabled).count();
+            long disabledCount = theseTests.stream().filter(metaData -> metaData.isDisabled).count();
+            expectOutputSection.appendNewLine("[INFO] Running " + testClass);
+            
+            if(disabledCount > 0) {
+                expectOutputSection.append("[WARNING] Tests run: " + testCount + ", Failures: 0, Errors: 0, Skipped: " + disabledCount + ",");
+            } else {
+                expectOutputSection.append("[INFO] Tests run: " + testCount + ", Failures: 0, Errors: 0, Skipped: " + disabledCount + ",");    
+            }
+            
+            expectOutputSection.appendNewLine("Time elapsed: y.yy s - in " +  testClass);
+            expectOutputSection.appendNewLine("[INFO]");
+        }
+        
+        expectOutputSection.appendNewLine("[INFO] Results:");
+        expectOutputSection.appendNewLine("[INFO]");
+        
+        long totalTestCount = testMetaData.stream().filter(metaData -> !metaData.isDisabled).count();
+        long totalDisabledCount = testMetaData.stream().filter(metaData -> metaData.isDisabled).count();
+        
+        if(totalDisabledCount > 0) {
+            expectOutputSection.appendNewLine("[WARNING] Tests run: " + totalTestCount + ", Failures: 0, Errors: 0, Skipped: " + totalDisabledCount);    
+        } else {
+            expectOutputSection.appendNewLine("[INFO] Tests run: " + totalTestCount + ", Failures: 0, Errors: 0, Skipped: " + totalDisabledCount);    
+        }
+        
+        expectOutputSection.appendNewLine("[INFO]");
+        expectOutputSection.appendNewLine("[INFO] -------------------------------------------------------");
+        expectOutputSection.appendNewLine("[INFO] BUILD SUCCESS");
+        expectOutputSection.appendNewLine("[INFO] -------------------------------------------------------");
+        expectOutputSection.appendNewLine("[INFO] Total time:  xx.xxx s");
+        expectOutputSection.appendNewLine("[INFO] Finished at: " + LocalDateTime.now().toString());
+        expectOutputSection.appendNewLine("[INFO] -------------------------------------------------------");
+        expectOutputSection.append("----");
+        
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(outputLocation))) {
+            writer.write(expectOutputSection.toString());
+        }
+    }
+    
+    /**
+     * Writes example signature test output to the generated adoc folder
+     * 
+     * @param apiPackages    - the API packages used by the signature test
+     * @param outputLocation - the output file
+     * @throws IOException   - exception if we cannot write to this location
+     */
+    private static void writeSigOutput(List<String> apiPackages, File outputLocation) throws IOException {
+        //TODO replace with testblock if we end up using Java 17
+        StringBufferWrapper expectSigOutputSection = new StringBufferWrapper();
+        
+        expectSigOutputSection.appendNewLine("[source, txt]");
+        expectSigOutputSection.appendNewLine("----");
+        expectSigOutputSection.appendNewLine("******************************************************");
+        expectSigOutputSection.appendNewLine("All package signatures passed.");
+        expectSigOutputSection.appendNewLine("\tPassed packages listed below:");
+        
+        for(String apiPackage : apiPackages) {
+            expectSigOutputSection.appendNewLine("\t\t" + apiPackage + "(static mode)");
+            expectSigOutputSection.appendNewLine("\t\t" + apiPackage + "(reflection mode)");
+        }
+        
+        expectSigOutputSection.appendNewLine("******************************************************");
+        expectSigOutputSection.appendNewLine("----");
+        
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(outputLocation))) {
+            writer.write(expectSigOutputSection.toString());
+        } 
+    }
+
+    /**
+     * Writes successful challenges to the generated adoc folder
+     * 
+     * @param testMetaData   - the test metadata we previously collected
+     * @param outputLocation - the output file
+     * @throws IOException   - exception if we cannot write to this location
+     */
+    private static void writeSuccessfulChallenges(List<TestMetaData> testMetaData, File outputLocation) throws IOException {
+        //TODO replace with testblock if we end up using Java 17
+        StringBufferWrapper exemptTestsSection = new StringBufferWrapper();
+
+        exemptTestsSection.appendNewLine("[cols=\"1,1,1\"]" );
+        exemptTestsSection.appendNewLine("|===" );
+        exemptTestsSection.appendNewParagraph("|Class |Method |Reason"  );
+        testMetaData.stream().filter(TestMetaData::isDisabled).forEach(test -> {
+            exemptTestsSection.appendNewLine("|" + test.testClass );
+            exemptTestsSection.appendNewLine("|" + test.testName );
+            exemptTestsSection.appendNewLine("|" + test.disabledText );
+            exemptTestsSection.appendNewLine("");
+        });
+        exemptTestsSection.append("|===");
+        
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(outputLocation))) {
+            writer.write(exemptTestsSection.toString() );
+        }
+        
+    }
+
+    /**
+     * Writes expected test counts output to the generated adoc folder
+     * 
+     * @param testMetaData   - the test metadata we previously collected
+     * @param outputLocation - the output file
+     * @throws IOException   - exception if we cannot write to this location
+     */
+    private static void writeTestCounts(List<TestMetaData> testMetaData, File outputLocation) throws IOException {
+        List<TestMetaData> runnableTestMetaData = testMetaData.stream().filter(TestMetaData::isRunnable).collect(Collectors.toList());
+        final String compatabilityStatement = "* tests must be passed to successfully claim $1 compatibility.";
+        
+        StringBufferWrapper runtimeTestsSection = new StringBufferWrapper();
+        
+        //TODO replace with testblock if we end up using Java 17
+        runtimeTestsSection.append("* *" + runnableTestMetaData.stream().filter(TestMetaData::isStandalone).count());
+        runtimeTestsSection.appendNewLine(compatabilityStatement.replace("$1", "standalone"));
+        runtimeTestsSection.append("* *" + runnableTestMetaData.stream().filter(TestMetaData::isCore).count());
+        runtimeTestsSection.appendNewLine(compatabilityStatement.replace("$1", "core"));
+        runtimeTestsSection.append("* *" + runnableTestMetaData.stream().filter(TestMetaData::isWeb).count());
+        runtimeTestsSection.appendNewLine(compatabilityStatement.replace("$1", "web"));
+        runtimeTestsSection.append("* *" + runnableTestMetaData.stream().filter(TestMetaData::isFull).count());
+        runtimeTestsSection.appendNewParagraph(compatabilityStatement.replace("$1", "full"));
+        runtimeTestsSection.append("*Note:* This count includes the signature test, but does not include disabled tests");
+        
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(outputLocation))) {
+            writer.write(runtimeTestsSection.toString());
+        }
+    }
+    
+    /**
+     * Inspects each class for methods and annotations and constructs a metadata object.
+     * Collects all metadata objects and returns them as a list. 
+     * 
+     * @param testClasses - the test classes
+     * @return list of metadata for each test
+     */
+    private static List<TestMetaData> collectMetaData(List<Class<?>> testClasses) {
+        return testClasses.stream()
+                .flatMap(clazz -> AnnotationSupport.findAnnotatedMethods(clazz, Assertion.class, HierarchyTraversalMode.TOP_DOWN).stream())
+                .map(method -> {
+                    TestMetaData metaData = new TestMetaData();
+                    metaData.testClass = method.getDeclaringClass().getCanonicalName();
+                    metaData.testName = method.getName();
+                    metaData.assertion = method.getAnnotation(Assertion.class).strategy();
+                    metaData.isDisabled = method.isAnnotationPresent(Disabled.class);
+                    metaData.disabledText = metaData.isDisabled ? method.getAnnotation(Disabled.class).value() : "";
+                    metaData.tags = findTags(method.getDeclaringClass());
+                    return metaData;
+                }).collect(Collectors.toList());
+    }
+    
+    /**
+     * Finds the tag(s) on a test class which could be a {@Tag} or {@Tags} annotation.
+     * 
+     * @param clazz - the test class
+     * @return - a list of tag values on this class 
+     */
+    private static List<String> findTags(Class<?> clazz) {
+        return Arrays.stream(clazz.getAnnotations())
+        // Get 1st level nested annotations
+        .flatMap(anno -> Arrays.stream(anno.annotationType().getAnnotations()))
+        // Get all tag annotations
+        .flatMap(anno -> {
+            if(anno instanceof Tag)
+                return Stream.of((Tag) anno);
+            if(anno instanceof Tags)
+                return Arrays.stream(((Tags) anno).value());
+            return Stream.empty();
+        })
+        .map(anno -> anno.value())
+        .collect(Collectors.toList());
+
+    }
+    
+    /**
+     * Finds and loads all test classes inside of a TCK jar
+     * 
+     * @param jarLocation - Path to the TCK jar
+     * @return List of test classes
+     * @throws Exception - throws exception if jar cannot be located, or classes cannot be loaded.
+     */
+    private static List<Class<?>> getClassNames(String jarLocation) throws Exception {
+        ArrayList<Class<?>> classList = new ArrayList<>();
+        
+        try (JarInputStream jar = new JarInputStream(new FileInputStream(jarLocation));) {
+            for(JarEntry entry = jar.getNextJarEntry(); entry != null; entry = jar.getNextJarEntry()) {
+                if(isTestClass(entry.getName())) {
+                    debug("Attempting to load test class: " + entry.getName());
+                    classList.add(getClass(entry.getName().replaceAll("/", "\\.")));
+                } else if(entry.getName().contains("sig-test-pkg-list.txt")) {
+                    debug("Attempting to read package list" + entry.getName());
+                    apiPackages = new String(jar.readAllBytes(), StandardCharsets.UTF_8).lines()
+                        .filter(line -> !line.contains("#"))
+                        .filter(line -> !line.isBlank())
+                        .collect(Collectors.toList());
+                    debug("apiPackages populated with: " + apiPackages.toString());
+                }
+                jar.closeEntry();
+            }
+        }
+        
+        return classList;
+    }
+    
+    /**
+     * Determines if a jar resource is a test class or not.
+     * 
+     * @param entryName - The fully qualified resource name
+     * @return true - if resource is a test class, false otherwise
+     */
+    private static boolean isTestClass(String entryName) {
+        if(! entryName.endsWith(".class") )
+            return false;
+        if(entryName.contains(FRAMEWORK_PACKAGE_PREFIX))
+            return false;
+        if(! entryName.substring(entryName.lastIndexOf("/"), entryName.lastIndexOf(".")).toLowerCase().contains("tests"))
+            return false;
+            
+        return true;
+    }
+ 
+    /**
+     * Loads a given class and returns it
+     * 
+     * @param className - The name of the class with or without the .class suffix
+     * @return The class object
+     */
+    private static Class<?> getClass(String className) {
+        try {
+            return Class.forName(className.substring(0, className.lastIndexOf('.')));
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    /**
+     * Prints message if debugging is enabled
+     * 
+     * @param message - The message to print
+     */
+    private static void debug(String message) {
+        if(debug)
+            System.out.println(message);
+    }
+    
+    /**
+     * A data structure that represents data associated with test methods.
+     */
+    public static class TestMetaData {
+        //TODO replace with record if we end up using Java 17
+        private String testClass;
+        private String testName;
+        private String assertion;
+        private boolean isDisabled;
+        private String disabledText;
+        private List<String> tags;
+        
+        @Override
+        public String toString() {
+            return "TestMetaData [testName=" + testName + ", assertion=" + assertion + ", isDisabled=" + isDisabled
+                    + ", disabledText=" + disabledText + ", tags=" + tags + "]";
+        }
+        
+        boolean isStandalone() {
+            return tags.contains("standalone");
+        }
+        
+        boolean isCore() {
+            return tags.contains("core");
+        }
+        
+        boolean isWeb() {
+            return tags.contains("web");
+        }
+        
+        boolean isFull() {
+            return tags.contains("full");
+        }
+        
+        boolean isDisabled() {
+            return isDisabled;
+        }
+        
+        boolean isRunnable() {
+            return ! isDisabled;
+        }
+    }
+    
+    /**
+     * Utility wrapper to append strings with new lines
+     * to make construction of asciidoctor files easier
+     */
+    public static class StringBufferWrapper {
+        private StringBuffer buf;
+        
+        private static final String nl = System.lineSeparator();
+        
+        public StringBufferWrapper() {
+            buf = new StringBuffer();
+        }
+        
+        public void append(String message) {
+            buf.append(message);
+        }
+        
+        public void appendNewLine(String message) {
+            buf.append(message + nl);
+        }
+        
+        public void appendNewParagraph(String message) {
+            buf.append(message + nl + nl);
+        }
+        
+        @Override
+        public String toString() {
+            return buf.toString();
+        }
+    }
+}

--- a/tck-dist/src/main/readme/README.md
+++ b/tck-dist/src/main/readme/README.md
@@ -1,0 +1,8 @@
+# Jakarta Data TCK Distribution
+
+This bundle contains the Jakarta Data TCK. The contents of this bundle are:
+- artifacts/* - the TCK tests jar and sample script to install into a local maven repo
+- docs/*      - the TCK user guide (HTML and PDF)
+- starter/*   - a TCK starter project with sample code from user guide
+- README.md   - this README
+- LICENSE     - the EFTL license terms

--- a/tck-dist/src/main/starter/ee-pom.xml
+++ b/tck-dist/src/main/starter/ee-pom.xml
@@ -1,0 +1,220 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Copyright (c) 2022 Contributors to the Eclipse Foundation
+ ~
+ ~ This program and the accompanying materials are made available under the
+ ~ terms of the Eclipse Public License v. 2.0, which is available at
+ ~ http://www.eclipse.org/legal/epl-2.0.
+ ~
+ ~ This Source Code may also be made available under the following Secondary
+ ~ Licenses when the conditions for such availability set forth in the
+ ~ Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ ~ version 2 with the GNU Classpath Exception, which is available at
+ ~ https://www.gnu.org/software/classpath/license.html.
+ ~
+ ~ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+ <modelVersion>4.0.0</modelVersion>
+
+ <groupId>[YOUR_GROUP_ID]</groupId>
+ <artifactId>data-tck-runner</artifactId>
+ <version>1.0-SNAPSHOT</version>
+ <name>Jakarta Data TCK Runner for [YOUR_IMPL]</name>
+
+ <properties>
+  <!-- General properties -->
+  <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+  <!-- TODO might need to update to 17 for Jakarta 11 -->
+  <maven.compiler.source>11</maven.compiler.source>
+  <maven.compiler.target>11</maven.compiler.target>
+
+  <!-- Dependency and Plugin Versions -->
+  <jakarta.data.version>1.0.0-SNAPSHOT</jakarta.data.version>
+
+  <arquillian.version>1.7.0.Alpha13</arquillian.version>
+  <junit.version>5.9.0</junit.version>
+  <sigtest.version>1.6</sigtest.version>
+
+  <maven.dep.plugin.version>3.3.0</maven.dep.plugin.version>
+  <maven.comp.plugin.version>3.10.1</maven.comp.plugin.version>
+  <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
+
+  <!-- Location to copy runtime dependencies to application server -->
+  <application.server.lib>[path/to/appserver/lib]</application.server.lib>
+
+  <!-- Pointer to logging.properties file that has the java.util.logging 
+   configuration -->
+  <logging.config>${project.basedir}/logging.properties</logging.config>
+
+  <!-- Output directory -->
+  <targetDirectory>${project.basedir}/target</targetDirectory>
+ </properties>
+
+ <repositories>
+  <!-- TODO add private repo if your implementation is not public -->
+  <!-- TODO add staging repo if you want to use SNAPSHOT versions of the 
+   API and TCK -->
+ </repositories>
+
+ <!-- tag::testClientDep[] -->
+ <!-- The Arquillian and Junit5 test frameworks -->
+ <dependencyManagement>
+  <dependencies>
+   <dependency>
+    <groupId>org.jboss.arquillian</groupId>
+    <artifactId>arquillian-bom</artifactId>
+    <version>${arquillian.version}</version>
+    <type>pom</type>
+    <scope>import</scope>
+   </dependency>
+   <dependency>
+    <groupId>org.junit</groupId>
+    <artifactId>junit-bom</artifactId>
+    <version>${junit.version}</version>
+    <type>pom</type>
+    <scope>import</scope>
+   </dependency>
+  </dependencies>
+ </dependencyManagement>
+
+ <!-- Client Dependencies -->
+ <dependencies>
+  <!-- The TCK -->
+  <dependency>
+   <groupId>jakarta-data</groupId>
+   <artifactId>jakarta-data-tck</artifactId>
+   <version>${jakarta.data.tck.version}</version>
+  </dependency>
+  <!-- The API -->
+  <dependency>
+   <groupId>jakarta-data</groupId>
+   <artifactId>jakarta-data-api</artifactId>
+   <version>${jakarta.data.version}</version>
+  </dependency>
+  <!-- Arquillian Implementation for JUnit5 -->
+  <dependency>
+   <groupId>org.jboss.arquillian.junit5</groupId>
+   <artifactId>arquillian-junit5-container</artifactId>
+  </dependency>
+  <!-- TODO add Arquillian SPI impl for your Jakarta EE Platform Server -->
+  <!-- Junit5 -->
+  <dependency>
+   <groupId>org.junit.jupiter</groupId>
+   <artifactId>junit-jupiter</artifactId>
+  </dependency>
+  <!-- Signature Test Plugin -->
+  <dependency>
+   <groupId>org.netbeans.tools</groupId>
+   <artifactId>sigtest-maven-plugin</artifactId>
+   <version>${sigtest.version}</version>
+  </dependency>
+  <!-- APIs provided by your Jakarta EE Platform server -->
+  <dependency>
+   <groupId>jakarta.servlet</groupId>
+   <artifactId>jakarta.servlet-api</artifactId>
+   <version>6.0</version>
+  </dependency>
+  <dependency>
+   <groupId>jakarta.enterprise</groupId>
+   <artifactId>jakarta.enterprise.cdi-api</artifactId>
+   <version>4.0</version>
+  </dependency>
+ </dependencies>
+ <!-- end::testClientDep[] -->
+
+ <build>
+  <directory>${targetDirectory}</directory>
+  <defaultGoal>clean test</defaultGoal>
+  <plugins>
+   <!-- tag::testServerDep[] -->
+   <!-- Test Server Dependencies -->
+   <plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-dependency-plugin</artifactId>
+    <version>${maven.dep.plugin.version}</version>
+    <configuration>
+     <artifactItems>
+      <artifactItem>
+       <groupId>org.junit.jupiter</groupId>
+       <artifactId>junit-jupiter</artifactId>
+       <version>${junit.version}</version>
+      </artifactItem>
+      <artifactItem>
+       <groupId>org.netbeans.tools</groupId>
+       <artifactId>sigtest-maven-plugin</artifactId>
+       <version>${sigtest.version}</version>
+      </artifactItem>
+     </artifactItems>
+     <outputDirectory>${application.server.lib}</outputDirectory>
+    </configuration>
+   </plugin>
+   <!-- end::testServerDep[] -->
+   <!-- Compile plugin for any supplemental class files -->
+   <plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-compiler-plugin</artifactId>
+    <version>${maven.comp.plugin.version}</version>
+    <configuration>
+     <source>${maven.compiler.source}</source>
+     <target>${maven.compiler.target}</target>
+    </configuration>
+   </plugin>
+   <!-- TODO: you can include a plugin to start your application server here -->
+   <!-- tag::configJunit5[] -->
+   <!-- Surefire plugin - Entrypoint for Junit5 -->
+   <plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-surefire-plugin</artifactId>
+    <version>${maven.surefire.plugin.version}</version>
+    <configuration>
+     <dependenciesToScan>
+      <dependency>jakarta.data:jakarta-data-tck</dependency>
+     </dependenciesToScan>
+     <!-- tag::displayName[] -->
+     <statelessTestsetReporter
+      implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
+      <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
+      <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
+     </statelessTestsetReporter>
+     <!-- end::displayName[] -->
+     <!-- tag::logging[] -->
+     <systemProperties>
+      <property>
+       <name>java.util.logging.config.file</name>
+       <value>${logging.config}</value>
+      </property>
+     </systemProperties>
+     <!-- end::logging[] -->
+     <!-- tag::arquillian[] -->
+     <systemPropertyVariables>
+      <!-- Properties shared with Arquillian -->
+      <tck_server>[TODO]</tck_server>
+      <tck_hostname>[TODO]</tck_hostname>
+      <tck_username>[TODO]</tck_username>
+      <tck_password>[TODO]</tck_password>
+      <tck_port>[TODO]</tck_port>
+      <tck_port>[TODO]</tck_port>
+     </systemPropertyVariables>
+     <!-- end::arquillian[] -->
+     <!-- Tags to include i.e. standalone/core/web/full -->
+     <groups>[TODO]</groups>
+     <!-- Tags to ignore i.e. signature -->
+     <excludedGroups>[TODO]</excludedGroups>
+     <!-- If running back-to-back tests at different levels use this to distinguish 
+      the results -->
+     <reportNameSuffix>[OPTIONAL]</reportNameSuffix>
+     <!-- Ensure surfire plugin looks under src/main/java instead of src/test/java -->
+     <testSourceDirectory>
+      ${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}
+     </testSourceDirectory>
+    </configuration>
+   </plugin>
+   <!-- end::configJunit5[] -->
+  </plugins>
+ </build>
+</project>

--- a/tck-dist/src/main/starter/logging.properties
+++ b/tck-dist/src/main/starter/logging.properties
@@ -1,0 +1,40 @@
+# Ensure that both your client and sever JVMs point to this file using the java.util.logging property
+# -Djava.util.logging.config.file=/path/to/logging.properties
+
+#Handlers we plan to use
+handlers=java.util.logging.FileHandler,java.util.logging.ConsoleHandler
+
+#Global logger - By default only log warnings
+.level=WARNING
+
+#Jakarta Data TCK logger - By default log everything for ee.jakarta.tck.data
+ee.jakarta.tck.data.level=ALL
+
+#Formatting for the simple formatter
+java.util.logging.SimpleFormatter.class.log=true
+java.util.logging.SimpleFormatter.class.full=false
+java.util.logging.SimpleFormatter.class.length=10
+
+java.util.logging.SimpleFormatter.level.log=true
+
+java.util.logging.SimpleFormatter.method.log=true
+java.util.logging.SimpleFormatter.method.length=30
+
+java.util.logging.SimpleFormatter.thread.log=true
+java.util.logging.SimpleFormatter.thread.length=3
+
+java.util.logging.SimpleFormatter.time.log=true
+java.util.logging.SimpleFormatter.time.format=[MM/dd/yyyy HH:mm:ss:SSS z]
+
+java.util.logging.SimpleFormatter.format=[%1$tF %1$tT] %4$.1s %3$s %5$s %n
+
+# Log warnings to console
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.ConsoleHandler.level=WARNING
+
+# Log everything else to file
+java.util.logging.FileHandler.pattern=DataTCK%g%u.log
+java.util.logging.FileHandler.limit = 500000
+java.util.logging.FileHandler.count = 5
+java.util.logging.FileHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.FileHandler.level=ALL

--- a/tck-dist/src/main/starter/se-pom.xml
+++ b/tck-dist/src/main/starter/se-pom.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Copyright (c) 2022 Contributors to the Eclipse Foundation
+ ~
+ ~ This program and the accompanying materials are made available under the
+ ~ terms of the Eclipse Public License v. 2.0, which is available at
+ ~ http://www.eclipse.org/legal/epl-2.0.
+ ~
+ ~ This Source Code may also be made available under the following Secondary
+ ~ Licenses when the conditions for such availability set forth in the
+ ~ Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ ~ version 2 with the GNU Classpath Exception, which is available at
+ ~ https://www.gnu.org/software/classpath/license.html.
+ ~
+ ~ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+ <modelVersion>4.0.0</modelVersion>
+
+ <groupId>[YOUR_GROUP_ID]</groupId>
+ <artifactId>data-tck-runner</artifactId>
+ <version>1.0-SNAPSHOT</version>
+ <name>Jakarta Data TCK Runner for [YOUR_IMPL]</name>
+
+ <properties>
+  <!-- General properties -->
+  <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+  <!-- TODO might need to update to 17 for Jakarta 11 -->
+  <maven.compiler.source>11</maven.compiler.source>
+  <maven.compiler.target>11</maven.compiler.target>
+
+  <!-- Dependency and Plugin Versions -->
+  <jakarta.data.version>1.0.0-SNAPSHOT</jakarta.data.version>
+
+  <arquillian.version>1.7.0.Alpha13</arquillian.version>
+  <junit.version>5.9.0</junit.version>
+  <sigtest.version>1.6</sigtest.version>
+
+  <maven.dep.plugin.version>3.3.0</maven.dep.plugin.version>
+  <maven.comp.plugin.version>3.10.1</maven.comp.plugin.version>
+  <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
+
+  <!-- Pointer to logging.properties file that has the java.util.logging 
+   configuration -->
+  <logging.config>${project.basedir}/logging.properties</logging.config>
+
+  <!-- Output directory -->
+  <targetDirectory>${project.basedir}/target</targetDirectory>
+ </properties>
+
+ <repositories>
+  <!-- TODO add private repo if your implementation is not public -->
+  <!-- TODO add staging repo if you want to use SNAPSHOT versions of the 
+   API and TCK -->
+ </repositories>
+
+ <!-- tag::runtimeDep[] -->
+ <!-- The Junit5 test frameworks -->
+ <dependencyManagement>
+  <dependencies>
+   <dependency>
+    <groupId>org.junit</groupId>
+    <artifactId>junit-bom</artifactId>
+    <version>${junit.version}</version>
+    <type>pom</type>
+    <scope>import</scope>
+   </dependency>
+  </dependencies>
+ </dependencyManagement>
+
+ <!-- Runtime Dependencies -->
+ <dependencies>
+  <!-- The TCK -->
+  <dependency>
+   <groupId>jakarta-data</groupId>
+   <artifactId>jakarta-data-tck</artifactId>
+   <version>${jakarta.data.tck.version}</version>
+  </dependency>
+  <!-- The API -->
+  <dependency>
+   <groupId>jakarta-data</groupId>
+   <artifactId>jakarta-data-api</artifactId>
+   <version>${jakarta.data.version}</version>
+  </dependency>
+  <!-- TODO add your implementation of the Jakarta Data API -->
+  <!-- Junit5 -->
+  <dependency>
+   <groupId>org.junit.jupiter</groupId>
+   <artifactId>junit-jupiter</artifactId>
+  </dependency>
+  <!-- Signature Test Plugin -->
+  <dependency>
+   <groupId>org.netbeans.tools</groupId>
+   <artifactId>sigtest-maven-plugin</artifactId>
+   <version>${sigtest.version}</version>
+  </dependency>
+  <!-- APIs referenced by TCK that do not require implementations for standalone 
+   tests -->
+  <dependency>
+   <groupId>org.jboss.shrinkwrap</groupId>
+   <artifactId>shrinkwrap-api</artifactId>
+   <version>1.2.6</version>
+  </dependency>
+  <dependency>
+   <groupId>org.jboss.arquillian.junit5</groupId>
+   <artifactId>arquillian-junit5-core</artifactId>
+   <version>1.7.0.Alpha13</version>
+  </dependency>
+  <dependency>
+   <groupId>jakarta.servlet</groupId>
+   <artifactId>jakarta.servlet-api</artifactId>
+   <version>6.0</version>
+  </dependency>
+  <dependency>
+   <groupId>jakarta.enterprise</groupId>
+   <artifactId>jakarta.enterprise.cdi-api</artifactId>
+   <version>4.0</version>
+  </dependency>
+ </dependencies>
+ <!-- end::runtimeDep[] -->
+
+ <build>
+  <directory>${targetDirectory}</directory>
+  <defaultGoal>clean test</defaultGoal>
+  <plugins>
+   <!-- Compile plugin for any supplemental class files -->
+   <plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-compiler-plugin</artifactId>
+    <version>${maven.comp.plugin.version}</version>
+    <configuration>
+     <source>${maven.compiler.source}</source>
+     <target>${maven.compiler.target}</target>
+    </configuration>
+   </plugin>
+   <!-- tag::configJunit5[] -->
+   <!-- Surefire plugin - Entrypoint for Junit5 -->
+   <plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-surefire-plugin</artifactId>
+    <version>${maven.surefire.plugin.version}</version>
+    <configuration>
+     <dependenciesToScan>
+      <dependency>jakarta.data:jakarta-data-tck</dependency>
+     </dependenciesToScan>
+     <!-- tag::displayName[] -->
+     <statelessTestsetReporter
+      implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
+      <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
+      <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
+     </statelessTestsetReporter>
+     <!-- end::displayName[] -->
+     <!-- tag::logging[] -->
+     <systemPropertyVariables>
+      <!-- tag::ignore[] -->
+      <jimage.dir>[path-to-extract-jvm-classes]</jimage.dir>
+      <signature.sigTestClasspath>[path-to]/jakarta-data-api.jar:[path-to-jimage]/java.base:[path-to-jimage]/java.rmi:[path-to-jimage]/java.sql:[path-to-jimage]/java.naming</signature.sigTestClasspath>
+      <!-- end::ignore[] -->
+      <java.util.logging.config.file>${logging.config}</java.util.logging.config.file>
+     </systemPropertyVariables>
+     <!-- end::logging[] -->
+     <groups>standalone</groups>
+     <!-- Tags to ignore i.e. signature -->
+     <excludedGroups>[TODO]</excludedGroups>
+     <!-- If running back-to-back tests at different levels use this to distinguish 
+      the results -->
+     <reportNameSuffix>[OPTIONAL]</reportNameSuffix>
+     <!-- Ensure surfire plugin looks under src/main/java instead of src/test/java -->
+     <testSourceDirectory>
+      ${basedir}${file.separarator}src${file.separarator}main${file.separarator}java${file.separarator}
+     </testSourceDirectory>
+    </configuration>
+   </plugin>
+   <!-- end::configJunit5[] -->
+  </plugins>
+ </build>
+</project>

--- a/tck-dist/src/main/starter/src/main/java/ee/jakarta/tck/data/example/extension/MyApplicationArchiveProcessor.java
+++ b/tck-dist/src/main/starter/src/main/java/ee/jakarta/tck/data/example/extension/MyApplicationArchiveProcessor.java
@@ -1,0 +1,23 @@
+package ee.jakarta.tck.data.example.extension;
+
+import java.util.List;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+//tag::applicationProcessor[]
+public class MyApplicationArchiveProcessor implements ApplicationArchiveProcessor {
+    
+    //List of test classes that deploy application that you need to customize
+    List<String> testClasses;
+
+    @Override
+    public void process(Archive<?> archive, TestClass testClass) {
+        if(testClasses.contains(testClass.getClass().getCanonicalName())){
+            ((WebArchive) archive).addAsWebInfResource("my-custom-sun-web.xml", "sun-web.xml");
+        }
+    }
+}
+//end::applicationProcessor[]

--- a/tck-dist/src/main/starter/src/main/java/ee/jakarta/tck/data/example/extension/MyLoadableExtension.java
+++ b/tck-dist/src/main/starter/src/main/java/ee/jakarta/tck/data/example/extension/MyLoadableExtension.java
@@ -1,0 +1,13 @@
+package ee.jakarta.tck.data.example.extension;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+//tag::loadableExtension[]
+public class MyLoadableExtension implements LoadableExtension {
+    @Override
+    public void register(ExtensionBuilder extensionBuilder) {
+        extensionBuilder.service(ApplicationArchiveProcessor.class, MyApplicationArchiveProcessor.class);
+    }
+}
+//end::loadableExtension[]

--- a/tck-dist/src/main/starter/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/tck-dist/src/main/starter/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+ee.jakarta.tck.data.example.extension.MyLoadableExtension

--- a/tck-dist/src/main/starter/src/test/resources/arquillian.xml
+++ b/tck-dist/src/main/starter/src/test/resources/arquillian.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+ ~ Copyright (c) 2022 Contributors to the Eclipse Foundation
+ ~
+ ~ This program and the accompanying materials are made available under the
+ ~ terms of the Eclipse Public License v. 2.0, which is available at
+ ~ http://www.eclipse.org/legal/epl-2.0.
+ ~
+ ~ This Source Code may also be made available under the following Secondary
+ ~ Licenses when the conditions for such availability set forth in the
+ ~ Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ ~ version 2 with the GNU Classpath Exception, which is available at
+ ~ https://www.gnu.org/software/classpath/license.html.
+ ~
+ ~ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+  -->
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="http://jboss.org/schema/arquillian"
+	xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+	
+	<engine>
+		<property name="deploymentExportPath">target/</property>
+	</engine>
+	
+	<container qualifier="[YOUR-CONTAINER-IMPL]" default="true">
+		<configuration>
+			<!-- Each variable used is set in surefire config in running pom.xml -->
+			<property name="serverName">${tck_server}</property>
+			<property name="hostName">${tck_hostname}</property>
+			<property name="username">${tck_username}</property>
+			<property name="password">${tck_password}</property>
+			<property name="httpPort">${tck_port}</property>
+			<property name="httpsPort">${tck_port_secure}</property>
+			<!-- Add additional properties for your container impl -->
+		</configuration>
+	</container>
+</arquillian> 

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -220,6 +220,7 @@
               <classes>${project.build.directory}/jakarta-data-api</classes>
               <packages>
                 jakarta.data,
+                jakarta.data.exceptions,
                 jakarta.data.repository
               </packages>
               <attach>false</attach>

--- a/tck/src/main/java/ee/jakarta/tck/data/core/example/CDIExampleTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/core/example/CDIExampleTests.java
@@ -22,7 +22,7 @@ import jakarta.inject.Inject;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 
 import ee.jakarta.tck.data.framework.junit.anno.Assertion;
 import ee.jakarta.tck.data.framework.junit.anno.Core;
@@ -42,9 +42,14 @@ public class CDIExampleTests {
     @Inject
     ExampleService service;
     
-    @Test
     @Assertion(id = "EXAMPLE", strategy = "Deployes a CDI bean to application server, and injects service to be tested")
     public void serviceAlwaysReturnsTrue() {
         assertTrue(service.getMessage(), "Message should have returned true");
+    }
+    
+    @Disabled(value = "Challenge #1")
+    @Assertion(id = "EXAMPLE", strategy = "Uses the disabled annotation to ensure test does not get executed")
+    public void disabledTest() {
+        
     }
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/junit/anno/Assertion.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/junit/anno/Assertion.java
@@ -21,12 +21,15 @@ import java.lang.annotation.Target;
 
 import java.lang.annotation.RetentionPolicy;
 
+import org.junit.jupiter.api.Test;
+
 /**
  * Test metadata to track what assertion from the spec is being tested, and the
  * strategy used to test that assertion.
  */
 @Target({ ElementType.METHOD })
 @Retention(RetentionPolicy.RUNTIME)
+@Test
 public @interface Assertion {
     String id();
 

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/signature/DataSignatureTestRunner.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/signature/DataSignatureTestRunner.java
@@ -68,7 +68,6 @@ public class DataSignatureTestRunner extends SigTestEE {
         return new String[] { "jakarta.data", "jakarta.data.repository" };
     }
 
-
     /**
      * Returns the classpath for the packages we are interested in.
      * @return the classpath as a colon (:) delimited string

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/example/StandaloneExampleTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/example/StandaloneExampleTests.java
@@ -22,7 +22,6 @@ import java.util.logging.Logger;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.Test;
 
 import ee.jakarta.tck.data.framework.junit.anno.Assertion;
 import ee.jakarta.tck.data.framework.junit.anno.Standalone;
@@ -37,7 +36,6 @@ public class StandaloneExampleTests {
                 .addClass(StandaloneExampleTests.class);
     }  
     
-    @Test
     @Assertion(id = "EXAMPLE", strategy = "Test runs on client JVM when running in standalone mode, otherwise gets deployed to server and run.")
     public void testStandaloneFunction() {
         assertEquals(1, 1, "One did not equal one.");

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/signature/SignatureTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/signature/SignatureTests.java
@@ -22,7 +22,6 @@ import java.util.logging.Logger;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.jupiter.api.Test;
 
 import ee.jakarta.tck.data.framework.junit.anno.Assertion;
 import ee.jakarta.tck.data.framework.junit.anno.Signature;
@@ -46,7 +45,6 @@ public class SignatureTests {
     @Inject
     SignatureTestBean testBean;
 
-    @Test
     @Assertion(id = "SIGNATURES", strategy = "Uses the sigtest-maven-plugin to execute signature tests on a Standalone JVM or on a Jakarta EE Server")
     public void testSignaturesStandalone() throws Exception {
 

--- a/tck/src/main/java/ee/jakarta/tck/data/web/example/ComplexServletTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/web/example/ComplexServletTests.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 import ee.jakarta.tck.data.framework.junit.anno.Assertion;
@@ -45,7 +44,6 @@ public class ComplexServletTests extends TestClient {
     @ArquillianResource
     URL baseURL;
     
-    @Test
     @Assertion(id = "EXAMPLE", strategy = "Run server side tests that will succeed and fail and assert the results.")
     public void testSuccessAndFailure(TestInfo testInfo) {
         URL requestURL = URLBuilder.fromURL(baseURL)
@@ -65,7 +63,6 @@ public class ComplexServletTests extends TestClient {
         });
     }
     
-    @Test
     @Assertion(id = "EXAMPLE", strategy = "Run server side test with a method name that matches the client side test.")
     public void testMatchServletSideMethodName(TestInfo testInfo) {
         URL requestURL = URLBuilder.fromURL(baseURL)
@@ -76,7 +73,6 @@ public class ComplexServletTests extends TestClient {
         super.runTest(requestURL);
     }
     
-    @Test
     @Assertion(id = "EXAMPLE", strategy = "Run server side test that append a unique string to the response body and make sure it is returned.")
     public void testServletSideCustomResponse(TestInfo testInfo) {
         URL requestURL = URLBuilder.fromURL(baseURL)

--- a/tck/src/main/java/ee/jakarta/tck/data/web/example/SimpleServletExampleTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/web/example/SimpleServletExampleTests.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.jupiter.api.Test;
 
 import ee.jakarta.tck.data.framework.junit.anno.Assertion;
 import ee.jakarta.tck.data.framework.junit.anno.Web;
@@ -34,7 +33,6 @@ public class SimpleServletExampleTests {
                 .addClass(SimpleServletExampleTests.class);
     } 
     
-    @Test
     @Assertion(id = "EXAMPLE", strategy = "Run a test directly on a servlet and make sure it works.")
     public void testRunOnServletUsingArquillian() {
         assertTrue(true, "Do something you could only do in a Web Container here!");

--- a/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/jakarta.data.sig
+++ b/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/jakarta.data.sig
@@ -1,12 +1,6 @@
 #Signature file v4.1
 #Version 1.0.0-SNAPSHOT
 
-CLSS public jakarta.data.DataException
-cons public init(java.lang.String)
-cons public init(java.lang.String,java.lang.Throwable)
-cons public init(java.lang.Throwable)
-supr java.lang.RuntimeException
-
 CLSS public abstract interface !annotation jakarta.data.Entity
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
@@ -18,6 +12,38 @@ CLSS public abstract interface !annotation jakarta.data.Id
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[FIELD])
 intf java.lang.annotation.Annotation
 meth public abstract !hasdefault java.lang.String value()
+
+CLSS public jakarta.data.exceptions.DataConnectionException
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr jakarta.data.exceptions.DataException
+
+CLSS public jakarta.data.exceptions.DataException
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr java.lang.RuntimeException
+
+CLSS public jakarta.data.exceptions.EmptyResultException
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr jakarta.data.exceptions.DataException
+
+CLSS public jakarta.data.exceptions.MappingException
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr jakarta.data.exceptions.DataException
+
+CLSS public jakarta.data.exceptions.NonUniqueResultException
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr jakarta.data.exceptions.DataException
+
+CLSS abstract interface jakarta.data.exceptions.package-info
 
 CLSS abstract interface jakarta.data.package-info
 
@@ -45,7 +71,17 @@ meth public static jakarta.data.repository.Direction valueOf(java.lang.String)
 meth public static jakarta.data.repository.Direction[] values()
 supr java.lang.Enum<jakarta.data.repository.Direction>
 
-CLSS public jakarta.data.repository.Limit
+CLSS public abstract interface jakarta.data.repository.KeysetAwarePage<%0 extends java.lang.Object>
+intf jakarta.data.repository.KeysetAwareSlice<{jakarta.data.repository.KeysetAwarePage%0}>
+intf jakarta.data.repository.Page<{jakarta.data.repository.KeysetAwarePage%0}>
+
+CLSS public abstract interface jakarta.data.repository.KeysetAwareSlice<%0 extends java.lang.Object>
+intf jakarta.data.repository.Slice<{jakarta.data.repository.KeysetAwareSlice%0}>
+meth public abstract jakarta.data.repository.Pageable nextPageable()
+meth public abstract jakarta.data.repository.Pageable previousPageable()
+meth public abstract jakarta.data.repository.Pageable$Cursor getKeysetCursor(int)
+
+CLSS public final jakarta.data.repository.Limit
 meth public long maxResults()
 meth public long startAt()
 meth public static jakarta.data.repository.Limit of(long)
@@ -69,21 +105,52 @@ CLSS public abstract interface static !annotation jakarta.data.repository.OrderB
 intf java.lang.annotation.Annotation
 meth public abstract jakarta.data.repository.OrderBy[] value()
 
-CLSS public jakarta.data.repository.Pageable
-meth public boolean equals(java.lang.Object)
-meth public int hashCode()
-meth public jakarta.data.repository.Pageable next()
-meth public java.lang.String toString()
-meth public long getPage()
-meth public long getSize()
-meth public static jakarta.data.repository.Pageable of(long,long)
-meth public static jakarta.data.repository.Pageable page(long)
-meth public static jakarta.data.repository.Pageable size(long)
-supr java.lang.Object
-hfds DEFAULT_SIZE,page,size
+CLSS public abstract interface jakarta.data.repository.Page<%0 extends java.lang.Object>
+intf jakarta.data.repository.Slice<{jakarta.data.repository.Page%0}>
+meth public abstract long totalElements()
+meth public abstract long totalPages()
+
+CLSS public abstract interface jakarta.data.repository.Pageable
+innr public abstract interface static Cursor
+innr public final static !enum Mode
+meth public abstract !varargs jakarta.data.repository.Pageable afterKeyset(java.lang.Object[])
+meth public abstract !varargs jakarta.data.repository.Pageable beforeKeyset(java.lang.Object[])
+meth public abstract !varargs jakarta.data.repository.Pageable sortBy(jakarta.data.repository.Sort[])
+meth public abstract boolean equals(java.lang.Object)
+meth public abstract int size()
+meth public abstract jakarta.data.repository.Pageable afterKeysetCursor(jakarta.data.repository.Pageable$Cursor)
+meth public abstract jakarta.data.repository.Pageable beforeKeysetCursor(jakarta.data.repository.Pageable$Cursor)
+meth public abstract jakarta.data.repository.Pageable newPage(long)
+meth public abstract jakarta.data.repository.Pageable newSize(int)
+meth public abstract jakarta.data.repository.Pageable next()
+meth public abstract jakarta.data.repository.Pageable sortBy(java.lang.Iterable<jakarta.data.repository.Sort>)
+meth public abstract jakarta.data.repository.Pageable$Cursor cursor()
+meth public abstract jakarta.data.repository.Pageable$Mode mode()
+meth public abstract java.util.List<jakarta.data.repository.Sort> sorts()
+meth public abstract long page()
+meth public static jakarta.data.repository.Pageable ofPage(long)
+meth public static jakarta.data.repository.Pageable ofSize(int)
+
+CLSS public abstract interface static jakarta.data.repository.Pageable$Cursor
+ outer jakarta.data.repository.Pageable
+meth public abstract boolean equals(java.lang.Object)
+meth public abstract int hashCode()
+meth public abstract int size()
+meth public abstract java.lang.Object getKeysetElement(int)
+meth public abstract java.lang.String toString()
+
+CLSS public final static !enum jakarta.data.repository.Pageable$Mode
+ outer jakarta.data.repository.Pageable
+fld public final static jakarta.data.repository.Pageable$Mode CURSOR_NEXT
+fld public final static jakarta.data.repository.Pageable$Mode CURSOR_PREVIOUS
+fld public final static jakarta.data.repository.Pageable$Mode OFFSET
+meth public static jakarta.data.repository.Pageable$Mode valueOf(java.lang.String)
+meth public static jakarta.data.repository.Pageable$Mode[] values()
+supr java.lang.Enum<jakarta.data.repository.Pageable$Mode>
 
 CLSS public abstract interface jakarta.data.repository.PageableRepository<%0 extends java.lang.Object, %1 extends java.lang.Object>
 intf jakarta.data.repository.CrudRepository<{jakarta.data.repository.PageableRepository%0},{jakarta.data.repository.PageableRepository%1}>
+meth public abstract jakarta.data.repository.Page<{jakarta.data.repository.PageableRepository%0}> findAll(jakarta.data.repository.Pageable)
 
 CLSS public abstract interface !annotation jakarta.data.repository.Param
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
@@ -95,6 +162,7 @@ CLSS public abstract interface !annotation jakarta.data.repository.Query
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD])
 intf java.lang.annotation.Annotation
+meth public abstract !hasdefault java.lang.String count()
 meth public abstract java.lang.String value()
 
 CLSS public abstract interface jakarta.data.repository.ReactiveRepository<%0 extends java.lang.Object, %1 extends java.lang.Object>
@@ -106,18 +174,31 @@ CLSS public abstract interface !annotation jakarta.data.repository.Repository
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
 intf java.lang.annotation.Annotation
 
-CLSS public jakarta.data.repository.Sort
+CLSS public abstract interface jakarta.data.repository.Slice<%0 extends java.lang.Object>
+intf jakarta.data.repository.Streamable<{jakarta.data.repository.Slice%0}>
+meth public abstract boolean hasContent()
+meth public abstract int numberOfElements()
+meth public abstract jakarta.data.repository.Pageable nextPageable()
+meth public abstract jakarta.data.repository.Pageable pageable()
+meth public abstract java.util.List<{jakarta.data.repository.Slice%0}> content()
+
+CLSS public final jakarta.data.repository.Sort
 meth public boolean equals(java.lang.Object)
 meth public boolean isAscending()
 meth public boolean isDescending()
 meth public int hashCode()
-meth public java.lang.String getProperty()
+meth public java.lang.String property()
 meth public java.lang.String toString()
 meth public static jakarta.data.repository.Sort asc(java.lang.String)
 meth public static jakarta.data.repository.Sort desc(java.lang.String)
 meth public static jakarta.data.repository.Sort of(java.lang.String,jakarta.data.repository.Direction)
 supr java.lang.Object
 hfds direction,property
+
+CLSS public abstract interface jakarta.data.repository.Streamable<%0 extends java.lang.Object>
+ anno 0 java.lang.FunctionalInterface()
+intf java.lang.Iterable<{jakarta.data.repository.Streamable%0}>
+meth public java.util.stream.Stream<{jakarta.data.repository.Streamable%0}> stream()
 
 CLSS abstract interface jakarta.data.repository.package-info
 
@@ -149,6 +230,17 @@ cons public init(java.lang.String)
 cons public init(java.lang.String,java.lang.Throwable)
 cons public init(java.lang.Throwable)
 supr java.lang.Throwable
+
+CLSS public abstract interface !annotation java.lang.FunctionalInterface
+ anno 0 java.lang.annotation.Documented()
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
+intf java.lang.annotation.Annotation
+
+CLSS public abstract interface java.lang.Iterable<%0 extends java.lang.Object>
+meth public abstract java.util.Iterator<{java.lang.Iterable%0}> iterator()
+meth public java.util.Spliterator<{java.lang.Iterable%0}> spliterator()
+meth public void forEach(java.util.function.Consumer<? super {java.lang.Iterable%0}>)
 
 CLSS public java.lang.Object
 cons public init()

--- a/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/sig-test-pkg-list.txt
+++ b/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/sig-test-pkg-list.txt
@@ -23,4 +23,5 @@
 ##
 
 jakarta.data
+jakarta.data.exceptions
 jakarta.data.repository


### PR DESCRIPTION
Fixes #58 

This module will create a TCK distribution as required by the [TCK Process Requirements](https://jakarta.ee/committees/specification/tckprocess/)

I also automated the process of generating some of this documentation using the CollectMetaData class: 
- runtime-tests.adoc: lists the number of expected tests per platform (standalone, core, web, full)
- successful-challenges.adoc: lists the names of tests and the reason(s) they were disabled
- expected-sig-output.adoc: shows expected output from the signature test based on package names
- expected-output.adoc: shows expected output from the surefire plugin