### PR TITLE
Document precedence of logical operators

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Repository.java
+++ b/api/src/main/java/jakarta/data/repository/Repository.java
@@ -297,7 +297,7 @@ import java.lang.annotation.Target;
  * For relational databases, the logical operator <code>And</code>
  * is evaluated on conditions before <code>Or</code> when both are specified
  * on the same method. Precedence for other database types is limited to
- * what the database is capable of.
+ * the capabilities of the database.
  * </p>
  *
  * <table style="width: 100%">

--- a/api/src/main/java/jakarta/data/repository/Repository.java
+++ b/api/src/main/java/jakarta/data/repository/Repository.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  * <p>Annotates a data repository interface that will be implemented by the container/runtime.</p>
  *
  * <p>This class is a CDI bean-defining annotation when CDI is available,
- * enabling the container/runtime to the implementation available via the
+ * enabling the container/runtime to make the implementation available via the
  * <code>jakarta.inject.Inject</code> annotation.</p>
  *
  * <p>For example,</p>
@@ -156,8 +156,7 @@ import java.lang.annotation.Target;
  *
  * <tr style="vertical-align: top"><td><code>And</code></td>
  * <td>conditions</td>
- * <td>Requires both conditions to be satisfied in order to match an entity.
- * Precedence is determined by the data access provider.</td>
+ * <td>Requires both conditions to be satisfied in order to match an entity.</td>
  * <td><code>findByNameLikeAndPriceLessThanEqual(namePattern, maxPrice)</code></td></tr>
  *
  * <tr style="vertical-align: top"><td><code>Asc</code></td>
@@ -262,8 +261,7 @@ import java.lang.annotation.Target;
  *
  * <tr style="vertical-align: top"><td><code>Or</code></td>
  * <td>conditions</td>
- * <td>Requires at least one of the two conditions to be satisfied in order to match an entity.
- * Precedence is determined by the data access provider.</td>
+ * <td>Requires at least one of the two conditions to be satisfied in order to match an entity.</td>
  * <td><code>findByPriceLessThanEqualOrDiscountGreaterThanEqual(maxPrice, minDiscount)</code></td></tr>
  *
  * <tr style="vertical-align: top"><td><code>OrderBy</code></td>
@@ -287,10 +285,19 @@ import java.lang.annotation.Target;
  *
  * </table>
  *
+ * <h3>Wildcard Characters</h3>
  * <p>
  * Wildcard characters for patterns are determined by the data access provider.
  * For Jakarta Persistence providers, <code>_</code> matches any one character
  * and <code>%</code> matches 0 or more characters.
+ * </p>
+ *
+ * <h3>Logical Operator Precedence</h3>
+ * <p>
+ * For relational databases, the logical operator <code>And</code>
+ * is evaluated on conditions before <code>Or</code> when both are specified
+ * on the same method. Precedence for other database types is limited to
+ * what the database is capable of.
  * </p>
  *
  * <table style="width: 100%">
@@ -447,9 +454,6 @@ import java.lang.annotation.Target;
 //       "... Jakarta NoSQL define entity models that are used by Jakarta Data."
 // TODO When can "By" be omitted and "All" added? Need to document that.
 // TODO keywords for update would be needed if included.
-// TODO We stated above that "Precedence is determined by the data access provider" when
-//       combining multiple conditions with AND/OR. Is it consistent between JPA and NoSQL,
-//       and if so, can we document it here?
 // TODO Does Jakarta NoSQL have the same or different wildcard characters? Document this
 //       under: "Wildcard characters for patterns are determined by the data access provider"
 // TODO Ensure we have all reserved words listed, including those we might want to reserve for future use.

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -278,7 +278,7 @@ Jakarta Data implementations often support the following list of predicate keywo
 
 ====== Logical Operator Precedence
 
-For relational databases, the logical operator ```And``` takes precedence over ```Or```, meaning that ```And``` is evaluated on conditions before ```Or``` when both are specified on the same method. For other database types, the precedence is limited by what the database is capable of. For example, some graph databases are limited to precedence in traversal order.
+For relational databases, the logical operator `And` takes precedence over `Or`, meaning that `And` is evaluated on conditions before `Or` when both are specified on the same method. For other database types, the precedence is limited to the capabilities of the database. For example, some graph databases are limited to precedence in traversal order.
 
 === Special Parameter Handling
 

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -276,6 +276,10 @@ Jakarta Data implementations often support the following list of predicate keywo
 
 |===
 
+====== Logical Operator Precedence
+
+For relational databases, the logical operator ```And``` takes precedence over ```Or```, meaning that ```And``` is evaluated on conditions before ```Or``` when both are specified on the same method. For other database types, the precedence is limited by what the database is capable of. For example, some graph databases are limited to precedence in traversal order.
+
 === Special Parameter Handling
 
 Jakarta Data also supports particular parameters to define pagination and sorting.


### PR DESCRIPTION
The specification should document the precedence for `And` and `Or` so that users can be assured what behavior they can rely on getting when writing a repository method like,

`findByNumDependantsGreaterThanOrFilingStatusAndIncomeBetween`

Users will likely expect to get the precedence [defined by JPQL](https://jakarta.ee/specifications/persistence/3.1/jakarta-persistence-spec-3.1.html#operators-and-operator-precedence) or by Java, which both have `And` taking precedence and being evaluated first.

Also, I spotted a typo in the same file where a sentence is missing the verb, so I've corrected that as well in this pull.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>