### PR TITLE
Eventual consistancy for read/write tests

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/framework/arquillian/extensions/TCKFrameworkAppender.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/arquillian/extensions/TCKFrameworkAppender.java
@@ -23,6 +23,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import ee.jakarta.tck.data.framework.junit.anno.Assertion;
 import ee.jakarta.tck.data.framework.junit.extensions.AssertionExtension;
 import ee.jakarta.tck.data.framework.utilities.TestProperty;
+import ee.jakarta.tck.data.framework.utilities.TestPropertyHandler;
 
 /**
  * This extension will intercept all archives before they are deployed to the container and append 
@@ -44,7 +45,7 @@ public class TCKFrameworkAppender implements AuxiliaryArchiveAppender {
     public Archive<?> createAuxiliaryArchive() {
         JavaArchive framework = ShrinkWrap.create(JavaArchive.class, "jakarta-data-framework.jar");
         framework.addPackages(false, annoPackage, extensionPackage, utilPackage);
-        return TestProperty.storeProperties(framework);
+        return TestPropertyHandler.storeProperties(framework);
     }
 
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/junit/extensions/StandaloneExtension.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/junit/extensions/StandaloneExtension.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.extension.InvocationInterceptor;
 import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
 import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
 
-import ee.jakarta.tck.data.framework.utilities.TestProperty;
+import ee.jakarta.tck.data.framework.utilities.TestPropertyUtility;
 
 /**
  * <p>This is a Junit5 extension class that extends ArquillianExtension</p>
@@ -47,7 +47,7 @@ public class StandaloneExtension extends ArquillianExtension implements BeforeAl
 
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
-        if (TestProperty.isStandalone()) {
+        if (TestPropertyUtility.isStandalone()) {
             log.info("Running tests in standalone mode, arquillian will not create or deploy archives for test class: " + context.getTestClass().get().getCanonicalName());
             return;
         }
@@ -56,7 +56,7 @@ public class StandaloneExtension extends ArquillianExtension implements BeforeAl
 
     @Override
     public void afterAll(ExtensionContext context) throws Exception {
-        if (TestProperty.isStandalone()) {
+        if (TestPropertyUtility.isStandalone()) {
             return;
         }
         super.afterAll(context);
@@ -64,7 +64,7 @@ public class StandaloneExtension extends ArquillianExtension implements BeforeAl
 
     @Override
     public void beforeEach(ExtensionContext context) throws Exception {
-        if (TestProperty.isStandalone()) {
+        if (TestPropertyUtility.isStandalone()) {
             return;
         }
         super.beforeEach(context);
@@ -72,7 +72,7 @@ public class StandaloneExtension extends ArquillianExtension implements BeforeAl
 
     @Override
     public void afterEach(ExtensionContext context) throws Exception {
-        if (TestProperty.isStandalone()) {
+        if (TestPropertyUtility.isStandalone()) {
             return;
         }
         super.afterEach(context);
@@ -81,7 +81,7 @@ public class StandaloneExtension extends ArquillianExtension implements BeforeAl
     @Override
     public void interceptTestTemplateMethod(Invocation<Void> invocation,
             ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
-        if (TestProperty.isStandalone()) {
+        if (TestPropertyUtility.isStandalone()) {
             invocation.proceed();
             return;
         }
@@ -91,7 +91,7 @@ public class StandaloneExtension extends ArquillianExtension implements BeforeAl
     @Override
     public void interceptTestMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext,
             ExtensionContext extensionContext) throws Throwable {
-        if (TestProperty.isStandalone()) {
+        if (TestPropertyUtility.isStandalone()) {
             invocation.proceed();
             return;
         }
@@ -101,7 +101,7 @@ public class StandaloneExtension extends ArquillianExtension implements BeforeAl
     @Override
     public void interceptBeforeEachMethod(Invocation<Void> invocation,
             ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
-        if (TestProperty.isStandalone()) {
+        if (TestPropertyUtility.isStandalone()) {
             invocation.proceed();
             return;
         }
@@ -111,7 +111,7 @@ public class StandaloneExtension extends ArquillianExtension implements BeforeAl
     @Override
     public void interceptAfterEachMethod(Invocation<Void> invocation,
             ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
-        if (TestProperty.isStandalone()) {
+        if (TestPropertyUtility.isStandalone()) {
             invocation.proceed();
             return;
         }
@@ -121,7 +121,7 @@ public class StandaloneExtension extends ArquillianExtension implements BeforeAl
     @Override
     public void interceptBeforeAllMethod(Invocation<Void> invocation,
             ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
-        if (TestProperty.isStandalone()) {
+        if (TestPropertyUtility.isStandalone()) {
             invocation.proceed();
             return;
         }
@@ -131,7 +131,7 @@ public class StandaloneExtension extends ArquillianExtension implements BeforeAl
     @Override
     public void interceptAfterAllMethod(Invocation<Void> invocation,
             ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
-        if (TestProperty.isStandalone()) {
+        if (TestPropertyUtility.isStandalone()) {
             invocation.proceed();
             return;
         }
@@ -140,7 +140,7 @@ public class StandaloneExtension extends ArquillianExtension implements BeforeAl
 
     @Override
     public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
-        if (TestProperty.isStandalone()) {
+        if (TestPropertyUtility.isStandalone()) {
             throw throwable;
         }
         super.handleTestExecutionException(context, throwable);

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/Populator.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/Populator.java
@@ -15,10 +15,9 @@
  */
 package ee.jakarta.tck.data.framework.read.only;
 
-import java.time.Duration;
 import java.util.logging.Logger;
 
-import ee.jakarta.tck.data.framework.utilities.TestProperty;
+import ee.jakarta.tck.data.framework.utilities.TestPropertyUtility;
 
 /**
  * Aids in the population of repositories with entities for read-only testing.
@@ -66,7 +65,7 @@ public interface Populator<T> {
         populationLogic(repo);
 
         log.info(repoName + " waiting for eventual consistency");
-        eventualConsistency();
+        TestPropertyUtility.waitForEventualConsistency();
         
         log.info(repoName + " verifying");
         if(! isPopulated(repo)) {
@@ -76,22 +75,4 @@ public interface Populator<T> {
         log.info(repoName + " populated");
     }
 
-    /**
-     * Waits for a configured eventual consistency delay.
-     * 
-     * This ensures that repositories that are a part of a distribution have all 
-     * been updated before tests are allowed to perform read operations.
-     */
-    public default void eventualConsistency() {
-        if(!TestProperty.delay.isSet()) {
-            return;
-        }
-        Duration delay = Duration.ofSeconds(TestProperty.delay.getLong());
-        try {
-            Thread.sleep(delay.toMillis());
-        } catch (InterruptedException e) {
-            log.warning("Did not wait full duration of " + delay.toMillis() 
-                      + "ms for eventual consistancy due to exception: " + e.getLocalizedMessage());
-        }
-    }
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TestPropertyHandler.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TestPropertyHandler.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.framework.utilities;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.container.ResourceContainer;
+
+/**
+ * This uitlity class handles the caching and loading of test properties between the 
+ * client and container when tests are run inside an Arquillian container.
+ */
+public class TestPropertyHandler {
+    
+    private static final Logger log = Logger.getLogger(TestPropertyHandler.class.getCanonicalName());
+    
+    private static final String PROP_FILE = "tck.properties";
+    private static Properties foundProperties;
+    
+    private TestPropertyHandler() {
+        //UTILITY CLASS
+    }
+
+    /**
+     * Container: Load properties from the TestProperty cache file, and return a properties object.
+     * If any error occurs in finding the cache file, or loading the properties, 
+     * then an empty properties object is returned. 
+     * 
+     * @return - the cached properties, or an empty properties object.
+     */
+    static Properties loadProperties() {   
+        if(foundProperties != null) {
+            return foundProperties;
+        }
+        
+        //Try to load property file
+        foundProperties = new Properties();
+        InputStream propsStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(PROP_FILE);
+        if(propsStream != null) {
+            try {
+                foundProperties.load(propsStream);
+            } catch (Exception e) {
+                log.info("Attempted to load properties from resource " + PROP_FILE + " but failed. Because: " + e.getLocalizedMessage());
+            }
+        }
+        
+        return foundProperties;
+    }
+    
+    /**
+     * Client: Store system properties from the client to a properties file 
+     * as a resource on the archive sent to the container. 
+     * 
+     * @param archive - The archive going to the container
+     * @return the archive with a resource file attached
+     */
+    public static Archive<?> storeProperties(Archive<?> archive) {
+        if(! (archive instanceof ResourceContainer) ) {
+            throw new RuntimeException("Could not store properties to archive, because it was not a ResourceConatiner. "
+                    + "Please raise an issue with the maintainers of the Jakarta Data TCK.");
+        }
+        
+        Properties filteredProps = new Properties();
+        for(TestProperty prop : TestProperty.values()) {
+            if(prop.getKey().startsWith("java.")) {
+                continue;
+            }
+            filteredProps.put(prop.getKey(), prop.getValue());
+        }
+        
+        try {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            filteredProps.store(out, "System properties shared with Arquillian container");
+            ((ResourceContainer<?>)archive).addAsResource(new StringAsset(out.toString()), PROP_FILE);
+        } catch (Exception e) {
+            throw new RuntimeException("Could not store properties file to archive", e);
+        }
+        
+        return archive;
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TestPropertyUtility.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TestPropertyUtility.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.framework.utilities;
+
+import java.time.Duration;
+import java.util.logging.Logger;
+
+/**
+ * This is a generic utility class that has methods that use test properties
+ * to perform repetitive and useful actions. 
+ *
+ */
+public class TestPropertyUtility {
+    
+    private static final Logger log = Logger.getLogger(TestPropertyUtility.class.getCanonicalName());
+    
+    private TestPropertyUtility() {
+        //UTILITY CLASS
+    }
+    
+    /**
+     * Checks the profile property and determine if it is standalone or not.
+     * 
+     * @return - true if TCK is configured in standalone mode, false otherwise. 
+     */
+    public static boolean isStandalone() {
+        return TestProperty.profile.equals("none");
+    }
+    
+    /**
+     * If a delay was configured for eventual consistency then sleep this thread
+     * for that amount of time. 
+     * A warning is produced if the thread is interrupted during sleep. 
+     */
+    public static void waitForEventualConsistency() {
+        if(!TestProperty.delay.isSet()) {
+            return;
+        }
+        Duration delay = Duration.ofSeconds(TestProperty.delay.getLong());
+        try {
+            Thread.sleep(delay.toMillis());
+        } catch (InterruptedException e) {
+            log.warning("Did not wait full duration of " + delay.toMillis() 
+                      + "ms for eventual consistency due to interruption: " + e.getLocalizedMessage());
+        }
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/nosql/example/Catalog.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/nosql/example/Catalog.java
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-package ee.jakarta.tck.data.core.nosql.example;
+package ee.jakarta.tck.data.standalone.nosql.example;
 
 import java.util.List;
 

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/nosql/example/NoSQLEntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/nosql/example/NoSQLEntityTests.java
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-package ee.jakarta.tck.data.core.nosql.example;
+package ee.jakarta.tck.data.standalone.nosql.example;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -26,15 +26,17 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
 
 import ee.jakarta.tck.data.framework.junit.anno.Assertion;
-import ee.jakarta.tck.data.framework.junit.anno.Core;
 import ee.jakarta.tck.data.framework.junit.anno.NoSQL;
+import ee.jakarta.tck.data.framework.junit.anno.Standalone;
+import ee.jakarta.tck.data.framework.utilities.TestPropertyUtility;
 import jakarta.data.exceptions.MappingException;
 import jakarta.inject.Inject;
 
 /**
- * Execute a test with an NoSQL specific entity.
+ * Example test class:
+ * Execute a test with an NoSQL specific entity with a repository that requires read and writes (AKA not read-only)
  */
-@Core
+@Standalone
 @NoSQL
 public class NoSQLEntityTests {
     
@@ -56,6 +58,11 @@ public class NoSQLEntityTests {
         products.add(Product.of(05L, "ruler", 2.00, 2.15));
         
         products.stream().forEach(product -> catalog.save(product));
+        
+        //IMPORTANT - all NoSQL tests need to wait for eventual consistency after a write action
+        //because in a test environment we must be pessimistic and assume some wait is necessary for 
+        //all nodes to get the latest update.
+        TestPropertyUtility.waitForEventualConsistency(); 
         
         int countExpensive = catalog.countByPriceGreaterThanEqual(2.99);
         assertEquals(2, countExpensive, "Expected two products to be more than 3.00");

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/nosql/example/Product.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/nosql/example/Product.java
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-package ee.jakarta.tck.data.core.nosql.example;
+package ee.jakarta.tck.data.standalone.nosql.example;
 
 import jakarta.nosql.Column;
 import jakarta.nosql.Entity;

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/example/Catalog.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/example/Catalog.java
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-package ee.jakarta.tck.data.core.persistence.example;
+package ee.jakarta.tck.data.standalone.persistence.example;
 
 import java.util.List;
 

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/example/PersistenceEntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/example/PersistenceEntityTests.java
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-package ee.jakarta.tck.data.core.persistence.example;
+package ee.jakarta.tck.data.standalone.persistence.example;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -26,15 +26,16 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.Assertions;
 
 import ee.jakarta.tck.data.framework.junit.anno.Assertion;
-import ee.jakarta.tck.data.framework.junit.anno.Core;
 import ee.jakarta.tck.data.framework.junit.anno.Persistence;
+import ee.jakarta.tck.data.framework.junit.anno.Standalone;
 import jakarta.data.exceptions.MappingException;
 import jakarta.inject.Inject;
 
 /**
- * Execute a test with a Persistence specific entity. 
+ * Example test class:
+ * Execute a test with a Persistence specific entity with a repository that requires read and writes (AKA not read-only) 
  */
-@Core
+@Standalone
 @Persistence
 public class PersistenceEntityTests {
     

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/example/Product.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/example/Product.java
@@ -13,7 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-package ee.jakarta.tck.data.core.persistence.example;
+package ee.jakarta.tck.data.standalone.persistence.example;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;


### PR DESCRIPTION
- decouple test property enum from utility methods. 
- move read/write entity-specific tests to Standalone where they actually belong
- create a standard eventual consistency method for use in read-only tests and read/write tests.

Fixes #136 