### PR TITLE
complete the documentation of CrudRepository.delete

### DIFF
--- a/api/src/main/java/jakarta/data/exceptions/DataConsistencyException.java
+++ b/api/src/main/java/jakarta/data/exceptions/DataConsistencyException.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data.exceptions;
+
+/**
+ * Indicates a failure that is due to inconsistent state between the entity and the database.
+ * For example, {@link jakarta.data.repository.CrudRepository#delete(Object) delete(entity)}
+ * or {@link jakarta.data.repository.CrudRepository#deleteAll(Iterable) deleteAll(entities)}
+ * where the entity Id no longer exists in the database or the entity is versioned and the
+ * version no longer matches the version in the database.
+ */
+public class DataConsistencyException extends DataException {
+    private static final long serialVersionUID = 1982179693469903341L;
+
+    /**
+     * Constructs a new DataConsistencyException exception with the specified detail message.
+     *
+     * @param message the detail message.
+     */
+    public DataConsistencyException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new DataConsistencyException exception with the specified detail message.
+     *
+     * @param message the detail message.
+     * @param cause another exception or error that caused this exception.
+     *        Null indicates that no other cause is specified.
+     */
+    public DataConsistencyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new DataConsistencyException exception with the specified cause.
+     *
+     * @param cause the cause.
+     */
+    public DataConsistencyException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/api/src/main/java/jakarta/data/exceptions/OptimisticLockingFailureException.java
+++ b/api/src/main/java/jakarta/data/exceptions/OptimisticLockingFailureException.java
@@ -24,35 +24,35 @@ package jakarta.data.exceptions;
  * where the entity Id no longer exists in the database or the entity is versioned and the
  * version no longer matches the version in the database.
  */
-public class DataConsistencyException extends DataException {
+public class OptimisticLockingFailureException extends DataException {
     private static final long serialVersionUID = 1982179693469903341L;
 
     /**
-     * Constructs a new DataConsistencyException exception with the specified detail message.
+     * Constructs a new OptimisticLockingFailureException exception with the specified detail message.
      *
      * @param message the detail message.
      */
-    public DataConsistencyException(String message) {
+    public OptimisticLockingFailureException(String message) {
         super(message);
     }
 
     /**
-     * Constructs a new DataConsistencyException exception with the specified detail message.
+     * Constructs a new OptimisticLockingFailureException exception with the specified detail message.
      *
      * @param message the detail message.
      * @param cause another exception or error that caused this exception.
      *        Null indicates that no other cause is specified.
      */
-    public DataConsistencyException(String message, Throwable cause) {
+    public OptimisticLockingFailureException(String message, Throwable cause) {
         super(message, cause);
     }
 
     /**
-     * Constructs a new DataConsistencyException exception with the specified cause.
+     * Constructs a new OptimisticLockingFailureException exception with the specified cause.
      *
      * @param cause the cause.
      */
-    public DataConsistencyException(Throwable cause) {
+    public OptimisticLockingFailureException(Throwable cause) {
         super(cause);
     }
 }

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -17,7 +17,7 @@
  */
 package jakarta.data.repository;
 
-import jakarta.data.exceptions.DataConsistencyException;
+import jakarta.data.exceptions.OptimisticLockingFailureException;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -36,8 +36,8 @@ public interface CrudRepository<T, K> extends DataRepository<T, K> {
      * @param entity the entity to be saved
      * @param <S> type of entity to save
      * @return the saved entity; will never be {@literal null}.
-     * @throws DataConsistencyException if the entity is versioned and a different version
-     *         is present in the database.
+     * @throws OptimisticLockingFailureException if the entity has a version for optimistic locking
+     *         that differs from the version in the database.
      * @throws NullPointerException when the entity is null
      */
     <S extends T> S save(S entity);
@@ -48,8 +48,8 @@ public interface CrudRepository<T, K> extends DataRepository<T, K> {
      * @param entities an iterable of entities
      * @param <S> type of entity to save
      * @return the saved entities; will never be {@literal null}.
-     * @throws DataConsistencyException if an entity is versioned and a different version
-     *         is present in the database.
+     * @throws OptimisticLockingFailureException if an entity has a version for optimistic locking
+     *         that differs from the version in the database.
      * @throws NullPointerException if either the iterable is null or any element is null
      */
     <S extends T> Iterable<S> saveAll(Iterable<S> entities);
@@ -116,9 +116,8 @@ public interface CrudRepository<T, K> extends DataRepository<T, K> {
      * Other properties of the entity do not need to match.
      *
      * @param entity must not be {@literal null}.
-     * @throws DataConsistencyException if the entity is not found in the database for deletion
-     *         or if the entity is found but is versioned and has a version that is inconsistent
-     *         with the version in the database.
+     * @throws OptimisticLockingFailureException if the entity is not found in the database for deletion
+     *         or has a version for optimistic locking that is inconsistent with the version in the database.
      * @throws NullPointerException when the entity is null
      */
     void delete(T entity);
@@ -139,9 +138,8 @@ public interface CrudRepository<T, K> extends DataRepository<T, K> {
      * Other properties of the entity do not need to match.
      *
      * @param entities must not be {@literal null}. Must not contain {@literal null} elements.
-     * @throws DataConsistencyException if any of the entities are not found in the database for deletion
-     *         or if any of the entities are found but are versioned and has a version that is inconsistent
-     *         with the version in the database.
+     * @throws OptimisticLockingFailureException if an entity is not found in the database for deletion
+     *         or has a version for optimistic locking that is inconsistent with the version in the database.
      * @throws NullPointerException when either the iterable is null or contains null elements
      */
     void deleteAll(Iterable<? extends T> entities);

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
  */
 package jakarta.data.repository;
 
-
+import jakarta.data.exceptions.DataConsistencyException;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -36,6 +36,8 @@ public interface CrudRepository<T, K> extends DataRepository<T, K> {
      * @param entity the entity to be saved
      * @param <S> type of entity to save
      * @return the saved entity; will never be {@literal null}.
+     * @throws DataConsistencyException if the entity is versioned and a different version
+     *         is present in the database.
      * @throws NullPointerException when the entity is null
      */
     <S extends T> S save(S entity);
@@ -46,6 +48,8 @@ public interface CrudRepository<T, K> extends DataRepository<T, K> {
      * @param entities an iterable of entities
      * @param <S> type of entity to save
      * @return the saved entities; will never be {@literal null}.
+     * @throws DataConsistencyException if an entity is versioned and a different version
+     *         is present in the database.
      * @throws NullPointerException if either the iterable is null or any element is null
      */
     <S extends T> Iterable<S> saveAll(Iterable<S> entities);
@@ -107,9 +111,14 @@ public interface CrudRepository<T, K> extends DataRepository<T, K> {
     void deleteById(K id);
 
     /**
-     * Deletes a given entity.
+     * Deletes a given entity. Deletion is performed by matching the Id, and if the entity is
+     * versioned (for example, with {@code jakarta.persistence.Version}), then also the version.
+     * Other properties of the entity do not need to match.
      *
      * @param entity must not be {@literal null}.
+     * @throws DataConsistencyException if the entity is not found in the database for deletion
+     *         or if the entity is found but is versioned and has a version that is inconsistent
+     *         with the version in the database.
      * @throws NullPointerException when the entity is null
      */
     void delete(T entity);
@@ -125,9 +134,14 @@ public interface CrudRepository<T, K> extends DataRepository<T, K> {
     void deleteAllById(Iterable<K> ids);
 
     /**
-     * Deletes the given entities.
+     * Deletes the given entities. Deletion of each entity is performed by matching the Id, and if the entity is
+     * versioned (for example, with {@code jakarta.persistence.Version}), then also the version.
+     * Other properties of the entity do not need to match.
      *
      * @param entities must not be {@literal null}. Must not contain {@literal null} elements.
+     * @throws DataConsistencyException if any of the entities are not found in the database for deletion
+     *         or if any of the entities are found but are versioned and has a version that is inconsistent
+     *         with the version in the database.
      * @throws NullPointerException when either the iterable is null or contains null elements
      */
     void deleteAll(Iterable<? extends T> entities);


### PR DESCRIPTION
fixes #152

Among the different options here, comparing all entity attributes wouldn't always be achievable and likely wouldn't perform well either. Going with the approach that Spring has to consider the id and version (if versioned) seems best.  It makes sense to raise an error given that return type is void and the user needs to be informed somehow that their requested operation cannot be honored.