### PR TITLE
Address the TODO to reserve keywords for future

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Repository.java
+++ b/api/src/main/java/jakarta/data/repository/Repository.java
@@ -331,6 +331,9 @@ import java.lang.annotation.Target;
  * {@code WithQuarter}, {@code WithSecond}, {@code WithWeek}, {@code WithYear}.
  * </p>
  * <p>
+ * Reserved for find...By and count...By: {@code Distinct}.
+ * </p>
+ * <p>
  * Reserved for updates: {@code Add}, {@code Divide}, {@code Multiply}, {@code Set}, {@code Subtract}.
  * </p>
  *

--- a/api/src/main/java/jakarta/data/repository/Repository.java
+++ b/api/src/main/java/jakarta/data/repository/Repository.java
@@ -317,6 +317,23 @@ import java.lang.annotation.Target;
  *
  * </table>
  *
+ * <h3>Reserved for Future Use</h3>
+ * <p>
+ * The specification does not define behavior for the following keywords, but reserves
+ * them as keywords that must not be used as entity attribute names when using
+ * Query by Method Name. This gives the specification the flexibility to add them in
+ * future releases without introducing breaking changes to applications.
+ * </p>
+ * <p>
+ * Reserved for query conditions: {@code AbsoluteValue}, {@code CharCount}, {@code ElementCount},
+ * {@code Rounded}, {@code RoundedDown}, {@code RoundedUp}, {@code Trimmed},
+ * {@code WithDay}, {@code WithHour}, {@code WithMinute}, {@code WithMonth},
+ * {@code WithQuarter}, {@code WithSecond}, {@code WithWeek}, {@code WithYear}.
+ * </p>
+ * <p>
+ * Reserved for updates: {@code Add}, {@code Divide}, {@code Multiply}, {@code Set}, {@code Subtract}.
+ * </p>
+ *
  * <h3>Wildcard Characters</h3>
  * <p>
  * Wildcard characters for patterns are determined by the data access provider.
@@ -505,10 +522,8 @@ import java.lang.annotation.Target;
  * environment where the Jakarta EE technology that provides the interceptor is available.</p>
  */
 // TODO When can "By" be omitted and "All" added? Need to document that.
-// TODO keywords for update would be needed if included.
 // TODO Does Jakarta NoSQL have the same or different wildcard characters? Document this
 //       under: "Wildcard characters for patterns are determined by the data access provider"
-// TODO Ensure we have all reserved words listed, including those we might want to reserve for future use.
 // TODO Ensure we have all required supported return types listed.
 @Documented
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
There is a TODO comment to reserve any keywords that we might want to add meaning for in the future.  This is a good idea so that we avoid breaking changes to applications that are written with v1.0 so that they can move up and get identical behavior without experiencing breakages.  It informs them of particular keywords to avoid.  In this pull, I looked over the JPQL language and identified areas that query-by-method-name might possibly some day cover, but doesn't currently.  This includes abilities like extracting a particular component of a date, length of a string or size of a collection, rounding.  We can reserve the keywords now in case we ever want to leverage these capabilities.

Here are a few examples of things you cannot do now, but conceivably could be added via what Jakarta Persistence/JPQL supports:
```
packages.findByWidthRoundedDown(12.0)
people.findByBirthdateWithMonthAndBirthdateWithDay(Month.MAY.getValue(), 9);
people.findByNameCharCount(4);
cities.findByNameTrimmed("Rochester")
customers.findByEmailAddressesElementCountGreaterThan(1);
```