### PR TITLE
Allow for specific entity testing

### DIFF
--- a/tck-dist/src/main/asciidoc/sections/06requirements.adoc
+++ b/tck-dist/src/main/asciidoc/sections/06requirements.adoc
@@ -5,6 +5,9 @@ Therefore, we make a separate, clear note here of the required number of tests n
 
 === Expected Output
 
-For the {TCKTestPlatform} runtime tests of the TCK: 
+For the {TCKTestPlatform} runtime tests of the TCK, 
+the following table shows the number of tests that should pass based on platform and entity: 
 
 include::generated/runtime-tests.adoc[]
+
+Note: Counts include signature test, but do not include disabled tests.

--- a/tck-dist/src/main/asciidoc/sections/07.1se-mode.adoc
+++ b/tck-dist/src/main/asciidoc/sections/07.1se-mode.adoc
@@ -35,6 +35,8 @@ To enable this extension include the following configuration to your surefire pl
 include::{starterLoc}/se-pom.xml[tags=displayName]
 ----
 
+include::07.aentity-modes.adoc[]
+
 ==== Standalone Logging
 
 The {APILongName} TCK uses `java.util.logging` for logging debug messages, and to output test results in some cases.

--- a/tck-dist/src/main/asciidoc/sections/07.2ee-mode.adoc
+++ b/tck-dist/src/main/asciidoc/sections/07.2ee-mode.adoc
@@ -59,6 +59,8 @@ To enable this extension include the following configuration to your surefire pl
 include::{starterLoc}/ee-pom.xml[tags=displayName]
 ----
 
+include::07.aentity-modes.adoc[]
+
 ==== Configure Arquillian
 
 Application Servers that implement the Arquillian SPI use a configuration file to define properties, such as hostname, port, username, password, etc.

--- a/tck-dist/src/main/asciidoc/sections/07.aentity-modes.adoc
+++ b/tck-dist/src/main/asciidoc/sections/07.aentity-modes.adoc
@@ -1,0 +1,8 @@
+===== Entity Modes
+
+There are situations where we need to test entities from a specific provider, 
+and other times where the test is generalized to work for any provider.
+
+To accomplish this tests are tagged with either the `persistence` group, `nosql` group, or no entity group.
+
+When configuring Junit5 exclude the group name for the Entity type your provider does not support.

--- a/tck-dist/src/main/java/ee/jakarta/tck/data/metadata/CollectMetaData.java
+++ b/tck-dist/src/main/java/ee/jakarta/tck/data/metadata/CollectMetaData.java
@@ -272,10 +272,10 @@ public class CollectMetaData {
         runtimeTestsSection.appendNewLine("|" + full.stream().filter(Predicate.not(TestMetaData::isNoSQL)).count());
         
         runtimeTestsSection.appendNewLine("|nosql");
-        runtimeTestsSection.appendNewLine("|" + standalone.stream().filter(Predicate.not(TestMetaData::isPersistance)).count());
-        runtimeTestsSection.appendNewLine("|" + core.stream().filter(Predicate.not(TestMetaData::isPersistance)).count());
-        runtimeTestsSection.appendNewLine("|" + web.stream().filter(Predicate.not(TestMetaData::isPersistance)).count());
-        runtimeTestsSection.appendNewLine("|" + full.stream().filter(Predicate.not(TestMetaData::isPersistance)).count());
+        runtimeTestsSection.appendNewLine("|" + standalone.stream().filter(Predicate.not(TestMetaData::isPersistence)).count());
+        runtimeTestsSection.appendNewLine("|" + core.stream().filter(Predicate.not(TestMetaData::isPersistence)).count());
+        runtimeTestsSection.appendNewLine("|" + web.stream().filter(Predicate.not(TestMetaData::isPersistence)).count());
+        runtimeTestsSection.appendNewLine("|" + full.stream().filter(Predicate.not(TestMetaData::isPersistence)).count());
         
         runtimeTestsSection.appendNewLine("|BOTH");
         runtimeTestsSection.appendNewLine("|" + standalone.size());
@@ -440,7 +440,7 @@ public class CollectMetaData {
             return tags.contains("full");
         }
         
-        boolean isPersistance() {
+        boolean isPersistence() {
             return tags.contains("persistence");
         }
         

--- a/tck-dist/src/main/starter/ee-pom.xml
+++ b/tck-dist/src/main/starter/ee-pom.xml
@@ -201,9 +201,8 @@
       <tck_port>[TODO]</tck_port>
      </systemPropertyVariables>
      <!-- end::arquillian[] -->
-     <!-- Tags to include i.e. standalone/core/web/full -->
+     <!-- Supported tags - Profiles:[core|web|full] Entities:[persistence|nosql] Groups:[signature] -->
      <groups>[TODO]</groups>
-     <!-- Tags to ignore i.e. signature -->
      <excludedGroups>[TODO]</excludedGroups>
      <!-- If running back-to-back tests at different levels use this to distinguish 
       the results -->

--- a/tck-dist/src/main/starter/se-pom.xml
+++ b/tck-dist/src/main/starter/se-pom.xml
@@ -163,8 +163,8 @@
       <java.util.logging.config.file>${logging.config}</java.util.logging.config.file>
      </systemPropertyVariables>
      <!-- end::logging[] -->
+     <!-- Supported tags - Entities:[persistence|nosql] Groups:[signature] -->
      <groups>standalone</groups>
-     <!-- Tags to ignore i.e. signature -->
      <excludedGroups>[TODO]</excludedGroups>
      <!-- If running back-to-back tests at different levels use this to distinguish 
       the results -->

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- ~ Copyright (c) 2022 Contributors to the Eclipse Foundation
+ ~ Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  ~
  ~ This program and the accompanying materials are made available under the
  ~ terms of the Eclipse Public License v. 2.0, which is available at
@@ -48,6 +48,14 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
     </dependency>
+    
+    <!-- Data API -->
+    <dependency>
+    	<groupId>jakarta.data</groupId>
+    	<artifactId>jakarta-data-api</artifactId>
+    	<version>${jakarta.data.version}</version>
+    	<scope>provided</scope>
+    </dependency>
 
     <!-- EE Server Integration framework -->
     <dependency>
@@ -80,6 +88,21 @@
       <groupId>jakarta.enterprise</groupId>
       <artifactId>jakarta.enterprise.cdi-api</artifactId>
       <version>${jakarta.enterprise.cdi.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    
+    <!-- Provided Entity APIs -->
+    <dependency>
+      <groupId>jakarta.nosql</groupId>
+      <artifactId>nosql-core</artifactId>
+      <version>1.0.0-b6</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>jakarta.persistence</groupId>
+      <artifactId>jakarta.persistence-api</artifactId>
+      <version>3.1.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/tck/src/main/java/ee/jakarta/tck/data/core/example/CDIExampleTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/core/example/CDIExampleTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -42,14 +42,14 @@ public class CDIExampleTests {
     @Inject
     ExampleService service;
     
-    @Assertion(id = "EXAMPLE", strategy = "Deployes a CDI bean to application server, and injects service to be tested")
+    @Assertion(id = "26", strategy = "Deployes a CDI bean to application server, and injects service to be tested")
     public void serviceAlwaysReturnsTrue() {
         assertTrue(service.getMessage(), "Message should have returned true");
     }
     
     @Disabled(value = "Challenge #1")
-    @Assertion(id = "EXAMPLE", strategy = "Uses the disabled annotation to ensure test does not get executed")
+    @Assertion(id = "26", strategy = "Uses the disabled annotation to ensure test does not get executed")
     public void disabledTest() {
-        
+        assertTrue(false);
     }
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/core/nosql/example/Catalog.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/core/nosql/example/Catalog.java
@@ -21,7 +21,7 @@ import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Repository;
 
 @Repository
-public interface Order extends DataRepository<Product, Long> {
+public interface Catalog extends DataRepository<Product, Long> {
     
     void save(Product product);
     void deleteById(Long id);

--- a/tck/src/main/java/ee/jakarta/tck/data/core/nosql/example/NoSQLEntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/core/nosql/example/NoSQLEntityTests.java
@@ -40,11 +40,11 @@ public class NoSQLEntityTests {
     
     @Deployment
     public static JavaArchive createDeployment() {
-        return ShrinkWrap.create(JavaArchive.class).addClasses(Product.class, Order.class);
+        return ShrinkWrap.create(JavaArchive.class).addClasses(Product.class, Catalog.class);
     }
     
     @Inject
-    Order order;
+    Catalog catalog;
     
     @Assertion(id = "119", strategy = "Ensure that this test is only run when provider supports nosql entities")
     public void testNotRunOnPersistence() {
@@ -55,13 +55,13 @@ public class NoSQLEntityTests {
         products.add(Product.of(04L, "calculator", 15.00, 20.00));
         products.add(Product.of(05L, "ruler", 2.00, 2.15));
         
-        products.stream().forEach(product -> order.save(product));
+        products.stream().forEach(product -> catalog.save(product));
         
-        int countExpensive = order.countByPriceGreaterThanEqual(3.00);
+        int countExpensive = catalog.countByPriceGreaterThanEqual(2.99);
         assertEquals(2, countExpensive, "Expected two products to be more than 3.00");
         
         Assertions.assertThrows(MappingException.class, () -> {
-            order.countBySurgePriceGreaterThanEqual(3.00);
+            catalog.countBySurgePriceGreaterThanEqual(2.99);
         });
         
     }

--- a/tck/src/main/java/ee/jakarta/tck/data/core/nosql/example/NoSQLEntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/core/nosql/example/NoSQLEntityTests.java
@@ -47,7 +47,7 @@ public class NoSQLEntityTests {
     Order order;
     
     @Assertion(id = "119", strategy = "Ensure that this test is only run when provider supports nosql entities")
-    public void testNotRunOnPersistance() {
+    public void testNotRunOnPersistence() {
         List<Product> products = new ArrayList<>();
         products.add(Product.of(01L, "pen", 2.50, 3.50));
         products.add(Product.of(02L, "pencil", 1.25, 2.00));

--- a/tck/src/main/java/ee/jakarta/tck/data/core/nosql/example/NoSQLEntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/core/nosql/example/NoSQLEntityTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.core.nosql.example;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+
+import ee.jakarta.tck.data.framework.junit.anno.Assertion;
+import ee.jakarta.tck.data.framework.junit.anno.Core;
+import jakarta.data.exceptions.MappingException;
+import jakarta.inject.Inject;
+
+/**
+ * Ensure this test is only run when a persistence provider is being tested. 
+ */
+@Core
+@Tag("nosql")
+public class NoSQLEntityTests {
+    
+    @Deployment
+    public static JavaArchive createDeployment() {
+        return ShrinkWrap.create(JavaArchive.class).addClasses(Product.class, Order.class);
+    }
+    
+    @Inject
+    Order order;
+    
+    @Assertion(id = "119", strategy = "Ensure that this test is only run when provider supports nosql entities")
+    public void testNotRunOnPersistance() {
+        List<Product> products = new ArrayList<>();
+        products.add(Product.of(01L, "pen", 2.50, 3.50));
+        products.add(Product.of(02L, "pencil", 1.25, 2.00));
+        products.add(Product.of(03L, "marker", 3.00, 4.00));
+        products.add(Product.of(04L, "calculator", 15.00, 20.00));
+        products.add(Product.of(05L, "ruler", 2.00, 2.15));
+        
+        products.stream().forEach(product -> order.save(product));
+        
+        int countExpensive = order.countByPriceGreaterThanEqual(3.00);
+        assertEquals(2, countExpensive, "Expected two products to be more than 3.00");
+        
+        Assertions.assertThrows(MappingException.class, () -> {
+            order.countBySurgePriceGreaterThanEqual(3.00);
+        });
+        
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/core/nosql/example/Order.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/core/nosql/example/Order.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.core.nosql.example;
+
+import java.util.List;
+
+import jakarta.data.repository.DataRepository;
+import jakarta.data.repository.Repository;
+
+@Repository
+public interface Order extends DataRepository<Product, Long> {
+    
+    void save(Product product);
+    void deleteById(Long id);
+    
+    int countByPriceGreaterThanEqual(Double price);
+    int countBySurgePriceGreaterThanEqual(Double price);
+    
+    List<Product> findByNameLike(String name); 
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/core/nosql/example/Product.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/core/nosql/example/Product.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.core.nosql.example;
+
+import jakarta.nosql.Column;
+import jakarta.nosql.Entity;
+import jakarta.nosql.Id;
+
+@Entity
+public class Product {
+
+    @Id
+    private Long id;
+    
+    @Column
+    private String name;
+    
+    @Column
+    private Double price;
+    
+    private Double surgePrice;
+    
+    public static Product of(Long id, String name, Double price, Double surgePrice) {
+        return new Product(id, name, price, surgePrice);
+    }
+
+    public Product(Long id, String name, Double price, Double surgePrice) {
+        this.id = id;
+        this.name = name;
+        this.price = price;
+        this.surgePrice = surgePrice;
+    }
+
+    public Product() {
+        //do nothing
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Double getPrice() {
+        return price;
+    }
+
+    public void setPrice(Double price) {
+        this.price = price;
+    }
+
+    public Double getSurgePrice() {
+        return surgePrice;
+    }
+
+    public void setSurgePrice(Double surgePrice) {
+        this.surgePrice = surgePrice;
+    }
+    
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/core/persistence/example/Catalog.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/core/persistence/example/Catalog.java
@@ -21,7 +21,7 @@ import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Repository;
 
 @Repository
-public interface Order extends DataRepository<Product, Long> {
+public interface Catalog extends DataRepository<Product, Long> {
     
     void save(Product product);
     void deleteById(Long id);

--- a/tck/src/main/java/ee/jakarta/tck/data/core/persistence/example/Order.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/core/persistence/example/Order.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.core.persistence.example;
+
+import java.util.List;
+
+import jakarta.data.repository.DataRepository;
+import jakarta.data.repository.Repository;
+
+@Repository
+public interface Order extends DataRepository<Product, Long> {
+    
+    void save(Product product);
+    void deleteById(Long id);
+    
+    int countByPriceGreaterThanEqual(Double price);
+    int countBySurgePriceGreaterThanEqual(Double price);
+    
+    List<Product> findByNameLike(String name); 
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/core/persistence/example/PersistenceEntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/core/persistence/example/PersistenceEntityTests.java
@@ -40,11 +40,11 @@ public class PersistenceEntityTests {
     
     @Deployment
     public static JavaArchive createDeployment() {
-        return ShrinkWrap.create(JavaArchive.class).addClasses(Product.class, Order.class);
+        return ShrinkWrap.create(JavaArchive.class).addClasses(Product.class, Catalog.class);
     }
     
     @Inject
-    Order order;
+    Catalog catalog;
     
     @Assertion(id = "119", strategy = "Ensure that this test is only run when provider supports persistance entities")
     public void testNotRunOnNOSQL() {
@@ -55,13 +55,13 @@ public class PersistenceEntityTests {
         products.add(Product.of(04L, "calculator", 15.00, 20.00));
         products.add(Product.of(05L, "ruler", 2.00, 2.15));
         
-        products.stream().forEach(product -> order.save(product));
+        products.stream().forEach(product -> catalog.save(product));
         
-        int countExpensive = order.countByPriceGreaterThanEqual(3.00);
+        int countExpensive = catalog.countByPriceGreaterThanEqual(2.99);
         assertEquals(2, countExpensive, "Expected two products to be more than 3.00");
         
         Assertions.assertThrows(MappingException.class, () -> {
-            order.countBySurgePriceGreaterThanEqual(3.00);
+            catalog.countBySurgePriceGreaterThanEqual(2.99);
         });
         
     }

--- a/tck/src/main/java/ee/jakarta/tck/data/core/persistence/example/PersistenceEntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/core/persistence/example/PersistenceEntityTests.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.core.persistence.example;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+
+import ee.jakarta.tck.data.framework.junit.anno.Assertion;
+import ee.jakarta.tck.data.framework.junit.anno.Core;
+import jakarta.data.exceptions.MappingException;
+import jakarta.inject.Inject;
+
+/**
+ * Ensure this test is only run when a persistence provider is being tested. 
+ */
+@Core
+@Tag("persistence")
+public class PersistenceEntityTests {
+    
+    @Deployment
+    public static JavaArchive createDeployment() {
+        return ShrinkWrap.create(JavaArchive.class).addClasses(Product.class, Order.class);
+    }
+    
+    @Inject
+    Order order;
+    
+    @Assertion(id = "119", strategy = "Ensure that this test is only run when provider supports persistance entities")
+    public void testNotRunOnNOSQL() {
+        List<Product> products = new ArrayList<>();
+        products.add(Product.of(01L, "pen", 2.50, 3.50));
+        products.add(Product.of(02L, "pencil", 1.25, 2.00));
+        products.add(Product.of(03L, "marker", 3.00, 4.00));
+        products.add(Product.of(04L, "calculator", 15.00, 20.00));
+        products.add(Product.of(05L, "ruler", 2.00, 2.15));
+        
+        products.stream().forEach(product -> order.save(product));
+        
+        int countExpensive = order.countByPriceGreaterThanEqual(3.00);
+        assertEquals(2, countExpensive, "Expected two products to be more than 3.00");
+        
+        Assertions.assertThrows(MappingException.class, () -> {
+            order.countBySurgePriceGreaterThanEqual(3.00);
+        });
+        
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/core/persistence/example/Product.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/core/persistence/example/Product.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.core.persistence.example;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Transient;
+
+@Entity
+public class Product {
+
+    @Id
+    private Long id;
+    
+    private String name;
+    private Double price;
+    
+    @Transient
+    private Double surgePrice;
+    
+    public static Product of(Long id, String name, Double price, Double surgePrice) {
+        return new Product(id, name, price, surgePrice);
+    }
+
+    public Product(Long id, String name, Double price, Double surgePrice) {
+        this.id = id;
+        this.name = name;
+        this.price = price;
+        this.surgePrice = surgePrice;
+    }
+
+    public Product() {
+        //do nothing
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Double getPrice() {
+        return price;
+    }
+
+    public void setPrice(Double price) {
+        this.price = price;
+    }
+
+    public Double getSurgePrice() {
+        return surgePrice;
+    }
+
+    public void setSurgePrice(Double surgePrice) {
+        this.surgePrice = surgePrice;
+    }
+    
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/junit/anno/Assertion.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/junit/anno/Assertion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,7 +31,13 @@ import org.junit.jupiter.api.Test;
 @Retention(RetentionPolicy.RUNTIME)
 @Test
 public @interface Assertion {
+    /**
+     * The GitHub issue/PR number that lead to the test being created
+     */
     String id();
 
+    /**
+     * A longer description of the assertion being made to keep method names concise
+     */
     String strategy() default "";
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/junit/extensions/AssertionExtension.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/junit/extensions/AssertionExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -41,8 +41,9 @@ public class AssertionExtension implements TestWatcher {
         Assertion instance = testMethod.getAnnotation(Assertion.class);
         if (instance != null) {
             log.warning(testMethod.getName() + " failed " + nl
-                    + " @Assertion.id:" + instance.id() + nl
-                    + " @Assertion.strategy: " + instance.strategy());
+                    + " @Assertion.id:#" + instance.id() + nl
+                    + " @Assertion.strategy: " + instance.strategy()
+                    + " Throwable.cause: " + cause.getLocalizedMessage());
         }
     }
 
@@ -52,8 +53,9 @@ public class AssertionExtension implements TestWatcher {
         Assertion instance = testMethod.getAnnotation(Assertion.class);
         if (instance != null) {
             log.warning(testMethod.getName() + " was aborted " + nl
-                    + " @Assertion.id:" + instance.id() + nl
-                    + " @Assertion.strategy: " + instance.strategy());
+                    + " @Assertion.id:#" + instance.id() + nl
+                    + " @Assertion.strategy: " + instance.strategy()
+                    + " Throwable.cause: " + cause.getLocalizedMessage());
         }
     }
 
@@ -63,9 +65,9 @@ public class AssertionExtension implements TestWatcher {
         Assertion instance = testMethod.getAnnotation(Assertion.class);
         if (instance != null) {
             log.warning(testMethod.getName() + " is disabled" + nl
-                    + " @Assertion.id:" + instance.id() + nl
+                    + " @Assertion.id:#" + instance.id() + nl
                     + " @Assertion.strategy: " + instance.strategy() + nl
-                    + " Reason:" + reason.get());
+                    + " @Disabled.reason:" + reason.get());
         }
     }
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/example/StandaloneExampleTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/example/StandaloneExampleTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -36,7 +36,7 @@ public class StandaloneExampleTests {
                 .addClass(StandaloneExampleTests.class);
     }  
     
-    @Assertion(id = "EXAMPLE", strategy = "Test runs on client JVM when running in standalone mode, otherwise gets deployed to server and run.")
+    @Assertion(id = "26", strategy = "Test runs on client JVM when running in standalone mode, otherwise gets deployed to server and run.")
     public void testStandaloneFunction() {
         assertEquals(1, 1, "One did not equal one.");
     }

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/signature/SignatureTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/signature/SignatureTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -45,7 +45,7 @@ public class SignatureTests {
     @Inject
     SignatureTestBean testBean;
 
-    @Assertion(id = "SIGNATURES", strategy = "Uses the sigtest-maven-plugin to execute signature tests on a Standalone JVM or on a Jakarta EE Server")
+    @Assertion(id = "26", strategy = "Uses the sigtest-maven-plugin to execute signature tests on a Standalone JVM or on a Jakarta EE Server")
     public void testSignaturesStandalone() throws Exception {
 
         try {

--- a/tck/src/main/java/ee/jakarta/tck/data/web/example/ComplexServletTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/web/example/ComplexServletTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -44,7 +44,7 @@ public class ComplexServletTests extends TestClient {
     @ArquillianResource
     URL baseURL;
     
-    @Assertion(id = "EXAMPLE", strategy = "Run server side tests that will succeed and fail and assert the results.")
+    @Assertion(id = "26", strategy = "Run server side tests that will succeed and fail and assert the results.")
     public void testSuccessAndFailure(TestInfo testInfo) {
         URL requestURL = URLBuilder.fromURL(baseURL)
                 .withPath(ComplexServlet.URL_PATTERN)
@@ -63,7 +63,7 @@ public class ComplexServletTests extends TestClient {
         });
     }
     
-    @Assertion(id = "EXAMPLE", strategy = "Run server side test with a method name that matches the client side test.")
+    @Assertion(id = "26", strategy = "Run server side test with a method name that matches the client side test.")
     public void testMatchServletSideMethodName(TestInfo testInfo) {
         URL requestURL = URLBuilder.fromURL(baseURL)
                 .withPath(ComplexServlet.URL_PATTERN)
@@ -73,7 +73,7 @@ public class ComplexServletTests extends TestClient {
         super.runTest(requestURL);
     }
     
-    @Assertion(id = "EXAMPLE", strategy = "Run server side test that append a unique string to the response body and make sure it is returned.")
+    @Assertion(id = "26", strategy = "Run server side test that append a unique string to the response body and make sure it is returned.")
     public void testServletSideCustomResponse(TestInfo testInfo) {
         URL requestURL = URLBuilder.fromURL(baseURL)
                 .withPath(ComplexServlet.URL_PATTERN)

--- a/tck/src/main/java/ee/jakarta/tck/data/web/example/SimpleServletExampleTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/web/example/SimpleServletExampleTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -33,7 +33,7 @@ public class SimpleServletExampleTests {
                 .addClass(SimpleServletExampleTests.class);
     } 
     
-    @Assertion(id = "EXAMPLE", strategy = "Run a test directly on a servlet and make sure it works.")
+    @Assertion(id = "26", strategy = "Run a test directly on a servlet and make sure it works.")
     public void testRunOnServletUsingArquillian() {
         assertTrue(true, "Do something you could only do in a Web Container here!");
     }


### PR DESCRIPTION
Related to: #119 

Introduce a method to test the Persistence Entity and NoSQL Entity separately. 
This will be for cases where we want to test the specific functionality of either Entity that does not apply to the other. 

⚠️: The example tests I've written are not the intended use case (to duplicate code) they are just being used to have some sample tests available to reference once we start writing more complex tests. 