### PR TITLE
Avoiding conflicts between CDI extensions

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Repository.java
+++ b/api/src/main/java/jakarta/data/repository/Repository.java
@@ -492,4 +492,29 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface Repository {
+    /**
+     * Value for the {@link provider} attribute that allows the use of any
+     * available Jakarta Data provider that supports the type of entity
+     * annotation that is present on the repository's entity class.
+     */
+    static final String ANY_PROVIDER = "";
+
+    /**
+     * <p>Restricts the repository implementation to that of a specific
+     * Jakarta Data provider.</p>
+     *
+     * <p>This is useful when multiple Jakarta Data providers support the
+     * same type of entity annotation, in which case the provider attribute
+     * clarifies which Jakarta Data provider must be used.
+     * Jakarta Data providers must ignore {@link Repository} annotations
+     * that indicate a different provider's name as the provider.</p>
+     *
+     * <p>The default value of this attribute is {@link #ANY_PROVIDER},
+     * allowing the use of any available Jakarta Data provider that
+     * supports the type of entity annotation that is present on the
+     * repository's entity class.</p>
+     *
+     * @return the name of a Jakarta Data provider or {@link #ANY_PROVIDER}.
+     */
+    String provider() default ANY_PROVIDER;
 }

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -470,13 +470,13 @@ To run in environments with Jakarta Contexts and Dependency Injection (CDI), Jak
 
 === Entity Annotation Class
 
-The `jakarta.persistence.Entity` annotation from the Jakarta Persistence specification can be used by repository entity classes for Jakarta Data providers that are backed by a Jakarta Persistence provider. Jakarta Data providers that are not backed by a Jakarta Persistence provider must not support the `jakarta.persistence.Entity` annotation.
+The `jakarta.persistence.Entity` annotation from the Jakarta Persistence specification can be used by repository entity classes for Jakarta Data providers that are backed by a Jakarta Persistence provider. Other Jakarta Data providers must not support the `jakarta.persistence.Entity` annotation.
 
-The `jakarta.nosql.Entity` annotation from the Jakarta NoSQL specification can be used by repository entity classes for Jakarta Data providers that are backed by NoSQL databases. Jakarta Data providers that are not backed by NoSQL databases must not support the `jakarta.nosql.Entity` annotation.
+The `jakarta.nosql.Entity` annotation from the Jakarta NoSQL specification can be used by repository entity classes for Jakarta Data providers that are backed by NoSQL databases. Other Jakarta Data providers must not support the `jakarta.nosql.Entity` annotation.
 
-Jakarta Data providers can introduce and support custom entity annotations, but the class name of all supported entity annotation types must end with `Entity`. This enables Jakarta Data providers to know if a repository entity class contains entity annotations that belong to a different Jakarta Data provider without knowing in advance the full list of entity annotation types that exist across providers.
+Jakarta Data providers that define custom entity annotations must follow the convention that the class name of all supported entity annotation types ends with `Entity`. This enables Jakarta Data providers to identify if a repository entity class contains entity annotations from different Jakarta Data providers so that the corresponding `Repository` can be ignored by Jakarta Data providers that should not provide it.
 
-Jakarta Data provider CDI Extensions must ignore all `Repository` annotations for which all of the entity annotations available at run time on the Repository's entity class are not supported by the Jakarta Data provider. Ignoring these annotations allows other Jakarta Data providers to handle them.
+Jakarta Data provider CDI Extensions must ignore all `Repository` annotations where annotations for the corresponding entity are available at run time and none of the entity annotations are supported by the Jakarta Data provider. Ignoring these `Repository` annotations allows other Jakarta Data providers to handle them.
 
 === Jakarta Data Provider Name
 

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -464,3 +464,22 @@ for (Pageable p = Pageable.ofSize(25).sortBy(Sort.desc("yearBorn"), Sort.asc("na
 }
 ----
 
+== Jakarta Data CDI Extension
+
+To run in environments with Jakarta Contexts and Dependency Injection (CDI), Jakarta Data providers each register their own CDI extension (`jakarta.enterprise.inject.spi.Extension`) to produce the bean instances that are defined via the `Repository` annotation and injected via the `Inject` annotation. The Jakarta Data specification employs several strategies for reducing and avoiding conflicts between Jakarta Data providers. The entity annotation class is used as the primary strategy. The Jakarta Data provider name serves as a secondary strategy.
+
+=== Entity Annotation Class
+
+The `jakarta.persistence.Entity` annotation from the Jakarta Persistence specification can be used by repository entity classes for Jakarta Data providers that are backed by a Jakarta Persistence provider. Jakarta Data providers that are not backed by a Jakarta Persistence provider must not support the `jakarta.persistence.Entity` annotation.
+
+The `jakarta.nosql.Entity` annotation from the Jakarta NoSQL specification can be used by repository entity classes for Jakarta Data providers that are backed by NoSQL databases. Jakarta Data providers that are not backed by NoSQL databases must not support the `jakarta.nosql.Entity` annotation.
+
+Jakarta Data providers can introduce and support custom entity annotations, but the class name of all supported entity annotation types must end with `Entity`. This enables Jakarta Data providers to know if a repository entity class contains entity annotations that belong to a different Jakarta Data provider without knowing in advance the full list of entity annotation types that exist across providers.
+
+Jakarta Data provider CDI Extensions must ignore all `Repository` annotations for which all of the entity annotations available at run time on the Repository's entity class are not supported by the Jakarta Data provider. Ignoring these annotations allows other Jakarta Data providers to handle them.
+
+=== Jakarta Data Provider Name
+
+The entity annotation class will usually be sufficient to avoid conflicts between Jakarta Data providers, but in cases where the entity annotation class is not sufficient, the application can designate the name of the desired Jakarta Data provider on the optional `provider` attribute of the `Repository` annotation.
+
+Jakarta Data provider CDI Extensions must ignore all `Repository` annotations that designate a different provider's name via the `Repository.provider()` annotation attribute. Ignoring these annotations allows other Jakarta Data providers to handle them.


### PR DESCRIPTION
Come up with a set of rules for CDI extensions to reduce/avoid colliding on the same repositories when there are multiple providers active in the system.