### PR TITLE
specialization of repository types for supported reserved keywords

### DIFF
--- a/api/src/main/java/jakarta/data/repository/DataRepository.java
+++ b/api/src/main/java/jakarta/data/repository/DataRepository.java
@@ -17,6 +17,8 @@
  */
 package jakarta.data.repository;
 
+import java.util.Set;
+
 /**
  * Parent repository interface for all repositories.
  * Central repository marker interface. Captures the domain type to manage and the domain type's id type.
@@ -25,5 +27,27 @@ package jakarta.data.repository;
  */
 public interface DataRepository<T, K> {
 
-
+    /**
+     * <p>Returns the set of reserved keywords that are supported by the
+     * database to which the repository connects. Reserved keywords begin
+     * with a capital letter as they appear within a method name
+     * and as defined by the Jakarta Data specification in its list of
+     * {@link Repository Reserved Keywords}. This set also includes the
+     * Jakarta Data provider's vendor-specific reserved keywords (if any)
+     * that are supported by the database.
+     * This set does not include reserved method name prefixes,
+     * such as <code>find...By</code> and <code>deleteBy</code>.</p>
+     *
+     * <p>The following reserved keywords must be supported for all
+     * databases:</p>
+     *
+     * <ul>
+     * <li><code>And</code></li>
+     * <li>TODO specify the remainder of this list in a separate pull once the exact list is determined</li>
+     * </ul>
+     *
+     * @return reserved keywords for repository method names that are
+     *         supported by the database.
+     */
+    Set<String> supportedKeywords();
 }

--- a/api/src/main/java/jakarta/data/repository/Repository.java
+++ b/api/src/main/java/jakarta/data/repository/Repository.java
@@ -234,10 +234,18 @@ import java.lang.annotation.Target;
  * <td><code>findByNameStartsWith(firstTwoLetters)</code></td></tr>
  *
  * </table>
- * Wildcard characters for patterns are determined by the data access provider.
+ *
+ * <p>Wildcard characters for patterns are determined by the data access provider.
  * For Jakarta Persistence providers, <code>_</code> matches any one character
  * and <code>%</code> matches 0 or more characters.
- * <p>
+ * </p>
+ *
+ * <p>A core set of reserved keywords are supported by all databases.
+ * {@link DataRepository} subtypes, such as {@link SQLRepository}, mandate
+ * support for reserved keywords beyond that.
+ * Use the {@link DataRepository#supportedKeywords()} method to identify the
+ * list of reserved keywords that are supported for the database that your
+ * repository connects to.</p>
  *
  * <table style="width: 100%">
  * <caption><b>Return Types for Repository Methods</b></caption>

--- a/api/src/main/java/jakarta/data/repository/SQLRepository.java
+++ b/api/src/main/java/jakarta/data/repository/SQLRepository.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data.repository;
+
+/**
+ * <p>A repository for entities that are stored in a relational database
+ * with capability that is consistent with SQL and JPQL.</p>
+ *
+ * <p>The {@link #supportedKeywords() supportedKeywords} method return value
+ * of a repository that implements {@code SQLRepository} must include the
+ * following supported reserved keywords,</p>
+ *
+ * <ul>
+ * <li><code>IgnoreCase</code></li>
+ * <li>TODO specify the remainder of this list in a separate pull once the exact list is determined</li>
+ * </ul>
+ *
+ * @param <T> type of entity managed by the repository.
+ * @param <K> type of key that is the unique identifier for the entity.
+ */
+public interface SQLRepository<T, K> extends DataRepository<T, K> {
+}

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -184,7 +184,7 @@ The following table lists the subject keywords generally supported by Jakarta Da
 |Exists projection, returning typically a ```boolean``` result.
 |===
 
-Jakarta Data implementations often support the following list of predicate keywords. It might not work because some keywords listed here might not be supported in a particular store.
+The Jakarta Data specification defines reserved keywords for repository method name-based queries. A core set of reserved keywords, enumerated by the ```DataRepository.supportedKeywords()``` Javadoc, are supported for all databases. Subtypes of ```DataRepository```, such as ```SQLRepository```, add requirements on support for reserved keywords beyond the core set. Use the ```DataRepository.supportedKeywords()``` method to identify the complete list that are supported for the database that your repository connects to. The following table contains descriptions and example method names containing reserved keywords.
 
 |===
 |Keyword |Description | Method signature Sample


### PR DESCRIPTION
@otaviojava Here's my attempt at the specialization approach that I think you're asking for under #100.
I didn't go as far as enumerating the exact lists of reserved keywords for the core set and the additional keywords that are specific to SQL/JPQL/relational under this pull because for some I would be guessing, but I did include a place to put each, which can be done in a follow-on pull once the approach looks good.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>