### PR TITLE
Exception when database not capable of function

### DIFF
--- a/api/src/main/java/jakarta/data/repository/OrderBy.java
+++ b/api/src/main/java/jakarta/data/repository/OrderBy.java
@@ -59,6 +59,11 @@ import java.lang.annotation.Target;
  * <li>an <code>OrderBy</code> keyword</li>
  * <li>a {@link Query} annotation that contains an <code>ORDER BY</code> clause.</li>
  * </ul>
+ *
+ * <p>A repository method will fail with a
+ * {@link jakarta.data.exceptions.DataException DataException}
+ * or a more specific subclass if the database is incapable of
+ * ordering with the requested sort criteria.</p>
  */
 @Repeatable(OrderBy.List.class)
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/jakarta/data/repository/Pageable.java
+++ b/api/src/main/java/jakarta/data/repository/Pageable.java
@@ -39,7 +39,9 @@ import java.util.List;
  * }
  * </pre>
  *
- * <p>A repository method will fail if</p>
+ * <p>A repository method will fail with a
+ * {@link jakarta.data.exceptions.DataException DataException}
+ * or a more specific subclass if</p>
  * <ul>
  * <li>multiple <code>Pageable</code> parameters are supplied to the
  *     same method.</li>
@@ -49,6 +51,8 @@ import java.util.List;
  *     with the <code>First</code> keyword.</li>
  * <li>a <code>Pageable</code> parameter is supplied and separate
  *     {@link Sort} parameters are also supplied to the same method.</li>
+ * <li>the database is incapable of ordering with the requested
+ *     sort criteria.</li>
  * </ul>
  */
 public interface Pageable {

--- a/api/src/main/java/jakarta/data/repository/Sort.java
+++ b/api/src/main/java/jakarta/data/repository/Sort.java
@@ -47,9 +47,16 @@ import java.util.Objects;
  * sort criteria is applied first, followed by the dynamic sort criteria
  * that is defined by <code>Sort</code> instances in the order listed.</p>
  *
- * <p>A repository method will fail if a <code>Sort</code> parameter is
- * specified in combination with a {@link Pageable} parameter with
- * {@link Pageable#sorts()}.</p>
+ * <p>A repository method will fail with a
+ * {@link jakarta.data.exceptions.DataException DataException}
+ * or a more specific subclass if</p>
+ * <ul>
+ * <li>a <code>Sort</code> parameter is
+ *     specified in combination with a {@link Pageable} parameter with
+ *     {@link Pageable#sorts()}.</li>
+ * <li>the database is incapable of ordering with the requested
+ *     sort criteria.</li>
+ * </ul>
  */
 public final class Sort {
 

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -199,7 +199,7 @@ The following table lists the subject keywords generally supported by Jakarta Da
 |Exists projection, returning typically a ```boolean``` result.
 |===
 
-Jakarta Data implementations often support the following list of predicate keywords. It might not work because some keywords listed here might not be supported in a particular store.
+Jakarta Data implementations support the following list of predicate keywords to the extent that the database is capable of the behavior. A repository method will raise `jakarta.data.exceptions.DataException` or a more specific subclass of the exception if the database does not provide the requested functionality.
 
 |===
 |Keyword |Description | Method signature Sample


### PR DESCRIPTION
It was brought up by @otaviojava in an issue discussion and on the previous Jakarta Data call that we need a way in the spec to acknowledge that databases will have limited support for some capabilities, specifically around ordering.  In cases like this, the Jakarta Data specification can simply call out that the Jakarta Data provider is expected to raise an error for what the underlying database itself doesn't support.  That way Jakarta Data providers themselves can remain compliant regardless of whether the database is or is not capable of every requested aspect of the sort criteria.  This will have value to more than just NoSQL.  I tried out a scenario with Jakarta Persistence where I attempted to specify ordering based on a collection valued attribute (as opposed to a numeric or string).  This fails as probably everyone would expect.  With these updates, the spec will now be consistent with allowing that scenario and others like it to be a failure.