### PR TITLE
repository keyword for Empty

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Repository.java
+++ b/api/src/main/java/jakarta/data/repository/Repository.java
@@ -163,6 +163,12 @@ import java.lang.annotation.Target;
  * <td>Specifies descending sort order for <code>findBy</code> queries</td>
  * <td><code>findByAuthorLastNameOrderByYearPublishedDesc(surname)</code></td></tr>
  *
+ * <tr style="vertical-align: top"><td><code>Empty</code></td>
+ * <td>collections</td>
+ * <td>Requires that the entity's attribute is an empty collection or has a null value.</td>
+ * <td><code>countByPhoneNumbersEmpty()</code>
+ * <br><code>findByInviteesNotEmpty()</code></td></tr>
+ *
  * <tr style="vertical-align: top"><td><code>EndsWith</code></td>
  * <td>strings</td>
  * <td>Requires that the characters at the end of the entity's attribute value

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -201,6 +201,10 @@ Jakarta Data implementations often support the following list of predicate keywo
 |Find results where the property is between the given values
 |findByDateBetween
 
+|Empty
+|Find results where the property is an empty collection or has a null value.
+|deleteByPendingTasksEmpty
+
 |LessThan
 |Find results where the property is less than the given value
 |findByAgeLessThan


### PR DESCRIPTION
[Micronaut](https://micronaut-projects.github.io/micronaut-data/latest/guide/) and [Spring Data](https://docs.spring.io/spring-data/jpa/docs/current/reference/html/) have repository keywords to check for empty collections. This pull adds Empty to Jakarta Data documentation, which currently lacks it.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>