### PR TITLE
Minimal identifier to enable vendor configuration

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Repository.java
+++ b/api/src/main/java/jakarta/data/repository/Repository.java
@@ -500,6 +500,37 @@ public @interface Repository {
     static final String ANY_PROVIDER = "";
 
     /**
+     * Value for the {@link dataStore} attribute that indicates that the
+     * Jakarta Data provider should choose a default data store to use.
+     * The default data store might require additional vendor-specific
+     * configuration, depending on the vendor.
+     */
+    static final String DEFAULT_DATA_STORE = "";
+
+    /**
+     * <p>Optionally indicates the data store to use for the repository.</p>
+     *
+     * <p>The Jakarta Data specification does not define a full configuration
+     * model, and relies upon the Jakarta Data providers to provide configuration.
+     * This value serves as an identifier linking to vendor-specific configuration
+     * for each Jakarta Data provider to interpret in a vendor-specific way.</p>
+     *
+     * <p>For some Jakarta Data providers, this value could map directly to an
+     * identifier in vendor-specific configuration. For others, this value could
+     * map to a base configuration path that forms a configuration hierarchy,
+     * such as in MicroProfile Config, or possibly Jakarta Config in a future
+     * version of this specification. For providers backed by Jakarta Persistence,
+     * it might point to a {@code jakarta.annotation.sql.DataSourceDefinition} name
+     * or a {@code javax.sql.DataSource} JNDI name or resource reference,
+     * or other vendor-specific configuration.</p>
+     *
+     * <p>The default value of this attribute is {@link #DEFAULT_DATA_STORE}.</p>
+     *
+     * @return the name of a data store or {@link #DEFAULT_DATA_STORE}.
+     */
+    String dataStore() default DEFAULT_DATA_STORE;
+
+    /**
      * <p>Restricts the repository implementation to that of a specific
      * Jakarta Data provider.</p>
      *


### PR DESCRIPTION
Have a simple identifier that can optionally be specified on a repository that Jakarta Data providers can use to distinguish which vendor-specific configuration is wanted for the repository.  In a future version of the spec, this could be reused to identify a Jakarta Config base configuration path, but should hopefully be something that Jakarta Data providers can use in a vendor-specific way as well.
