### PR TITLE
Switch to int for Limit.maxResults

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Limit.java
+++ b/api/src/main/java/jakarta/data/repository/Limit.java
@@ -47,11 +47,11 @@ package jakarta.data.repository;
  * </ul>
  */
 public final class Limit {
-    private static final long DEFAULT_START_AT = 1L;
-    private final long maxResults;
-    private final long startAt;
+    private static final int DEFAULT_START_AT = 1;
+    private final int maxResults;
+    private final int startAt;
 
-    private Limit(long maxResults, long startAt) {
+    private Limit(int maxResults, int startAt) {
         this.maxResults = maxResults;
         this.startAt = startAt;
     }
@@ -62,7 +62,7 @@ public final class Limit {
      *
      * @return maximum number of results for a query.
      */
-    public long maxResults() {
+    public int maxResults() {
         return maxResults;
     }
 
@@ -72,7 +72,7 @@ public final class Limit {
      *
      * @return offset of the first result.
      */
-    public long startAt() {
+    public int startAt() {
         return startAt;
     }
 
@@ -85,7 +85,7 @@ public final class Limit {
      *         or <code>&#64;Query</code> method; will never be {@literal null}.
      * @throws IllegalArgumentException if maxResults is less than 1.
      */
-    public static Limit of(long maxResults) {
+    public static Limit of(int maxResults) {
         if (maxResults < 1)
             throw new IllegalArgumentException("maxResults: " + maxResults);
 
@@ -106,7 +106,7 @@ public final class Limit {
      * @throws IllegalArgumentException if <code>startAt</code> is less than 1
      *         or <code>endAt</code> is less than <code>startAt</code>.
      */
-    public static Limit range(long startAt, long endAt) {
+    public static Limit range(int startAt, int endAt) {
         if (startAt < 1)
             throw new IllegalArgumentException("startAt: " + startAt);
 

--- a/api/src/test/java/jakarta/data/repository/LimitTest.java
+++ b/api/src/test/java/jakarta/data/repository/LimitTest.java
@@ -68,8 +68,8 @@ class LimitTest {
 
         assertSoftly(soft -> {
             soft.assertThat(limit).isNotNull();
-            soft.assertThat(limit.maxResults()).isEqualTo(1L);
-            soft.assertThat(limit.startAt()).isEqualTo(1L);
+            soft.assertThat(limit.maxResults()).isEqualTo(1);
+            soft.assertThat(limit.startAt()).isEqualTo(1);
         });
     }
 
@@ -80,8 +80,8 @@ class LimitTest {
 
         assertSoftly(soft -> {
             soft.assertThat(limit).isNotNull();
-            soft.assertThat(limit.maxResults()).isEqualTo(10L);
-            soft.assertThat(limit.startAt()).isEqualTo(1L);
+            soft.assertThat(limit.maxResults()).isEqualTo(10);
+            soft.assertThat(limit.startAt()).isEqualTo(1);
         });
     }
 
@@ -92,8 +92,8 @@ class LimitTest {
 
         assertSoftly(soft -> {
             soft.assertThat(limit).isNotNull();
-            soft.assertThat(limit.maxResults()).isEqualTo(1L);
-            soft.assertThat(limit.startAt()).isEqualTo(1L);
+            soft.assertThat(limit.maxResults()).isEqualTo(1);
+            soft.assertThat(limit.startAt()).isEqualTo(1);
         });
     }
 
@@ -104,8 +104,8 @@ class LimitTest {
 
         assertSoftly(soft -> {
             soft.assertThat(limit).isNotNull();
-            soft.assertThat(limit.maxResults()).isEqualTo(10L);
-            soft.assertThat(limit.startAt()).isEqualTo(2L);
+            soft.assertThat(limit.maxResults()).isEqualTo(10);
+            soft.assertThat(limit.startAt()).isEqualTo(2);
         });
     }
 }


### PR DESCRIPTION
When Limit was added, usage of the `long` data type was copied from Pageable, which has since been switched to use `int`.  Limit.maxResults should similarly be switched.  Result sizes of that magnitude aren't even supported by JPA, wouldn't be compatible or work properly for some return types, and would defeat the purpose of using pagination and limits in the first place.  When users expect that many results, they should instead be reading results in pages (preferably with keysets).  I wasn't sure about startAt/endAt - it seems like those could arguably go either way.  If `long`, then the difference between them could imply a maxResults that exceeds Integer.MAX_VALUE, so I went ahead and switched those as well.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>