### PR TITLE
Document interoperability with Jakarta Transactions

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Repository.java
+++ b/api/src/main/java/jakarta/data/repository/Repository.java
@@ -481,6 +481,28 @@ import java.lang.annotation.Target;
  *                                 Sort.desc("amountSold"),
  *                                 Sort.asc("name"));
  * </pre>
+ *
+ * <h2>Jakarta Transactions</h2>
+ *
+ * <p>Repository methods can participate in global transactions.
+ * If a global transaction is active on the thread where a repository method runs
+ * and the data source that backs the repository is capable of transaction enlistment,
+ * then the repository operation runs as part of the transaction.
+ * The repository operation does not commit or roll back a transaction
+ * that was already present on the thread, but it might mark the transaction
+ * for rollback only ({@code jakarta.transaction.Status.STATUS_MARKED_ROLLBACK})
+ * if the repository operation fails.</p>
+ *
+ * <p>When running in an environment where Jakarta Transactions and Jakarta CDI are
+ * available, you can annotate repository methods with {@code jakarta.transaction.Transactional}
+ * to define how the container manages transactions with respect to the repository
+ * method.</p>
+ *
+ * <h2>Interceptor Annotations on Repository Methods</h2>
+ *
+ * <p>Interceptor bindings such as {@code jakarta.transaction.Transactional} can annotate a
+ * repository method. The repository bean honors these annotations when running in an
+ * environment where the Jakarta EE technology that provides the interceptor is available.</p>
  */
 // TODO When can "By" be omitted and "All" added? Need to document that.
 // TODO keywords for update would be needed if included.

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -483,3 +483,17 @@ Jakarta Data provider CDI Extensions must ignore all `Repository` annotations wh
 The entity annotation class will usually be sufficient to avoid conflicts between Jakarta Data providers, but in cases where the entity annotation class is not sufficient, the application can designate the name of the desired Jakarta Data provider on the optional `provider` attribute of the `Repository` annotation.
 
 Jakarta Data provider CDI Extensions must ignore all `Repository` annotations that designate a different provider's name via the `Repository.provider()` annotation attribute. Ignoring these annotations allows other Jakarta Data providers to handle them.
+
+== Interoperability with other Jakarta EE Specifications
+
+When running within a Jakarta EE product, other Jakarta EE Technologies might be available depending on the profile. This section defines how related technologies from other Jakarta EE Specifications interoperate with Jakarta Data.
+
+=== Jakarta Transactions Usage
+
+When running in an environment where Jakarta Transactions is available and a global transaction is active on the thread of execution for a repository operation and the data source backing the repository is capable of transaction enlistment, the repository operation enlists the data source resource as a participant in the transaction. The repository operation does not commit or roll back the transaction that was already present on the thread, but it might cause the transaction to be marked as rollback only (`jakarta.transaction.Status.STATUS_MARKED_ROLLBACK`) if the repository operation fails.
+
+When running in an environment where Jakarta Transactions and Jakarta CDI are available, a repository method can be annotated with the `jakarta.transaction.Transactional` annotation, which is applied to the execution of the repository method.
+
+=== Interceptor Annotations on Repository Methods
+
+When a repository method is annotated with an interceptor binding annotation, the interceptor is bound to the repository bean according to the interceptor binding annotation of the repository interface method, causing the bound interceptor to be invoked around the repository method when it runs. This enables the use of interceptors such as `jakarta.transaction.Transactional` on repository methods when running in an environment where the Jakarta EE technology that provides the interceptor is available.


### PR DESCRIPTION
The spec needs to state what must happen if there is a JTA transaction already on the thread when a repository method is invoked so that users can know what to expect, both for resources types that are enlistable (these participate in the transaction) and for those which are not (these do not participate in the transaction).  The spec should also acknowledge that a failure running a repository method might cause a transaction to be marked as rollback-only (JPA does this in some cases) so that users are not surprised by that behavior.