### PR TITLE
javadoc update missed when Sort was added to Pageable

### DIFF
--- a/api/src/main/java/jakarta/data/repository/OrderBy.java
+++ b/api/src/main/java/jakarta/data/repository/OrderBy.java
@@ -51,7 +51,8 @@ import java.lang.annotation.Target;
  * specified in combination with any of:</p>
  * <ul>
  * <li>an <code>OrderBy</code> keyword</li>
- * <li>a <code>Sort</code> parameter</li>
+ * <li>a {@link Sort} parameter</li>
+ * <li>a {@link Pageable} parameter with {@link Pageable#sorts()}</li>
  * <li>a {@link Query} annotation that contains an <code>ORDER BY</code> clause.</li>
  * </ul>
  */

--- a/api/src/main/java/jakarta/data/repository/Sort.java
+++ b/api/src/main/java/jakarta/data/repository/Sort.java
@@ -47,6 +47,7 @@ import java.util.Objects;
  * <li>an <code>OrderBy</code> keyword</li>
  * <li>an {@link OrderBy} annotation</li>
  * <li>a {@link Query} annotation that contains an <code>ORDER BY</code> clause.</li>
+ * <li>a {@link Pageable} parameter with {@link Pageable#sorts()}</li>
  * </ul>
  */
 public final class Sort {


### PR DESCRIPTION
Fixes #94 issue where JavaDoc for 2 classes wasn't update when Sort was added to Pageable.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>