### PR TITLE
Release version 1.0.0-b1

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -6,16 +6,18 @@ All notable changes to this project will be documented in this file.
 The format is based on https://keepachangelog.com/en/1.0.0/[Keep a Changelog]
 and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Versioning].
 
-== 1.0.0
+== [Unreleased]
 
-=== Changed
+== [1.0.0-b1] - 2022-12-27
+
+
+=== Added
 
 * jakarta-data-api
-    * Removed `hamcrest-all` in favour of `assertj-core`
-    * Changed the assertions in `PageableTest` and `SortTest`
-    * Removed redundant tests on `SortTest`
+** Removed `hamcrest-all` in favour of `assertj-core`
+** Changed the assertions in `PageableTest` and `SortTest`
+** Removed redundant tests on `SortTest`
 * jakarta-data-parent
-    * Updated the following libraries
-        * `mockito`.version` to `4.8.0`
-        * `junit` to `5.9.0`
-    * Fix typo on `mockito.version` 
+** Updated the following libraries
+* Add initial TCK structure
+* Add repository resource

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>jakarta.data</groupId>
         <artifactId>jakarta-data-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0-b1</version>
     </parent>
 
     <artifactId>jakarta-data-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>jakarta.data</groupId>
     <artifactId>jakarta-data-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0-b1</version>
     <packaging>pom</packaging>
 
     <name>Jakarta Data</name>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>jakarta.data</groupId>
         <artifactId>jakarta-data-parent</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>1.0.0-b1</version>
     </parent>
 
     <artifactId>jakarta-data-spec</artifactId>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>jakarta.data</groupId>
     <artifactId>jakarta-data-parent</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0-b1</version>
   </parent>
 
   <artifactId>jakarta-data-tck</artifactId>


### PR DESCRIPTION
This PR creates a release version to 1.0.0-b1.

As we discussed, the first release primarily aims to receive feedback from the community and see some implementations/vendor feedback.
