### PR TITLE
JavaDoc warnings and lack of serialVersionUID on exceptions

### DIFF
--- a/api/src/main/java/jakarta/data/exceptions/DataConnectionException.java
+++ b/api/src/main/java/jakarta/data/exceptions/DataConnectionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ package jakarta.data.exceptions;
  * the application must ensure that the transaction is rolled back before retrying the operation under a new transaction.
  */
 public class DataConnectionException extends DataException {
+    private static final long serialVersionUID = 4736774083679114892L;
 
     /**
      * Constructs a new DataConnectionException exception with the specified detail message.
@@ -38,6 +39,8 @@ public class DataConnectionException extends DataException {
      * Constructs a new DataConnectionException exception with the specified detail message.
      *
      * @param message the detail message.
+     * @param cause another exception or error that caused this exception.
+     *        Null indicates that no other cause is specified.
      */
     public DataConnectionException(String message, Throwable cause) {
         super(message, cause);

--- a/api/src/main/java/jakarta/data/exceptions/DataException.java
+++ b/api/src/main/java/jakarta/data/exceptions/DataException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ package jakarta.data.exceptions;
  * Thrown by the data provider when a problem occurs.
  */
 public class DataException extends RuntimeException {
-
+    private static final long serialVersionUID = 468278092602073093L;
 
     /**
      * Constructs a new DataException exception with the specified detail message.

--- a/api/src/main/java/jakarta/data/exceptions/EmptyResultException.java
+++ b/api/src/main/java/jakarta/data/exceptions/EmptyResultException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ package jakarta.data.exceptions;
  * but zero rows (or elements) were actually returned.
  */
 public class EmptyResultException extends DataException {
+    private static final long serialVersionUID = -4477636987874974491L;
 
     /**
      * Constructs a new EmptyResultException exception with the specified detail message.
@@ -36,6 +37,8 @@ public class EmptyResultException extends DataException {
      * Constructs a new EmptyResultException exception with the specified detail message.
      *
      * @param message the detail message.
+     * @param cause another exception or error that caused this exception.
+     *        Null indicates that no other cause is specified.
      */
     public EmptyResultException(String message, Throwable cause) {
         super(message, cause);

--- a/api/src/main/java/jakarta/data/exceptions/MappingException.java
+++ b/api/src/main/java/jakarta/data/exceptions/MappingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ package jakarta.data.exceptions;
  * A mapping exception is one thrown if an issue exists at runtime or build time in the data mapping.
  */
 public class MappingException extends DataException {
+    private static final long serialVersionUID = 6021238091536264838L;
 
     /**
      * Constructs a new MappingException exception with the specified detail message.
@@ -35,6 +36,8 @@ public class MappingException extends DataException {
      * Constructs a new MappingException exception with the specified detail message.
      *
      * @param message the detail message.
+     * @param cause another exception or error that caused this exception.
+     *        Null indicates that no other cause is specified.
      */
     public MappingException(String message, Throwable cause) {
         super(message, cause);

--- a/api/src/main/java/jakarta/data/exceptions/NonUniqueResultException.java
+++ b/api/src/main/java/jakarta/data/exceptions/NonUniqueResultException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ package jakarta.data.exceptions;
  * <code>Limit.of(1)</code> as a parameter to explicitly request only the first result.
  */
 public class NonUniqueResultException extends DataException {
+    private static final long serialVersionUID = 7742411163016495764L;
 
     /**
      * Constructs a new NonUniqueResultException exception with the specified detail message.
@@ -38,6 +39,8 @@ public class NonUniqueResultException extends DataException {
      * Constructs a new NonUniqueResultException exception with the specified detail message.
      *
      * @param message the detail message.
+     * @param cause another exception or error that caused this exception.
+     *        Null indicates that no other cause is specified.
      */
     public NonUniqueResultException(String message, Throwable cause) {
         super(message, cause);

--- a/api/src/main/java/jakarta/data/repository/Repository.java
+++ b/api/src/main/java/jakarta/data/repository/Repository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -264,10 +264,12 @@ import java.lang.annotation.Target;
  * <td><code>findByAvailableTrue()</code></td></tr>
  *
  * </table>
+ *
+ * <p>
  * Wildcard characters for patterns are determined by the data access provider.
  * For Jakarta Persistence providers, <code>_</code> matches any one character
  * and <code>%</code> matches 0 or more characters.
- * <p>
+ * </p>
  *
  * <table style="width: 100%">
  * <caption><b>Return Types for Repository Methods</b></caption>


### PR DESCRIPTION
The exception classes in Jakarta Data are missing serialVersionUID (they are Serializable because they inherit from Throwable) which could make them incompatible across JVMs that generate the value differently. This also shows as a warning in some editors.

Also, there are JavaDoc warnings from some of the exception classes for an undocumented method parameter (plus 1 other JavaDoc warning that I'll fix here as well)

```
[WARNING] Javadoc Warnings
[WARNING] /Users/njr/lgit/data/api/src/main/java/jakarta/data/repository/Repository.java:270: warning: empty <p> tag
[WARNING] * <p>
[WARNING] ^
[WARNING] /Users/njr/lgit/data/api/src/main/java/jakarta/data/exceptions/DataConnectionException.java:43: warning: no @param for cause
[WARNING] public DataConnectionException(String message, Throwable cause) {
[WARNING] ^
[WARNING] /Users/njr/lgit/data/api/src/main/java/jakarta/data/exceptions/EmptyResultException.java:41: warning: no @param for cause
[WARNING] public EmptyResultException(String message, Throwable cause) {
[WARNING] ^
[WARNING] /Users/njr/lgit/data/api/src/main/java/jakarta/data/exceptions/MappingException.java:40: warning: no @param for cause
[WARNING] public MappingException(String message, Throwable cause) {
[WARNING] ^
[WARNING] /Users/njr/lgit/data/api/src/main/java/jakarta/data/exceptions/NonUniqueResultException.java:43: warning: no @param for cause
[WARNING] public NonUniqueResultException(String message, Throwable cause) {
[WARNING] ^
```

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>