### PR TITLE
precedence for sort criteria

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Limit.java
+++ b/api/src/main/java/jakarta/data/repository/Limit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,13 +36,13 @@ package jakarta.data.repository;
  * secondMostExpensive50 = products.freeShippingEligible(6.0f, 360.0f, Limit.range(51, 100));
  * </pre>
  *
- * <p>A repository method will raise {@link IllegalArgumentException} if</p>
+ * <p>A repository method will fail if</p>
  * <ul>
- * <li>multiple <code>Limit</code> parameters are specified on the
+ * <li>multiple <code>Limit</code> parameters are supplied to the
  *     same method.</li>
- * <li><code>Limit</code> and {@link Pageable} parameters are specified on the
+ * <li><code>Limit</code> and {@link Pageable} parameters are supplied to the
  *     same method.</li>
- * <li>a <code>Limit</code> parameter is specified in combination
+ * <li>a <code>Limit</code> parameter is supplied in combination
  *     with the <code>First</code> keyword.</li>
  * </ul>
  */

--- a/api/src/main/java/jakarta/data/repository/OrderBy.java
+++ b/api/src/main/java/jakarta/data/repository/OrderBy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,18 +28,24 @@ import java.lang.annotation.Target;
  *
  * <p>When multiple <code>OrderBy</code> annotations are specified on a
  * repository method, the precedence for sorting follows the order
- * in which the <code>OrderBy</code> annotations are specified.</p>
+ * in which the <code>OrderBy</code> annotations are specified,
+ * and after that follows any sort criteria that is supplied
+ * dynamically by {@link Sort} parameters or by a
+ * {@link Pageable} parameter with {@link Pageable#sorts()}.</p>
  *
  * <p>For example, the following sorts first by the
  * <code>lastName</code> attribute in ascending order,
  * and secondly, for entities with the same <code>lastName</code>,
  * it then sorts by the <code>firstName</code> attribute,
- * also in ascending order,</p>
+ * also in ascending order. For entities with the same
+ * <code>lastName</code> and <code>firstName</code>,
+ * it then sorts by criteria that is specified in the
+ * {@link Pageable#sorts()}.</p>
  *
  * <pre>
  * &#64;OrderBy("lastName")
  * &#64;OrderBy("firstName")
- * Person[] findByZipCode(int zipCode);
+ * Person[] findByZipCode(int zipCode, Pageable pagination);
  * </pre>
  *
  * <p>The precise meaning of ascending and descending order is
@@ -51,8 +57,6 @@ import java.lang.annotation.Target;
  * specified in combination with any of:</p>
  * <ul>
  * <li>an <code>OrderBy</code> keyword</li>
- * <li>a {@link Sort} parameter</li>
- * <li>a {@link Pageable} parameter with {@link Pageable#sorts()}</li>
  * <li>a {@link Query} annotation that contains an <code>ORDER BY</code> clause.</li>
  * </ul>
  */

--- a/api/src/main/java/jakarta/data/repository/Pageable.java
+++ b/api/src/main/java/jakarta/data/repository/Pageable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,14 +39,16 @@ import java.util.List;
  * }
  * </pre>
  *
- * <p>A repository method will raise {@link IllegalArgumentException} if</p>
+ * <p>A repository method will fail if</p>
  * <ul>
- * <li>multiple <code>Pageable</code> parameters are specified on the
+ * <li>multiple <code>Pageable</code> parameters are supplied to the
  *     same method.</li>
- * <li><code>Pageable</code> and {@link Limit} parameters are specified on the
+ * <li><code>Pageable</code> and {@link Limit} parameters are supplied to the
  *     same method.</li>
- * <li>a <code>Pageable</code> parameter is specified in combination
+ * <li>a <code>Pageable</code> parameter is supplied in combination
  *     with the <code>First</code> keyword.</li>
+ * <li>a <code>Pageable</code> parameter is supplied and separate
+ *     {@link Sort} parameters are also supplied to the same method.</li>
  * </ul>
  */
 public interface Pageable {
@@ -213,18 +215,11 @@ public interface Pageable {
     /**
      * <p>Creates a new <code>Pageable</code> instance representing the same
      * pagination information, except using the specified sort criteria.
-     * The order of precedence of sort criteria is the order of the
+     * The order of precedence for sort criteria is that of any statically
+     * specified sort criteria (from the <code>OrderBy</code> keyword,
+     * {@link OrderBy} annotation or <code>ORDER BY</code> clause of a the
+     * {@link Query} annotation) followed by the order of the
      * {@link Iterable} that is supplied to this method.</p>
-     *
-     * <p>A repository method will fail if a sort criteria is specified on a
-     * <code>Pageable</code> in combination with any of:</p>
-     * <ul>
-     * <li>an <code>OrderBy</code> keyword</li>
-     * <li>an {@link OrderBy} annotation</li>
-     * <li>a {@link Query} annotation that contains an <code>ORDER BY</code> clause.</li>
-     * <li>{@link Sort} parameters that are specified independently of
-     *     <code>Pageable</code> on a repository method</li>
-     * </ul>
      *
      * @param sorts sort criteria to use.
      * @return a new instance of <code>Pageable</code>. This method never returns <code>null</code>.
@@ -234,18 +229,11 @@ public interface Pageable {
     /**
      * <p>Creates a new <code>Pageable</code> instance representing the same
      * pagination information, except using the specified sort criteria.
-     * The order of precedence of sort criteria is the order in which the
+     * The order of precedence for sort criteria is that of any statically
+     * specified sort criteria (from the <code>OrderBy</code> keyword,
+     * {@link OrderBy} annotation or <code>ORDER BY</code> clause of a the
+     * {@link Query} annotation) followed by the order in which the
      * {@link Sort} parameters to this method are listed.</p>
-     *
-     * <p>A repository method will fail if a sort criteria is specified on a
-     * <code>Pageable</code> in combination with any of:</p>
-     * <ul>
-     * <li>an <code>OrderBy</code> keyword</li>
-     * <li>an {@link OrderBy} annotation</li>
-     * <li>a {@link Query} annotation that contains an <code>ORDER BY</code> clause.</li>
-     * <li>{@link Sort} parameters that are specified independently of
-     *     <code>Pageable</code> on a repository method</li>
-     * </ul>
      *
      * @param sorts sort criteria to use. This method can be invoked without parameters
      *        to request a <code>Pageable</code> that does not specify sort criteria.

--- a/api/src/main/java/jakarta/data/repository/Query.java
+++ b/api/src/main/java/jakarta/data/repository/Query.java
@@ -31,7 +31,14 @@ import java.lang.annotation.Target;
 public @interface Query {
 
     /**
-     * Defines the query to be executed when the annotated method is called.
+     * <p>Defines the query to be executed when the annotated method is called.</p>
+     *
+     * <p>If an application defines a repository method with <code>&#64;Query</code>
+     * and supplies other forms of sorting (such as {@link Sort}) to that method,
+     * then it is the responsibility of the application to compose the query in
+     * such a way that an <code>ORDER BY</code> clause (or query language equivalent)
+     * can be validly appended. The Jakarta Data provider is not expected to
+     * parse query language that is provided by the application.</p>
      *
      * @return the query to be executed when the annotated method is called.
      */

--- a/api/src/main/java/jakarta/data/repository/Sort.java
+++ b/api/src/main/java/jakarta/data/repository/Sort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,13 @@ package jakarta.data.repository;
 import java.util.Objects;
 
 /**
- * <p><code>Sort</code> implements the pairing of a {@link Direction} and a property.</p>
+ * <p><code>Sort</code> allows the application to dynamically provide
+ * sort criteria which includes a case sensitivity request,
+ * a {@link Direction} and a property.</p>
  *
- * <p>Dynamic <code>Sort</code> criteria are optionally specified as
+ * <p>Dynamic <code>Sort</code> criteria can be specified when
+ * {@link Pageable#sortBy(Sort[]) requesting a page of results}
+ * or can be optionally specified as
  * parameters to a repository method in any of the positions that are after
  * the query parameters. You can use <code>Sort...</code> to allow a variable
  * number of <code>Sort</code> criteria. For example,</p>
@@ -37,18 +41,15 @@ import java.util.Objects;
  *                                                 Sort.asc("firstName"));
  * </pre>
  *
- * <p>It is preferable to use static sorting criteria
- * (<code>OrderBy</code> keyword or {@link Query} or {@link OrderBy} annotation)
- * where possible to better allow for optimizations by the provider.</p>
+ * <p>When combined on a method with static sort criteria
+ * (<code>OrderBy</code> keyword or {@link OrderBy} annotation or
+ * {@link Query} with an <code>ORDER BY</code> clause), the static
+ * sort criteria is applied first, followed by the dynamic sort criteria
+ * that is defined by <code>Sort</code> instances in the order listed.</p>
  *
  * <p>A repository method will fail if a <code>Sort</code> parameter is
- * specified in combination with any of:</p>
- * <ul>
- * <li>an <code>OrderBy</code> keyword</li>
- * <li>an {@link OrderBy} annotation</li>
- * <li>a {@link Query} annotation that contains an <code>ORDER BY</code> clause.</li>
- * <li>a {@link Pageable} parameter with {@link Pageable#sorts()}</li>
- * </ul>
+ * specified in combination with a {@link Pageable} parameter with
+ * {@link Pageable#sorts()}.</p>
  */
 public final class Sort {
 

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -76,7 +76,7 @@ You may use ```jakarta.nosql.mapping.Entity``` and the corresponding entity-rela
 In Jakarta Data, besides finding by an ID, custom queries can be written in two ways:
 
 * Through Query annotation: It will create a method annotated with the @Query with the query.
-* Using method by query convention: Using some pattern vocabulary will provide a query.
+* Using query by method convention: Using some pattern vocabulary will provide a query.
 
 WARNING: Due to the variety of data sources, those resources might not work; it varies based on the Jakarta Data implementation and the database engine, which can provide queries on more than a Key or ID or not, such as a Key-value database.
 
@@ -347,13 +347,10 @@ Pageable p = Pageable.ofSize(50).afterKeyset(c.lastName, c.firstName, c.id);
 page = customers.findByZipcodeOrderByLastNameAscFirstNameAscIdAsc(55902, p);
 ----
 
-The sort criteria for a repository method that performs keyset pagination must uniquely identify each entity and must be provided by one of:
+The sort criteria for a repository method that performs keyset pagination must uniquely identify each entity and must be provided by:
 
-* `OrderBy` name pattern of the repository method (as in the examples above).
-* `@OrderBy` annotation(s) on the repository method.
+* `OrderBy` name pattern of the repository method (as in the examples above) or `@OrderBy` annotation(s) on the repository method.
 * `Sort` parameters of the `Pageable` that is supplied to the repository method.
-
-If either of the first are specified, the `Sort` list of the `Pageable` must be empty or unspecified.
 
 ==== Example of Appending to Queries for Keyset Pagination
 

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -312,6 +312,50 @@ first20 = products.findByNameLike(name, pageable);
 
 ----
 
+=== Precedence of Sort Criteria
+
+The specification defines different ways of providing sort criteria on queries. This section discusses how these different mechanisms relate to each other.
+
+==== Sort Criteria within Query Language
+
+Sort criteria can be hard-coded directly within query language by making use of the ```@Query``` annotation. A repository method that is annotated with ```@Query``` with a value that contains an ```ORDER BY``` clause (or query language equivalent) must not provide sort criteria via the other mechanisms.
+
+A repository method that is annotated with ```@Query``` with a value that does not contain an ```ORDER BY``` clause and ends with a ```WHERE``` clause (or query language equivalents to these) can use other mechanisms that are defined by this specification for providing sort criteria.
+
+==== Static Mechanisms for Sort Criteria
+
+Sort criteria is provided statically for a repository method by using the ```OrderBy``` keyword or by annotating the method with one or more ```@OrderBy``` annotations. The ```OrderBy``` keyword cannot be intermixed with the ```@OrderBy``` annotation or the ```@Query``` annotation. Static sort criteria takes precedence over dynamic sort criteria in that static sort criteria is evaluated first. When static sort criteria sorts entities to the same position, dynamic sort criteria is applied to further order those entities.
+
+==== Dynamic Mechanisms for Sort Criteria
+
+Sort criteria is provided dynamically to repository methods either via ```Sort``` parameters or via a ```Pageable``` parameter that has one or more ```Sort``` values. ```Sort``` and```Pageable``` containing ```Sort``` must not both be provided to the same method.
+
+==== Examples of Sort Criteria Precedence
+
+The following examples work through scenarios where static and dynamic sort criteria are provided to the same method.
+
+[source,java]
+----
+// Sorts first by type. When type is the same, applies the Pageable's sort criteria
+Page<User> findByNameStartsWithOrderByType(String namePrefix, Pageable pagination);
+
+// Sorts first by type. When type is the same, applies the criteria in the Sorts
+List<User> findByNameStartsWithOrderByType(String namePrefix, Sort... sorts);
+
+// Sorts first by age. When age is the same, applies the Pageable's sort criteria
+@OrderBy("age")
+Page<User> findByNameStartsWith(String namePrefix, Pageable pagination);
+
+// Sorts first by age. When age is the same, applies the criteria in the Sorts
+@OrderBy("age")
+List<User> findByNameStartsWith(String namePrefix, Sort... sorts);
+
+// Sorts first by name. When name is the same, applies the Pageable's sort criteria
+@Query("SELECT u FROM User u WHERE (u.age > ?1)")
+@OrderBy("name")
+KeysetAwarePage<User> olderThan(int age, Pageable pagination);
+----
+
 === Keyset Pagination
 
 Keyset pagination aims to reduce missed and duplicate results across pages by querying relative to the observed values of entity properties that constitute the sorting criteria. Keyset pagination can also offer an improvement in performance because it avoids fetching and ordering results from prior pages by causing those results to be non-matching. A Jakarta Data provider appends additional conditions to the query and tracks keyset values automatically when `KeysetAwareSlice` or `KeysetAwarePage` are used as the repository method return type. The application invokes `nextPageable` or `previousPageable` on the keyset aware slice or page to obtain a `Pageable` which keeps track of the keyset values.


### PR DESCRIPTION
Fixes #116 - defines precedence for sort criteria according to the discussion in that issue.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>