### PR TITLE
repository keywords for boolean conditions and Null

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Repository.java
+++ b/api/src/main/java/jakarta/data/repository/Repository.java
@@ -172,7 +172,7 @@ import java.lang.annotation.Target;
  * <tr style="vertical-align: top"><td><code>False</code></td>
  * <td>boolean</td>
  * <td>Requires that the entity's attribute value has a boolean value of false.</td>
- * <td><code>findByIsCanceledFalseAndDurationLessThan(max)</code></td></tr>
+ * <td><code>findByIsCanceledFalse()</code></td></tr>
  *
  * <tr style="vertical-align: top"><td><code>First</code></td>
  * <td>find...By</td>
@@ -221,8 +221,8 @@ import java.lang.annotation.Target;
  * <tr style="vertical-align: top"><td><code>Null</code></td>
  * <td>nullable types</td>
  * <td>Requires that the entity's attribute has a null value.</td>
- * <td><code>findByEndTimeNullAndStartTimeLessThan(maxStartedAt)</code>
- * <br><code>findByAgeNotNullAndAgeBetween(min, max)</code></td></tr>
+ * <td><code>findByEndTimeNull()</code>
+ * <br><code>findByAgeNotNull()</code></td></tr>
  *
  * <tr style="vertical-align: top"><td><code>Or</code></td>
  * <td>conditions</td>
@@ -247,7 +247,7 @@ import java.lang.annotation.Target;
  * <tr style="vertical-align: top"><td><code>True</code></td>
  * <td>boolean</td>
  * <td>Requires that the entity's attribute value has a boolean value of true.</td>
- * <td><code>findByIsAvailableTrueAndPriceLessThan(max)</code></td></tr>
+ * <td><code>findByIsAvailableTrue()</code></td></tr>
  *
  * </table>
  * Wildcard characters for patterns are determined by the data access provider.

--- a/api/src/main/java/jakarta/data/repository/Repository.java
+++ b/api/src/main/java/jakarta/data/repository/Repository.java
@@ -169,6 +169,11 @@ import java.lang.annotation.Target;
  * match the parameter value, which can be a pattern.</td>
  * <td><code>findByNameEndsWith(surname)</code></td></tr>
  *
+ * <tr style="vertical-align: top"><td><code>False</code></td>
+ * <td>boolean</td>
+ * <td>Requires that the entity's attribute value has a boolean value of false.</td>
+ * <td><code>findByIsCanceledFalseAndDurationLessThan(max)</code></td></tr>
+ *
  * <tr style="vertical-align: top"><td><code>First</code></td>
  * <td>find...By</td>
  * <td>Limits the amount of results that can be returned by the query
@@ -213,6 +218,12 @@ import java.lang.annotation.Target;
  * <td><code>deleteByNameNotLike(namePattern)</code>
  * <br><code>findByStatusNot("RUNNING")</code></td></tr>
  *
+ * <tr style="vertical-align: top"><td><code>Null</code></td>
+ * <td>nullable types</td>
+ * <td>Requires that the entity's attribute has a null value.</td>
+ * <td><code>findByEndTimeNullAndStartTimeLessThan(maxStartedAt)</code>
+ * <br><code>findByAgeNotNullAndAgeBetween(min, max)</code></td></tr>
+ *
  * <tr style="vertical-align: top"><td><code>Or</code></td>
  * <td>conditions</td>
  * <td>Requires at least one of the two conditions to be satisfied in order to match an entity.
@@ -232,6 +243,11 @@ import java.lang.annotation.Target;
  * <td>Requires that the characters at the beginning of the entity's attribute value
  * match the parameter value, which can be a pattern.</td>
  * <td><code>findByNameStartsWith(firstTwoLetters)</code></td></tr>
+ *
+ * <tr style="vertical-align: top"><td><code>True</code></td>
+ * <td>boolean</td>
+ * <td>Requires that the entity's attribute value has a boolean value of true.</td>
+ * <td><code>findByIsAvailableTrueAndPriceLessThan(max)</code></td></tr>
  *
  * </table>
  * Wildcard characters for patterns are determined by the data access provider.

--- a/api/src/main/java/jakarta/data/repository/Repository.java
+++ b/api/src/main/java/jakarta/data/repository/Repository.java
@@ -172,7 +172,7 @@ import java.lang.annotation.Target;
  * <tr style="vertical-align: top"><td><code>False</code></td>
  * <td>boolean</td>
  * <td>Requires that the entity's attribute value has a boolean value of false.</td>
- * <td><code>findByIsCanceledFalse()</code></td></tr>
+ * <td><code>findByCanceledFalse()</code></td></tr>
  *
  * <tr style="vertical-align: top"><td><code>First</code></td>
  * <td>find...By</td>
@@ -247,7 +247,7 @@ import java.lang.annotation.Target;
  * <tr style="vertical-align: top"><td><code>True</code></td>
  * <td>boolean</td>
  * <td>Requires that the entity's attribute value has a boolean value of true.</td>
- * <td><code>findByIsAvailableTrue()</code></td></tr>
+ * <td><code>findByAvailableTrue()</code></td></tr>
  *
  * </table>
  * Wildcard characters for patterns are determined by the data access provider.

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -225,6 +225,18 @@ Jakarta Data implementations often support the following list of predicate keywo
 |Find results where the property is one of the values that are contained within the given list
 |findByIdIn
 
+|Null
+|Finds results where the property has a null value.
+|findByYearRetiredNull
+
+|True
+|Finds results where the property has a boolean value of true.
+|findByIsSalariedTrue
+
+|False
+|Finds results where the property has a boolean value of false.
+|findByIsCompletedFalse
+
 |OrderBy
 |Specify a static sorting order followed by the property path and direction of ascending.
 |findByNameOrderByAge

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -231,11 +231,11 @@ Jakarta Data implementations often support the following list of predicate keywo
 
 |True
 |Finds results where the property has a boolean value of true.
-|findByIsSalariedTrue
+|findBySalariedTrue
 
 |False
 |Finds results where the property has a boolean value of false.
-|findByIsCompletedFalse
+|findByCompletedFalse
 
 |OrderBy
 |Specify a static sorting order followed by the property path and direction of ascending.


### PR DESCRIPTION
[Micronaut](https://micronaut-projects.github.io/micronaut-data/latest/guide/) and [Spring Data](https://docs.spring.io/spring-data/jpa/docs/current/reference/html/) have repository keywords for boolean true/false conditions and checking for null.  Jakarta Data doesn't have these documented yet.  This pull adds them.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>