### PR TITLE
Compile against Java 17

### DIFF
--- a/.github/workflows/java-17.yml
+++ b/.github/workflows/java-17.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Java 11 CI with Maven
+name: Java 17 CI with Maven
 
 on:
   push:
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven

--- a/README.adoc
+++ b/README.adoc
@@ -79,7 +79,7 @@ Report Jakarta Data bugs at https://github.com/jakartaee/data/issues.
 
 == Building from Source
 
-You don’t need to build from source to use the project, but you can do so with Maven and Java 11 or higher.
+You don’t need to build from source to use the project, but you can do so with Maven and Java 17 or higher.
 
 [source, Bash]
 ----

--- a/api/src/main/java/jakarta/data/repository/Limit.java
+++ b/api/src/main/java/jakarta/data/repository/Limit.java
@@ -45,17 +45,29 @@ package jakarta.data.repository;
  * <li>a <code>Limit</code> parameter is supplied in combination
  *     with the <code>First</code> keyword.</li>
  * </ul>
+ *
+ * @param maxResults maximum number of results for a query.
+ * @param startAt    starting position for query results (1 is the first result).
  */
-public final class Limit {
-    private static final long DEFAULT_START_AT = 1L;
-    private final int maxResults;
-    private final long startAt;
+public record Limit(int maxResults, long startAt) {
 
-    private Limit(int maxResults, long startAt) {
-        this.maxResults = maxResults;
-        this.startAt = startAt;
+    private static final long DEFAULT_START_AT = 1L;
+
+    /**
+     * Constructs a limit on the amount of query results.
+     *
+     * @param maxResults maximum number of results for a query.
+     * @param startAt    starting position for query results (1 is the first result).
+     */
+    public Limit {
+        if (startAt < 1)
+            throw new IllegalArgumentException("startAt: " + startAt);
+
+        if (maxResults < 1)
+            throw new IllegalArgumentException("maxResults: " + maxResults);
     }
 
+    // Override to provide method documentation:
     /**
      * <p>Maximum number of results that can be returned for a
      * single invocation of the repository method.</p>
@@ -66,9 +78,10 @@ public final class Limit {
         return maxResults;
     }
 
+    // Override to provide method documentation:
     /**
      * <p>Offset at which to start when returning query results.
-     * The first query result is position <code>1</code>.<p>
+     * The first query result is position <code>1</code>.</p>
      *
      * @return offset of the first result.
      */
@@ -86,9 +99,6 @@ public final class Limit {
      * @throws IllegalArgumentException if maxResults is less than 1.
      */
     public static Limit of(int maxResults) {
-        if (maxResults < 1)
-            throw new IllegalArgumentException("maxResults: " + maxResults);
-
         return new Limit(maxResults, DEFAULT_START_AT);
     }
 
@@ -109,9 +119,6 @@ public final class Limit {
      *         exceeds {@link Integer#MAX_VALUE}.
      */
     public static Limit range(long startAt, long endAt) {
-        if (startAt < 1)
-            throw new IllegalArgumentException("startAt: " + startAt);
-
         if (endAt < startAt)
             throw new IllegalArgumentException("startAt: " + startAt + ", endAt: " + endAt);
 

--- a/api/src/main/java/jakarta/data/repository/Limit.java
+++ b/api/src/main/java/jakarta/data/repository/Limit.java
@@ -54,7 +54,11 @@ public record Limit(int maxResults, long startAt) {
     private static final long DEFAULT_START_AT = 1L;
 
     /**
-     * Constructs a limit on the amount of query results.
+     * <p>Limits query results. For more descriptive code, use:</p>
+     * <ul>
+     * <li>{@link #of(int) Limit.of(maxResults)} to cap the number of results.</li>
+     * <li>{@link #range(long, long) Limit.range(startAt, endAt)} to limit to a range.</li>
+     * </ul>
      *
      * @param maxResults maximum number of results for a query.
      * @param startAt    starting position for query results (1 is the first result).

--- a/api/src/main/java/jakarta/data/repository/Sort.java
+++ b/api/src/main/java/jakarta/data/repository/Sort.java
@@ -65,7 +65,13 @@ import java.util.Objects;
 public record Sort(String property, boolean isAscending, boolean ignoreCase) {
 
     /**
-     * Defines sort criteria for an entity property.
+     * <p>Defines sort criteria for an entity property. For more descriptive code, use:</p>
+     * <ul>
+     * <li>{@link #asc(String) Sort.asc(propertyName)} for ascending sort on a property.</li>
+     * <li>{@link #ascIgnoreCase(String) Sort.ascIgnoreCase(propertyName)} for case insensitive ascending sort on a property.</li>
+     * <li>{@link #desc(String) Sort.desc(propertyName)} for descending sort on a property.</li>
+     * <li>{@link #descIgnoreCase(String) Sort.descIgnoreCase(propertyName)} for case insensitive descending sort on a property.</li>
+     * </ul>
      *
      * @param property    name of the property to order by.
      * @param isAscending whether ordering for this property is ascending (true) or descending (false).

--- a/api/src/main/java/jakarta/data/repository/Sort.java
+++ b/api/src/main/java/jakarta/data/repository/Sort.java
@@ -57,28 +57,35 @@ import java.util.Objects;
  * <li>the database is incapable of ordering with the requested
  *     sort criteria.</li>
  * </ul>
+ *
+ * @param property    name of the property to order by.
+ * @param isAscending whether ordering for this property is ascending (true) or descending (false).
+ * @param ignoreCase  whether or not to request case insensitive ordering from a database with case sensitive collation.
  */
-public final class Sort {
-
-    private final String property;
-
-    private final Direction direction;
-
-    private final boolean ignoreCase;
-
-    private Sort(String property, Direction direction, boolean ignoreCase) {
-        this.property = property;
-        this.direction = direction;
-        this.ignoreCase = ignoreCase;
-    }
+public record Sort(String property, boolean isAscending, boolean ignoreCase) {
 
     /**
+     * Defines sort criteria for an entity property.
+     *
+     * @param property    name of the property to order by.
+     * @param isAscending whether ordering for this property is ascending (true) or descending (false).
+     * @param ignoreCase  whether or not to request case insensitive ordering from a database with case sensitive collation.
+     */
+    public Sort {
+        Objects.requireNonNull(property, "property is required");
+    }
+
+    // Override to provide method documentation:
+    /**
+     * Name of the property to order by.
+     *
      * @return The property name to order by; will never be {@literal null}.
      */
     public String property() {
-        return this.property;
+        return property;
     }
 
+    // Override to provide method documentation:
     /**
      * <p>Indicates whether or not to request case insensitive ordering
      * from a database with case sensitive collation.
@@ -91,46 +98,23 @@ public final class Sort {
         return ignoreCase;
     }
 
+    // Override to provide method documentation:
     /**
+     * Indicates whether to sort the property in ascending order (true) or descending order (false).
+     *
      * @return Returns whether sorting for this property shall be ascending.
      */
     public boolean isAscending() {
-        return Direction.ASC.equals(direction);
+        return isAscending;
     }
 
     /**
+     * Indicates whether to sort the property in descending order (true) or ascending order (false).
+     *
      * @return Returns whether sorting for this property shall be descending.
      */
     public boolean isDescending() {
-        return Direction.DESC.equals(direction);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Sort sort = (Sort) o;
-        return Objects.equals(property, sort.property) && direction == sort.direction && ignoreCase == sort.ignoreCase;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(property, direction, ignoreCase);
-    }
-
-    @Override
-    public String toString() {
-        StringBuilder s = new StringBuilder(property.length() + 32)
-                .append("Sort{property='").append(property)
-                .append("', direction=").append(direction);
-        if (ignoreCase)
-            s.append(", ignore case");
-        s.append('}');
-        return s.toString();
+        return !isAscending;
     }
 
     /**
@@ -143,9 +127,8 @@ public final class Sort {
      * @throws NullPointerException when there is a null parameter
      */
     public static Sort of(String property, Direction direction, boolean ignoreCase) {
-        Objects.requireNonNull(property, "property is required");
         Objects.requireNonNull(direction, "direction is required");
-        return new Sort(property, direction, ignoreCase);
+        return new Sort(property, Direction.ASC.equals(direction), ignoreCase);
     }
 
     /**
@@ -157,7 +140,7 @@ public final class Sort {
      * @throws NullPointerException when the property is null
      */
     public static Sort asc(String property) {
-        return of(property, Direction.ASC, false);
+        return new Sort(property, true, false);
     }
 
     /**
@@ -169,7 +152,7 @@ public final class Sort {
      * @throws NullPointerException when the property is null.
      */
     public static Sort ascIgnoreCase(String property) {
-        return of(property, Direction.ASC, true);
+        return new Sort(property, true, true);
     }
 
     /**
@@ -181,7 +164,7 @@ public final class Sort {
      * @throws NullPointerException when the property is null
      */
     public static Sort desc(String property) {
-        return of(property, Direction.DESC, false);
+        return new Sort(property, false, false);
     }
 
     /**
@@ -193,6 +176,6 @@ public final class Sort {
      * @throws NullPointerException when the property is null.
      */
     public static Sort descIgnoreCase(String property) {
-        return of(property, Direction.DESC, true);
+        return new Sort(property, false, true);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -63,8 +63,8 @@
     </developers>
 
     <properties>
-        <maven.compiler.release>11</maven.compiler.release>
-        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.source>17</maven.compiler.source>
         <maven.compile.version>3.10.1</maven.compile.version>
         <maven.surefire.plugin.version>3.0.0-M5</maven.surefire.plugin.version>
         <maven-javadoc-plugin.vesion>3.4.1</maven-javadoc-plugin.vesion>

--- a/spec/README.adoc
+++ b/spec/README.adoc
@@ -6,7 +6,7 @@ This module contains AsciiDoc sources and configuration to generate Jakarta Data
 
 === Prerequisites:
 
-* JDK 11+
+* JDK 17+
 * Maven 3.0.5+
 
 === Execute the full build:

--- a/tck-dist/src/main/starter/ee-pom.xml
+++ b/tck-dist/src/main/starter/ee-pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- ~ Copyright (c) 2022 Contributors to the Eclipse Foundation
+ ~ Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
  ~
  ~ This program and the accompanying materials are made available under the
  ~ terms of the Eclipse Public License v. 2.0, which is available at
@@ -29,9 +29,9 @@
   <!-- General properties -->
   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-  <!-- TODO might need to update to 17 for Jakarta 11 -->
-  <maven.compiler.source>11</maven.compiler.source>
-  <maven.compiler.target>11</maven.compiler.target>
+  <!-- TODO might need to update to 21 for Jakarta 11 -->
+  <maven.compiler.source>17</maven.compiler.source>
+  <maven.compiler.target>17</maven.compiler.target>
 
   <!-- Dependency and Plugin Versions -->
   <jakarta.data.version>1.0.0-SNAPSHOT</jakarta.data.version>

--- a/tck-dist/src/main/starter/se-pom.xml
+++ b/tck-dist/src/main/starter/se-pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- ~ Copyright (c) 2022 Contributors to the Eclipse Foundation
+ ~ Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
  ~
  ~ This program and the accompanying materials are made available under the
  ~ terms of the Eclipse Public License v. 2.0, which is available at
@@ -29,9 +29,9 @@
   <!-- General properties -->
   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-  <!-- TODO might need to update to 17 for Jakarta 11 -->
-  <maven.compiler.source>11</maven.compiler.source>
-  <maven.compiler.target>11</maven.compiler.target>
+  <!-- TODO might need to update to 21 for Jakarta 11 -->
+  <maven.compiler.source>17</maven.compiler.source>
+  <maven.compiler.target>17</maven.compiler.target>
 
   <!-- Dependency and Plugin Versions -->
   <jakarta.data.version>1.0.0-SNAPSHOT</jakarta.data.version>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -143,8 +143,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven.compile.version}</version>
         <configuration>
-          <source>11</source>
-          <target>11</target>
+          <source>17</source>
+          <target>17</target>
         </configuration>
       </plugin>
       <plugin>
@@ -170,7 +170,7 @@
               <goal>jar</goal>
             </goals>
             <configuration>
-              <source>11</source>
+              <source>17</source>
               <quiet>true</quiet>
               <additionalJOption>-Xdoclint:none</additionalJOption>
             </configuration>
@@ -195,7 +195,7 @@
       </activation>
       <properties>
         <!--Default assumed JDK version, can be overriden via -Dmajor.jdk.version=X -->
-        <jdk.major.version>11</jdk.major.version>
+        <jdk.major.version>17</jdk.major.version>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
[Jakarta EE 11](https://eclipse-ee4j.github.io/jakartaee-platform/jakartaee11/JakartaEE11ReleasePlan) is looking to make Java 21 the minimum supported runtime level.  Java 21 isn't available yet, but a step toward getting there is to update from Java 11 to Java 17, the most recent long term support release of Java that is currently available.  This enables us to update some classes to utilize Java records as we previously voted.  At the time, those classes were updated to look like Java records in the way that methods were formed, but with compilation still at Java 11, they still included implementation of accessor methods/equals/toString/hashCode and so forth simulating what Java records would provide.

This can be looked at after Otavio gets beta 2 out.