### PR TITLE
Clarify entity property names

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Repository.java
+++ b/api/src/main/java/jakarta/data/repository/Repository.java
@@ -80,13 +80,35 @@ import java.lang.annotation.Target;
  * because the built-in repository methods are consistent with the
  * same set of conventions that you use to write custom repository methods.</p>
  *
- * <p>Entity property names are determined from the entity model's
- * <code>&#64;Id</code> and <code>&#64;Column</code> annotations,
- * or otherwise from the the fields and accessor methods of the entity class.
- * These property names must not contain reserved words if used within
- * name-pattern based repository query methods.</p>
+ * <p>Entity property names are computed from the fields and accessor methods
+ * of the entity class and must be unique ignoring case. For simple entity
+ * properties, the field or accessor method name is used as the entity property
+ * name. In the case of embedded classes within entities, entity property names
+ * are computed by concatenating the field or accessor method names at each level,
+ * delimited by <code>_</code> or undelimited for query by method name (such as
+ * <code>findByAddress_ZipCode</code> or <code>findByAddressZipCode</code>)
+ * when referred to within repository method names, and delimited by
+ * <code>.</code> when used within annotation values, such as for
+ * {@link OrderBy#value} and {@link Query#value},</p>
  *
- * <h2>Reserved Keywords for Name-Pattern-Based Repository Methods</h2>
+ * <pre>
+ * &#64;Repository
+ * public interface Orders {
+ *     &#64;OrderBy("address.zipCode")
+ *     List&lt;Order&gt; findByAddressZipCodeIn(List&lt;Integer&gt; zipCodes);
+ *
+ *     &#64;Query("SELECT o FROM Order o WHERE o.address.zipCode=?1")
+ *     List&lt;Order&gt; forZipCode(int zipCode);
+ *
+ *     void save(Order order);
+ * }
+ * </pre>
+ *
+ * <p>In queries by method name, <code>Id</code> is an alias for the entity property
+ * that is designated as the id. Entity property names that are used in queries
+ * by method name must not contain reserved words.</p>
+ *
+ * <h2>Reserved Keywords for Query by Method Name</h2>
  *
  * <table style="width: 100%">
  * <caption><b>Reserved Method Name Prefixes</b></caption>

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Contributors to the Eclipse Foundation
+// Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -69,10 +69,6 @@ Entity classes are simple Java objects with fields or accessor methods designati
 
 TODO Write the remainder of this section after we determine if a common entity model can be created, or if Jakarta Data will define its own entity model, or if we will reuse the entity models from Jakarta Persistence and Jakarta NoSQL.
 
-==== Entity Property Names
-
-Within an entity, property names must be unique ignoring case and are either computed from the field or accessor method name or by other means defined by the entity model, such as through the `@Id` or `@Column` annotations, which take precedence if present on the field or accessor method. The entity property that is chosen as the id is referred to in repository methods by the name `Id` or optionally by its other designated name, for example if one is is assigned by an `@Id` or `@Column` annotation, with the latter being used to refer to the id property in query language. Entity properties which are not the id give precedence to the `@Column` name if specified or otherwise the field or accessor method name in both name-pattern based repository query methods and query language. Entity property names that are used in composing name-pattern based repository query methods must not contain reserved words.
-
 === Queries Methods
 
 In Jakarta Data, besides finding by an ID, custom queries can be written in two ways:
@@ -135,10 +131,25 @@ The first part defines the query's subject or condition, and the second the cond
 
 A predicate can refer only to a direct property of the managed entity. We also have the option to handle entities with another class on them.
 
-Assume an Order entity has an Address with a Zipcode. In that case, the access is ```order.address.zipCode```.
+==== Entity Property Names
 
-The resolution algorithm starts by interpreting the whole part (AddressZipCode) as the property and checks the domain class for a property with that name (uncapitalized). If the algorithm succeeds, it uses that property.
-//Jakarta Persistence @Embeddable might be an exception to this pattern, allowing the embeddable's attributes to be used directly as attributes of the main entity. Let's make a TODO note here to check on that and update if necessary at a later point. This doesn't need to be a part of this initial pull.
+Within an entity, property names must be unique ignoring case. For simple entity properties, the field or accessor method name serves as the entity property name. In the case of embedded classes, entity property names are computed by concatenating the field or accessor method names at each level.
+
+Assume an Order entity has an Address with a ZipCode. In that case, the access is ```order.address.zipCode```. This form is used within annotations, such as ```@Query```,
+
+[source,java]
+----
+@Repository
+public interface OrderRepository extends CrudRepository<Order, Long> {
+
+  @Query("SELECT order FROM Order order WHERE order.address.zipCode=?1")
+  List<Order> withZipCode(ZipCode zipCode);
+
+}
+----
+
+For queries by method name, the resolution algorithm starts by interpreting the whole part (AddressZipCode) as the property and checks the domain class for a property with that name (uncapitalized). If the algorithm succeeds, it uses that property.
+
 [source,java]
 ----
 @Repository
@@ -162,7 +173,9 @@ public interface OrderRepository extends CrudRepository<Order, Long> {
 }
 ----
 
-WARNING: Define as a priority following standard Java naming conventions, camel case,  using underscore as the last instance resource.
+WARNING: Define as a priority following standard Java naming conventions, camel case,  using underscore as the last resort.
+
+In queries by method name, ```Id``` is an alias for the entity property that is designated as the id. Entity property names that are used in queries by method name must not contain reserved words.
 
 ===== Query Methods Keywords
 


### PR DESCRIPTION
I made a mistake in an earlier pull while discussing usage of `Id` in query by method name, erroneously stating that the name/value from the `@Column` or `@Id` annotations could be used as the entity property name. The `@Column` name attribute has a different purpose in JPA - it's for the database column name, not an entity property name, which can be easily verified in JPQL. We should correct this in the spec and better clarify.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>