### PR TITLE
Documentation of Standalone and Jakarta EE modes for using Jakarta Data providers

### DIFF
--- a/api/src/main/java/jakarta/data/spi/provider/DataProvider.java
+++ b/api/src/main/java/jakarta/data/spi/provider/DataProvider.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data.spi.provider;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+import jakarta.data.exceptions.MappingException;
+
+/**
+ * <p>Jakarta Data providers can make themselves discoverable by
+ * Jakarta EE products via the Jakarta Data Provider SPI. This enables
+ * Jakarta EE products with CDI support to provide CDI dependency injection
+ * and other integration with CDI on behalf of Jakarta Data providers.
+ * Jakarta Data providers with their own custom dependency injection
+ * are not required to implement or provide the Jakarta Data Provider SPI.</p>
+ *
+ * <p>Jakarta Data providers that implement the Jakarta Data Provider SPI
+ * make an implementation of this interface available to the
+ * {@link java.util.ServiceLoader ServiceLoader} as follows.</p>
+ *
+ * <p>The {@code DataProvider} implementation and related classes are packaged
+ * within the Jakarta Data provider's JAR file, also including a file with the
+ * following name and location,</p>
+ *
+ * <pre>META-INF/services/jakarta.data.spi.provider.DataProvider</pre>
+ * 
+ * <p>The content of the above file must be one or more lines, each specifying
+ * the fully qualified name of a {@code DataProvider} implementation that is
+ * provided within the JAR file.</p>
+ *
+ * <p>Jakarta EE applications do not use the Jakarta Data Provider SPI directly.
+ * Jakarta EE products are not required to make this class available to
+ * applications.</p>
+ */
+public interface DataProvider {
+    /**
+     * <p>Provides implementation of the specified repository interface.</p>
+     *
+     * @param <R>                 interface class that defines the data repository.
+     * @param repositoryInterface the repository interface.
+     * @param entityClass         type of entity that the repository persists.
+     * @return repository instance. Never {@code null}.
+     * @throws MappingException for inconsistencies between the repository or
+     *         entity class and the database.
+     */
+    <R> R getRepository(Class<R> repositoryInterface, Class<?> entityClass) throws MappingException;
+
+
+    /**
+     * <p>Returns the name of the Jakarta Data provider. This name can be used
+     * in configuration when referring to this provider and when logging or
+     * displaying messages to the user.</p>
+     *
+     * @return name that identifies the Jakarta Data provider. Never {@code null}.
+     */
+    String name();
+
+    /**
+     * <p>Invoked by the Jakarta EE product to notify the the Jakarta Data
+     * provider that the CDI managed bean for a previously-obtained repository
+     * instance has reached the end of its life cycle. If multiple invocations of
+     * {@link #getRepository(Class, Class) getRepository} return the same
+     * repository instance, multiple dispose notifications will be sent for the
+     * instance, each corresponding to the disposal of a different CDI managed bean.</p>
+     *
+     * @param repository instance that was previously returned by
+     *        {@link #getRepository(Class, Class) getRepository}.
+     */
+    void repositoryBeanDisposed(Object repository);
+
+    /**
+     * <p>Returns the type of entity annotations that are supported by this provider.
+     * For example, <code>jakarta.persistence.Entity</code> or <code>jakarta.nosql.Entity</code>.
+     * This tells the Jakarta EE product that it can request repositories for entities
+     * of this type from this provider.</p>
+     *
+     * @return type of entity annotations that are supported by this provider.
+     */
+    Set<Class<? extends Annotation>> supportedEntityAnnotations();
+}

--- a/api/src/main/java/jakarta/data/spi/provider/DataProvider.java
+++ b/api/src/main/java/jakarta/data/spi/provider/DataProvider.java
@@ -52,14 +52,13 @@ public interface DataProvider {
     /**
      * <p>Provides an instance that implements the specified repository interface.</p>
      *
-     * @param <R>                 interface class that defines the data repository.
-     * @param repositoryInterface the repository interface.
-     * @param entityClass         type of entity that the repository persists.
+     * @param <R>        interface class that defines the data repository.
+     * @param repository the repository interface.
      * @return repository instance. Never {@code null}.
      * @throws MappingException for inconsistencies between the repository or
      *         entity class and the database.
      */
-<R> R getRepository(Class<R> repository) throws MappingException;
+    <R> R getRepository(Class<R> repository) throws MappingException;
 
 
     /**
@@ -75,12 +74,12 @@ public interface DataProvider {
      * <p>Invoked by the Jakarta EE product to notify the Jakarta Data
      * provider that the CDI managed bean for a previously-obtained repository
      * instance has reached the end of its life cycle. If multiple invocations of
-     * {@link #getRepository(Class, Class) getRepository} return the same
+     * {@link #getRepository(Class) getRepository} return the same
      * repository instance, multiple dispose notifications will be sent for the
      * instance, each corresponding to the disposal of a different CDI managed bean.</p>
      *
      * @param repository instance that was previously returned by
-     *        {@link #getRepository(Class, Class) getRepository}.
+     *        {@link #getRepository(Class) getRepository}.
      */
     void repositoryBeanDisposed(Object repository);
 

--- a/api/src/main/java/jakarta/data/spi/provider/DataProvider.java
+++ b/api/src/main/java/jakarta/data/spi/provider/DataProvider.java
@@ -23,13 +23,10 @@ import java.util.Set;
 import jakarta.data.exceptions.MappingException;
 
 /**
- * <p>Jakarta Data providers can make themselves discoverable by
- * Jakarta EE products via the Jakarta Data Provider SPI.
- * Jakarta EE products with CDI support are thus able to automatically provide
- * a CDI extension on behalf of the discovered Jakarta Data providers
- * without those Jakarta Data providers themselves needing to depend on CDI.
- * Jakarta Data providers with their own custom dependency injection
- * are not required to implement or provide the Jakarta Data Provider SPI.</p>
+ * <p>In a Jakarta EE profile, Jakarta Data providers can use the
+ * Jakarta Data Provider SPI to register to provide repository instances
+ * to the Jakarta EE product's CDI extension that handles
+ * {@link jakarta.data.repository.Repository Repository} injection points.</p>
  *
  * <p>Jakarta Data providers that implement the Jakarta Data Provider SPI
  * make an implementation of this interface available to the

--- a/api/src/main/java/jakarta/data/spi/provider/DataProvider.java
+++ b/api/src/main/java/jakarta/data/spi/provider/DataProvider.java
@@ -24,9 +24,10 @@ import jakarta.data.exceptions.MappingException;
 
 /**
  * <p>Jakarta Data providers can make themselves discoverable by
- * Jakarta EE products via the Jakarta Data Provider SPI. This enables
- * Jakarta EE products with CDI support to provide CDI dependency injection
- * and other integration with CDI on behalf of Jakarta Data providers.
+ * Jakarta EE products via the Jakarta Data Provider SPI.
+ * Jakarta EE products with CDI support are thus able to automatically provide
+ * a CDI extension on behalf of the discovered Jakarta Data providers
+ * without those Jakarta Data providers themselves needing to depend on CDI.
  * Jakarta Data providers with their own custom dependency injection
  * are not required to implement or provide the Jakarta Data Provider SPI.</p>
  *

--- a/api/src/main/java/jakarta/data/spi/provider/DataProvider.java
+++ b/api/src/main/java/jakarta/data/spi/provider/DataProvider.java
@@ -59,7 +59,7 @@ public interface DataProvider {
      * @throws MappingException for inconsistencies between the repository or
      *         entity class and the database.
      */
-    <R> R getRepository(Class<R> repositoryInterface, Class<?> entityClass) throws MappingException;
+<R> R getRepository(Class<R> repository) throws MappingException;
 
 
     /**

--- a/api/src/main/java/jakarta/data/spi/provider/DataProvider.java
+++ b/api/src/main/java/jakarta/data/spi/provider/DataProvider.java
@@ -44,7 +44,7 @@ import jakarta.data.exceptions.MappingException;
  * the fully qualified name of a {@code DataProvider} implementation that is
  * provided within the JAR file.</p>
  *
- * <p>Jakarta EE applications do not use the Jakarta Data Provider SPI directly.
+ * <p>Jakarta EE applications do not use the Jakarta Data Provider SPI.
  * Jakarta EE products are not required to make this class available to
  * applications.</p>
  */

--- a/api/src/main/java/jakarta/data/spi/provider/DataProvider.java
+++ b/api/src/main/java/jakarta/data/spi/provider/DataProvider.java
@@ -50,7 +50,7 @@ import jakarta.data.exceptions.MappingException;
  */
 public interface DataProvider {
     /**
-     * <p>Provides implementation of the specified repository interface.</p>
+     * <p>Provides an instance that implements the specified repository interface.</p>
      *
      * @param <R>                 interface class that defines the data repository.
      * @param repositoryInterface the repository interface.

--- a/api/src/main/java/jakarta/data/spi/provider/DataProvider.java
+++ b/api/src/main/java/jakarta/data/spi/provider/DataProvider.java
@@ -72,7 +72,7 @@ public interface DataProvider {
     String name();
 
     /**
-     * <p>Invoked by the Jakarta EE product to notify the the Jakarta Data
+     * <p>Invoked by the Jakarta EE product to notify the Jakarta Data
      * provider that the CDI managed bean for a previously-obtained repository
      * instance has reached the end of its life cycle. If multiple invocations of
      * {@link #getRepository(Class, Class) getRepository} return the same

--- a/api/src/main/java/jakarta/data/spi/provider/package-info.java
+++ b/api/src/main/java/jakarta/data/spi/provider/package-info.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * <p>This package defines the Service Provider Interface (SPI) by which
+ * Jakarta Data providers can make themselves discoverable by Jakarta EE products
+ * for CDI dependency injection.</p>
+ *
+ * <p>Jakarta Data providers that provide their own custom dependency injection
+ * or other vendor-specific mechanisms can ignore this SPI and do not need
+ * to provide or implement it.</p>
+ *
+ * <p>Jakarta EE applications do not use the Jakarta Data Provider SPI directly.
+ * Jakarta EE products are not required to make this package available to
+ * applications.</p>
+ */
+package jakarta.data.spi.provider;

--- a/api/src/main/java/jakarta/data/spi/provider/package-info.java
+++ b/api/src/main/java/jakarta/data/spi/provider/package-info.java
@@ -25,7 +25,7 @@
  * or other vendor-specific mechanisms can ignore this SPI and do not need
  * to provide or implement it.</p>
  *
- * <p>Jakarta EE applications do not use the Jakarta Data Provider SPI directly.
+ * <p>Jakarta EE applications do not use the Jakarta Data Provider SPI.
  * Jakarta EE products are not required to make this package available to
  * applications.</p>
  */

--- a/api/src/main/java/jakarta/data/spi/provider/package-info.java
+++ b/api/src/main/java/jakarta/data/spi/provider/package-info.java
@@ -18,8 +18,10 @@
 
 /**
  * <p>This package defines the Service Provider Interface (SPI) by which
- * Jakarta Data providers can make themselves discoverable by Jakarta EE products
- * for CDI dependency injection.</p>
+ * Jakarta Data providers can register to provide repository instances
+ * to the Jakarta EE product's CDI extension that handles
+ * {@link jakarta.data.repository.Repository Repository} injection points
+ * when running in a Jakarta EE profile.</p>
  *
  * <p>Jakarta Data providers that provide their own custom dependency injection
  * or other vendor-specific mechanisms can ignore this SPI and do not need

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,5 +18,6 @@
 module jakarta.data.api {
     exports jakarta.data.repository;
     exports jakarta.data.exceptions;
+    exports jakarta.data.spi.provider;
     opens jakarta.data.repository;
 }

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -464,3 +464,28 @@ for (Pageable p = Pageable.ofSize(25).sortBy(Sort.desc("yearBorn"), Sort.asc("na
 }
 ----
 
+== Jakarta Data Providers
+
+=== Modes
+
+Jakarta Data Providers implement the Jakarta Data API and specification requirements for one or more of the following modes.
+
+==== Standalone Mode
+
+Standalone mode means that the Jakarta Data provider is able to run on its own outside of a Jakarta EE platform or profile. Standalone Jakarta Data providers can choose whether or not to provide their own custom dependency injection leveraging `@Inject`, whether or not to provide extensions to tie into dependency injection via Jakarta Contexts and Dependency Injection (CDI) SE, whether or not to tie into the Jakarta Data Provider SPI, and whether or not to define other vendor specific ways of accessing Jakarta Data repositories. The Jakarta Data TCK includes a Standalone mode for validating Jakarta Data Providers that requires at least one of the first three of the aforementioned approaches.
+
+==== Jakarta EE Mode
+
+Jakarta EE mode means that the Jakarta Data provider is able to run within a Jakarta EE product, which is a product that provides a Jakarta EE profile or the full Jakarta EE platform, or a product that is comprised of a subset of Jakarta EE specifications. If the Jakarta EE product is running in a mode that provides Jakarta Contexts and Dependency Injection (CDI), then the Jakarta EE product coordinates CDI dependency injection for all Jakarta Data providers that it discovers via the Jakarta Data Provider SPI. Jakarta Data providers do not need to support CDI. Jakarta Data providers can continue using their own custom dependency injection models without CDI present. The Jakarta Data TCK includes a Jakarta EE mode for validating Jakarta Data Providers that leverages the `@Inject` annotation that is common to both CDI and custom dependency injection models.
+
+==== Both Standalone and Jakarta EE Mode
+
+A Jakarta Data provider can choose to support running in both Standalone and Jakarta EE Modes. In such cases, the Jakarta Data provider can certify with the Jakarta Data TCK in Standalone mode as a compatible Jakarta Data provider, and a Jakarta EE product that supports Jakarta Data will use the Jakarta Data provider to certify with the Jakarta Data TCK in Jakarta EE mode as a compatible Jakarta EE product.
+
+=== Multiple Jakarta Data Providers
+
+Multiple Jakarta Data Providers can coexist, allowing customers to write applications where some repositories are backed by relational databases and others by NoSQL databases, or other combinations. A Jakarta EE product that is aware of multiple Jakarta Data providers directs requests to each based on the type of entity annotations that each supports.
+
+==== Discovery
+
+Jakarta Data providers can make themselves available for discovery by Jakarta EE products via the Jakarta Data Provider SPI. This enables Jakarta EE products with CDI support to provide CDI dependency injection and other integration with CDI for Jakarta Data providers. Jakarta Data providers with their own custom dependency injection or other vendor-specific mechanisms are not required to implement or provide the Jakarta Data Provider SPI.


### PR DESCRIPTION
This pull adds documentation of the ways of using Jakarta Data, which can be as Standalone providers, within Jakarta EE products, or both.
It explicitly documents that injection can be accomplished either by custom dependency injection or by CDI and addresses discovery of providers for the latter, giving Jakarta Data providers the flexibility to choose the approach that best suits them without imposing requirements on providers that already have their own dependency injection.