### PR TITLE
Updates for Java 21

### DIFF
--- a/.github/workflows/java-CI.yml
+++ b/.github/workflows/java-CI.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Java 17 CI with Maven
+name: Java CI with Maven
 
 on:
   push:
@@ -14,15 +14,18 @@ permissions:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        java-version: [ '17', '21-ea' ]
 
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-    - name: Set up JDK 17
+    - name: Set up JDK ${{ matrix.java-version }}
       uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # v3.11.0
       with:
-        java-version: '17'
+        java-version: ${{ matrix.java-version }}
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven

--- a/tck-dist/src/main/asciidoc/sections/05inventory.adoc
+++ b/tck-dist/src/main/asciidoc/sections/05inventory.adoc
@@ -72,6 +72,5 @@ EE Mode:
 
 - An Application Server to test against | <<Software To Install>>
 - The {APILongName} API, Arquillian SPI, and JUnit5 libraries available to the `Test Client` | <<Test Client Dependencies>>
-- The Arquillian, JUnit5, and Signature Test libraries available to the `Test Server` | <<Test Server Dependencies>>
 - An Arquillian SPI implementation for your Application Server | <<Configure Arquillian>>
 - A logging configuration for TCK logging on `Test Client` and `Test Server` | <<Configure Client and Server Logging>>

--- a/tck-dist/src/main/asciidoc/sections/07.2ee-mode.adoc
+++ b/tck-dist/src/main/asciidoc/sections/07.2ee-mode.adoc
@@ -18,25 +18,6 @@ include::{starterLoc}/ee-pom.xml[tag=testClientDep]
 
 Each of these Arquillian tests run within the runtime container, with the help of an Arquillian adapter for that runtime implementation (mentioned as a prerequisite).
 
-==== Test Server Dependencies
-
-If the Test Server is running on a separate JVM (recommended), then the Test Server will also need access to JUnit5 and Signature Test Plugin libraries.
-The Test Server dependencies can be copied over during the build phase.
-
-Example ee-pom.xml:
-
-[source, xml]
-----
-include::{starterLoc}/ee-pom.xml[tag=testServerDep]
-----
-
-Using the maven command:
-
-[source, sh]
-----
-$ mvn dependency:copy
-----
-
 ==== Configure {TCKTestPlatform}
 
 {TCKTestPlatform} needs to be configured to know which packages contain tests to run.
@@ -89,13 +70,6 @@ include::{starterLoc}/ee-pom.xml[tags=systemProperties;!logging;!signature;!stan
 ==== Configure Jakarta EE Platform Server
 
 The {APILongName} TCK requires that your Jakarta EE Platform Server has a valid implementation of the {APILongName} API.
-
-The TCK also requires external libraries at runtime that also need to be available on the Application Server's class path.
-
-- org.junit.jupiter:junit-jupiter - For test assertions
-- org.netbeans.tools:sigtest-maven-plugin - For signature testing
-
-Refer back to <<Test Server Dependencies>> for information on how to make to pull and copy these dependencies.
 
 ==== Configure Client and Server Logging
 

--- a/tck-dist/src/main/asciidoc/sections/10signature.adoc
+++ b/tck-dist/src/main/asciidoc/sections/10signature.adoc
@@ -25,18 +25,6 @@ JDK modules back into class files for signature testing.
 The signature test plugin we use will also attempt to perform reflective access of classes, methods, and fields.
 Due to the new module system in JDK 9+ special permissions need to be added in order for these tests to run: 
 
-==== with a Security Manager
-
-If you are using a Security Manager add the following permissions to the 
-`sigtest-maven-plugin` on your Jakarta EE Platform server:
-
-[source, txt]
-----
-permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal";
-permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.reflect";
-permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.vm.annotation";
-----
-
 ==== with Modules
 
 By default the java.base module only exposes certain classes for reflective access. 

--- a/tck-dist/src/main/assembly/assembly.xml
+++ b/tck-dist/src/main/assembly/assembly.xml
@@ -36,11 +36,6 @@
       <source>src/main/readme/README.md</source>
       <destName>README.md</destName>
     </file>
-    <!-- Signature file -->
-    <file>
-      <source>${project.parent.basedir}/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/jakarta.data.sig</source>
-      <outputDirectory>/artifacts</outputDirectory>
-    </file>
   </files>
 
   <fileSets>
@@ -66,6 +61,14 @@
     <fileSet>
       <directory>src/main/starter/</directory>
       <outputDirectory>/starter</outputDirectory>
+    </fileSet>
+    <!-- Signature files -->
+    <fileSet>
+      <directory>${project.parent.basedir}/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/</directory>
+      <outputDirectory>/artifacts</outputDirectory>
+      <includes>
+      	<include>**/*.sig*</include>
+      </includes>
     </fileSet>
   </fileSets>
 

--- a/tck-dist/src/main/starter/ee-pom.xml
+++ b/tck-dist/src/main/starter/ee-pom.xml
@@ -131,29 +131,6 @@
   <directory>${targetDirectory}</directory>
   <defaultGoal>clean test</defaultGoal>
   <plugins>
-   <!-- tag::testServerDep[] -->
-   <!-- Test Server Dependencies -->
-   <plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-dependency-plugin</artifactId>
-    <version>${maven.dep.plugin.version}</version>
-    <configuration>
-     <artifactItems>
-      <artifactItem>
-       <groupId>org.junit.jupiter</groupId>
-       <artifactId>junit-jupiter</artifactId>
-       <version>${junit.version}</version>
-      </artifactItem>
-      <artifactItem>
-       <groupId>org.netbeans.tools</groupId>
-       <artifactId>sigtest-maven-plugin</artifactId>
-       <version>${sigtest.version}</version>
-      </artifactItem>
-     </artifactItems>
-     <outputDirectory>${application.server.lib}</outputDirectory>
-    </configuration>
-   </plugin>
-   <!-- end::testServerDep[] -->
    <!-- Compile plugin for any supplemental class files -->
    <plugin>
     <groupId>org.apache.maven.plugins</groupId>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -98,7 +98,14 @@
       <version>3.1.0</version>
       <scope>provided</scope>
     </dependency>
-
+    
+    <!-- Test Dependencies -->
+    <dependency>
+      <groupId>org.netbeans.tools</groupId>
+      <artifactId>sigtest-maven-plugin</artifactId>
+      <version>${sigtest.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -192,6 +199,7 @@
       </properties>
       <build>
         <plugins>
+          <!-- Extract api into output directory for use by signature plugin -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
@@ -220,6 +228,32 @@
               </execution>
             </executions>
           </plugin>
+
+          <!-- Extract JDK modules into output directory for use by signature plugin -->
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>3.1.0</version>
+            <executions>
+                <execution>
+                    <id>extractModules</id>
+                    <phase>generate-sources</phase>
+                    <goals>
+                        <goal>exec</goal>
+                    </goals>
+                </execution>
+            </executions>
+            <configuration>
+                <executable>jimage</executable>
+                <arguments>
+                    <argument>extract</argument>
+                    <argument>--dir=${project.build.directory}/jimage</argument>
+                    <argument>${java.home}/lib/modules</argument>
+                </arguments>
+            </configuration>
+          </plugin>
+
+          <!-- Run signature plugin to generate signature file -->
           <plugin>
             <groupId>org.netbeans.tools</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
@@ -234,6 +268,7 @@
             </executions>
             <configuration>
               <classes>${project.build.directory}/jakarta-data-api</classes>
+              <classes>${project.build.directory}/jimage/java.base</classes><classes>${project.build.directory}/jimage/java.base</classes>
               <packages>
                 jakarta.data,
                 jakarta.data.exceptions,

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/arquillian/extensions/TCKFrameworkAppender.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/arquillian/extensions/TCKFrameworkAppender.java
@@ -15,7 +15,7 @@
  */
 package ee.jakarta.tck.data.framework.arquillian.extensions;
 
-import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
+import org.jboss.arquillian.container.test.spi.client.deployment.CachedAuxilliaryArchiveAppender;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -30,19 +30,19 @@ import ee.jakarta.tck.data.framework.utilities.TestPropertyHandler;
  * a library with the following:
  * 
  * <p>ee.jakarta.tck.data.framework.junit.anno package</p>
- * <p>eee.jakarta.tck.data.framework.junit.extensions package</p>
+ * <p>ee.jakarta.tck.data.framework.junit.extensions package</p>
  * <p>ee.jakarta.tck.data.framework.utilities package</p>
  * <p>A resource file with system properties from the client, that are needed on the container.</p>
  *
  */
-public class TCKFrameworkAppender implements AuxiliaryArchiveAppender {
+public class TCKFrameworkAppender extends CachedAuxilliaryArchiveAppender {
     
     private static final Package annoPackage = Assertion.class.getPackage();
     private static final Package extensionPackage = AssertionExtension.class.getPackage();
     private static final Package utilPackage = TestProperty.class.getPackage();
 
     @Override
-    public Archive<?> createAuxiliaryArchive() {
+    protected Archive<?> buildArchive() {
         JavaArchive framework = ShrinkWrap.create(JavaArchive.class, "jakarta-data-framework.jar");
         framework.addPackages(false, annoPackage, extensionPackage, utilPackage);
         return TestPropertyHandler.storeProperties(framework);

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/signature/DataSignatureTestRunner.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/signature/DataSignatureTestRunner.java
@@ -37,6 +37,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.logging.Logger;
 
+import ee.jakarta.tck.data.framework.utilities.TestProperty;
+
 /**
  * This class performs the interactions between the test client (EE Application
  * or Standalone Test class) and the signature test framework.
@@ -73,13 +75,13 @@ public class DataSignatureTestRunner extends SigTestEE {
      * @return the classpath as a colon (:) delimited string
      */
     protected String getClasspath() {
-        final String defined = System.getProperty("signature.sigTestClasspath");
+        final String defined = TestProperty.signatureClasspath.getValue();
         if (defined != null && !defined.isBlank()) {
             return defined;
         }
 
         // The Jakarta artifacts we want added to our classpath
-        String[] classes = new String[] { "jakarta.data.Entity", // For jakarta-data-api.jar
+        String[] classes = new String[] { "jakarta.data.repository.Repository", // For jakarta-data-api.jar
         };
 
         // The JDK modules we want added to our classpath
@@ -108,7 +110,7 @@ public class DataSignatureTestRunner extends SigTestEE {
 
         // Get JDK modules from jimage
         // Add JDK classes to classpath
-        File jimageOutput = new File(testInfo.getJImageDir());
+        File jimageOutput = new File(TestProperty.signatureImageDir.getValue());
         for (String module : jdkModules) {
             Path modulePath = Paths.get(jimageOutput.getAbsolutePath(), module);
             if (Files.isDirectory(modulePath)) {
@@ -236,7 +238,7 @@ public class DataSignatureTestRunner extends SigTestEE {
         ArrayList<String> unlistedTechnologyPkgs = getUnlistedOptionalPackages();
 
         // Need to extract java modules into classes
-        String jimageDir = testInfo.getJImageDir();
+        String jimageDir = TestProperty.signatureImageDir.getValue();
         File f = new File(jimageDir);
         f.mkdirs();
 
@@ -304,21 +306,21 @@ public class DataSignatureTestRunner extends SigTestEE {
         // Ensure that jimage directory is set.
         // This is where modules will be converted back to .class files for use in
         // signature testing
-        assertNotNull(System.getProperty("jimage.dir"),
+        assertNotNull(TestProperty.signatureImageDir.getValue(),
                 "The system property jimage.dir must be set in order to run the Signature test.");
 
         if (standalone) {
             // Ensure that a test classpath is set
             // The signature test plugin runs tests on a forked JVM that uses a separate
             // classpath.
-            assertNotNull(System.getProperty("signature.sigTestClasspath"),
+            assertNotNull(TestProperty.signatureClasspath.getValue(),
                     "The system property signature.sigTestClasspath must be set in order to run the Signature test.");
         }
 
-        // Ensure user is running on JDK 11 or higher, different JDKs produce different
-        // signatures
+        // Ensure user is running on JDK 17 or higher, different JDKs produce different signatures
+        // TODO update to JDK 21 once it is GA
         int javaSpecVersion = Integer.parseInt(System.getProperty("java.specification.version"));
-        assertTrue(javaSpecVersion >= 11, "The signature tests must be run on a JVM using Java 11 or higher.");
+        assertTrue(javaSpecVersion >= 17, "The signature tests must be run on a JVM using Java 17 or higher.");
 
         // Ensure user has the correct security/JDK settings to allow the plugin access
         // to internal JDK classes.

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/signature/SigTestData.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/signature/SigTestData.java
@@ -68,8 +68,4 @@ public class SigTestData {
     public String getJtaJarClasspath() {
         return props.getProperty("jtaJarClasspath", "");
     }
-
-    public String getJImageDir() {
-        return TestProperty.signatureImageDir.getValue();
-    }
 } // end class SigTestData

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/signature/SigTestEE.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/signature/SigTestEE.java
@@ -24,6 +24,8 @@ import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Properties;
 
+import ee.jakarta.tck.data.framework.utilities.TestProperty;
+
 /**
  * This class should be extended by TCK developers that wish to create a set of
  * signature tests that run inside all the Java EE containers. Developers must
@@ -251,7 +253,7 @@ public abstract class SigTestEE {
         Properties sysProps = System.getProperties();
         String version = (String) sysProps.get("java.version");
         if (!version.startsWith("1.")) {
-            String jimageDir = testInfo.getJImageDir();
+            String jimageDir = TestProperty.signatureImageDir.getValue();
             File f = new File(jimageDir);
             f.mkdirs();
 

--- a/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/jakarta.data.sig_17
+++ b/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/jakarta.data.sig_17
@@ -1,47 +1,47 @@
 #Signature file v4.1
 #Version 1.0.0-SNAPSHOT
 
-CLSS public abstract interface !annotation jakarta.data.Entity
- anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
- anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
-intf java.lang.annotation.Annotation
-meth public abstract !hasdefault java.lang.String value()
-
-CLSS public abstract interface !annotation jakarta.data.Id
- anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
- anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[FIELD])
-intf java.lang.annotation.Annotation
-meth public abstract !hasdefault java.lang.String value()
-
 CLSS public jakarta.data.exceptions.DataConnectionException
 cons public init(java.lang.String)
 cons public init(java.lang.String,java.lang.Throwable)
 cons public init(java.lang.Throwable)
 supr jakarta.data.exceptions.DataException
+hfds serialVersionUID
 
 CLSS public jakarta.data.exceptions.DataException
 cons public init(java.lang.String)
 cons public init(java.lang.String,java.lang.Throwable)
 cons public init(java.lang.Throwable)
 supr java.lang.RuntimeException
+hfds serialVersionUID
 
 CLSS public jakarta.data.exceptions.EmptyResultException
 cons public init(java.lang.String)
 cons public init(java.lang.String,java.lang.Throwable)
 cons public init(java.lang.Throwable)
 supr jakarta.data.exceptions.DataException
+hfds serialVersionUID
 
 CLSS public jakarta.data.exceptions.MappingException
 cons public init(java.lang.String)
 cons public init(java.lang.String,java.lang.Throwable)
 cons public init(java.lang.Throwable)
 supr jakarta.data.exceptions.DataException
+hfds serialVersionUID
 
 CLSS public jakarta.data.exceptions.NonUniqueResultException
 cons public init(java.lang.String)
 cons public init(java.lang.String,java.lang.Throwable)
 cons public init(java.lang.Throwable)
 supr jakarta.data.exceptions.DataException
+hfds serialVersionUID
+
+CLSS public jakarta.data.exceptions.OptimisticLockingFailureException
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr jakarta.data.exceptions.DataException
+hfds serialVersionUID
 
 CLSS abstract interface jakarta.data.exceptions.package-info
 
@@ -82,11 +82,15 @@ meth public abstract jakarta.data.repository.Pageable previousPageable()
 meth public abstract jakarta.data.repository.Pageable$Cursor getKeysetCursor(int)
 
 CLSS public final jakarta.data.repository.Limit
-meth public long maxResults()
+cons public init(int,long)
+meth public final boolean equals(java.lang.Object)
+meth public final int hashCode()
+meth public final java.lang.String toString()
+meth public int maxResults()
 meth public long startAt()
-meth public static jakarta.data.repository.Limit of(long)
+meth public static jakarta.data.repository.Limit of(int)
 meth public static jakarta.data.repository.Limit range(long,long)
-supr java.lang.Object
+supr java.lang.Record
 hfds DEFAULT_START_AT,maxResults,startAt
 
 CLSS public abstract interface !annotation jakarta.data.repository.OrderBy
@@ -96,6 +100,7 @@ CLSS public abstract interface !annotation jakarta.data.repository.OrderBy
 innr public abstract interface static !annotation List
 intf java.lang.annotation.Annotation
 meth public abstract !hasdefault boolean descending()
+meth public abstract !hasdefault boolean ignoreCase()
 meth public abstract java.lang.String value()
 
 CLSS public abstract interface static !annotation jakarta.data.repository.OrderBy$List
@@ -120,9 +125,9 @@ meth public abstract boolean equals(java.lang.Object)
 meth public abstract int size()
 meth public abstract jakarta.data.repository.Pageable afterKeysetCursor(jakarta.data.repository.Pageable$Cursor)
 meth public abstract jakarta.data.repository.Pageable beforeKeysetCursor(jakarta.data.repository.Pageable$Cursor)
-meth public abstract jakarta.data.repository.Pageable newPage(long)
-meth public abstract jakarta.data.repository.Pageable newSize(int)
 meth public abstract jakarta.data.repository.Pageable next()
+meth public abstract jakarta.data.repository.Pageable page(long)
+meth public abstract jakarta.data.repository.Pageable size(int)
 meth public abstract jakarta.data.repository.Pageable sortBy(java.lang.Iterable<jakarta.data.repository.Sort>)
 meth public abstract jakarta.data.repository.Pageable$Cursor cursor()
 meth public abstract jakarta.data.repository.Pageable$Mode mode()
@@ -165,14 +170,15 @@ intf java.lang.annotation.Annotation
 meth public abstract !hasdefault java.lang.String count()
 meth public abstract java.lang.String value()
 
-CLSS public abstract interface jakarta.data.repository.ReactiveRepository<%0 extends java.lang.Object, %1 extends java.lang.Object>
-intf jakarta.data.repository.DataRepository<{jakarta.data.repository.ReactiveRepository%0},{jakarta.data.repository.ReactiveRepository%1}>
-
 CLSS public abstract interface !annotation jakarta.data.repository.Repository
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
+fld public final static java.lang.String ANY_PROVIDER = ""
+fld public final static java.lang.String DEFAULT_DATA_STORE = ""
 intf java.lang.annotation.Annotation
+meth public abstract !hasdefault java.lang.String dataStore()
+meth public abstract !hasdefault java.lang.String provider()
 
 CLSS public abstract interface jakarta.data.repository.Slice<%0 extends java.lang.Object>
 intf jakarta.data.repository.Streamable<{jakarta.data.repository.Slice%0}>
@@ -183,17 +189,21 @@ meth public abstract jakarta.data.repository.Pageable pageable()
 meth public abstract java.util.List<{jakarta.data.repository.Slice%0}> content()
 
 CLSS public final jakarta.data.repository.Sort
-meth public boolean equals(java.lang.Object)
+cons public init(java.lang.String,boolean,boolean)
+meth public boolean ignoreCase()
 meth public boolean isAscending()
 meth public boolean isDescending()
-meth public int hashCode()
+meth public final boolean equals(java.lang.Object)
+meth public final int hashCode()
+meth public final java.lang.String toString()
 meth public java.lang.String property()
-meth public java.lang.String toString()
 meth public static jakarta.data.repository.Sort asc(java.lang.String)
+meth public static jakarta.data.repository.Sort ascIgnoreCase(java.lang.String)
 meth public static jakarta.data.repository.Sort desc(java.lang.String)
-meth public static jakarta.data.repository.Sort of(java.lang.String,jakarta.data.repository.Direction)
-supr java.lang.Object
-hfds direction,property
+meth public static jakarta.data.repository.Sort descIgnoreCase(java.lang.String)
+meth public static jakarta.data.repository.Sort of(java.lang.String,jakarta.data.repository.Direction,boolean)
+supr java.lang.Record
+hfds ignoreCase,isAscending,property
 
 CLSS public abstract interface jakarta.data.repository.Streamable<%0 extends java.lang.Object>
  anno 0 java.lang.FunctionalInterface()
@@ -209,8 +219,10 @@ meth public abstract int compareTo({java.lang.Comparable%0})
 
 CLSS public abstract java.lang.Enum<%0 extends java.lang.Enum<{java.lang.Enum%0}>>
 cons protected init(java.lang.String,int)
+innr public final static EnumDesc
 intf java.io.Serializable
 intf java.lang.Comparable<{java.lang.Enum%0}>
+intf java.lang.constant.Constable
 meth protected final java.lang.Object clone() throws java.lang.CloneNotSupportedException
 meth protected final void finalize()
 meth public final boolean equals(java.lang.Object)
@@ -219,9 +231,11 @@ meth public final int hashCode()
 meth public final int ordinal()
 meth public final java.lang.Class<{java.lang.Enum%0}> getDeclaringClass()
 meth public final java.lang.String name()
+meth public final java.util.Optional<java.lang.Enum$EnumDesc<{java.lang.Enum%0}>> describeConstable()
 meth public java.lang.String toString()
 meth public static <%0 extends java.lang.Enum<{%%0}>> {%%0} valueOf(java.lang.Class<{%%0}>,java.lang.String)
 supr java.lang.Object
+hfds name,ordinal
 
 CLSS public java.lang.Exception
 cons protected init(java.lang.String,java.lang.Throwable,boolean,boolean)
@@ -230,6 +244,7 @@ cons public init(java.lang.String)
 cons public init(java.lang.String,java.lang.Throwable)
 cons public init(java.lang.Throwable)
 supr java.lang.Throwable
+hfds serialVersionUID
 
 CLSS public abstract interface !annotation java.lang.FunctionalInterface
  anno 0 java.lang.annotation.Documented()
@@ -257,6 +272,13 @@ meth public final void wait(long,int) throws java.lang.InterruptedException
 meth public int hashCode()
 meth public java.lang.String toString()
 
+CLSS public abstract java.lang.Record
+cons protected init()
+meth public abstract boolean equals(java.lang.Object)
+meth public abstract int hashCode()
+meth public abstract java.lang.String toString()
+supr java.lang.Object
+
 CLSS public java.lang.RuntimeException
 cons protected init(java.lang.String,java.lang.Throwable,boolean,boolean)
 cons public init()
@@ -264,6 +286,7 @@ cons public init(java.lang.String)
 cons public init(java.lang.String,java.lang.Throwable)
 cons public init(java.lang.Throwable)
 supr java.lang.Exception
+hfds serialVersionUID
 
 CLSS public java.lang.Throwable
 cons protected init(java.lang.String,java.lang.Throwable,boolean,boolean)
@@ -286,6 +309,8 @@ meth public void printStackTrace(java.io.PrintStream)
 meth public void printStackTrace(java.io.PrintWriter)
 meth public void setStackTrace(java.lang.StackTraceElement[])
 supr java.lang.Object
+hfds CAUSE_CAPTION,EMPTY_THROWABLE_ARRAY,NULL_CAUSE_MESSAGE,SELF_SUPPRESSION_MESSAGE,SUPPRESSED_CAPTION,SUPPRESSED_SENTINEL,UNASSIGNED_STACK,backtrace,cause,depth,detailMessage,serialVersionUID,stackTrace,suppressedExceptions
+hcls PrintStreamOrWriter,SentinelHolder,WrappedPrintStream,WrappedPrintWriter
 
 CLSS public abstract interface java.lang.annotation.Annotation
 meth public abstract boolean equals(java.lang.Object)
@@ -319,4 +344,7 @@ CLSS public abstract interface !annotation java.lang.annotation.Target
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[ANNOTATION_TYPE])
 intf java.lang.annotation.Annotation
 meth public abstract java.lang.annotation.ElementType[] value()
+
+CLSS public abstract interface java.lang.constant.Constable
+meth public abstract java.util.Optional<? extends java.lang.constant.ConstantDesc> describeConstable()
 

--- a/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/jakarta.data.sig_21
+++ b/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/jakarta.data.sig_21
@@ -1,0 +1,351 @@
+#Signature file v4.1
+#Version 1.0.0-SNAPSHOT
+
+CLSS public jakarta.data.exceptions.DataConnectionException
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr jakarta.data.exceptions.DataException
+hfds serialVersionUID
+
+CLSS public jakarta.data.exceptions.DataException
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr java.lang.RuntimeException
+hfds serialVersionUID
+
+CLSS public jakarta.data.exceptions.EmptyResultException
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr jakarta.data.exceptions.DataException
+hfds serialVersionUID
+
+CLSS public jakarta.data.exceptions.MappingException
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr jakarta.data.exceptions.DataException
+hfds serialVersionUID
+
+CLSS public jakarta.data.exceptions.NonUniqueResultException
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr jakarta.data.exceptions.DataException
+hfds serialVersionUID
+
+CLSS public jakarta.data.exceptions.OptimisticLockingFailureException
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr jakarta.data.exceptions.DataException
+hfds serialVersionUID
+
+CLSS abstract interface jakarta.data.exceptions.package-info
+
+CLSS abstract interface jakarta.data.package-info
+
+CLSS public abstract interface jakarta.data.repository.CrudRepository<%0 extends java.lang.Object, %1 extends java.lang.Object>
+intf jakarta.data.repository.DataRepository<{jakarta.data.repository.CrudRepository%0},{jakarta.data.repository.CrudRepository%1}>
+meth public abstract <%0 extends {jakarta.data.repository.CrudRepository%0}> java.lang.Iterable<{%%0}> saveAll(java.lang.Iterable<{%%0}>)
+meth public abstract <%0 extends {jakarta.data.repository.CrudRepository%0}> {%%0} save({%%0})
+meth public abstract boolean existsById({jakarta.data.repository.CrudRepository%1})
+meth public abstract java.util.Optional<{jakarta.data.repository.CrudRepository%0}> findById({jakarta.data.repository.CrudRepository%1})
+meth public abstract java.util.stream.Stream<{jakarta.data.repository.CrudRepository%0}> findAll()
+meth public abstract java.util.stream.Stream<{jakarta.data.repository.CrudRepository%0}> findAllById(java.lang.Iterable<{jakarta.data.repository.CrudRepository%1}>)
+meth public abstract long count()
+meth public abstract void delete({jakarta.data.repository.CrudRepository%0})
+meth public abstract void deleteAll()
+meth public abstract void deleteAll(java.lang.Iterable<? extends {jakarta.data.repository.CrudRepository%0}>)
+meth public abstract void deleteAllById(java.lang.Iterable<{jakarta.data.repository.CrudRepository%1}>)
+meth public abstract void deleteById({jakarta.data.repository.CrudRepository%1})
+
+CLSS public abstract interface jakarta.data.repository.DataRepository<%0 extends java.lang.Object, %1 extends java.lang.Object>
+
+CLSS public final !enum jakarta.data.repository.Direction
+fld public final static jakarta.data.repository.Direction ASC
+fld public final static jakarta.data.repository.Direction DESC
+meth public static jakarta.data.repository.Direction valueOf(java.lang.String)
+meth public static jakarta.data.repository.Direction[] values()
+supr java.lang.Enum<jakarta.data.repository.Direction>
+
+CLSS public abstract interface jakarta.data.repository.KeysetAwarePage<%0 extends java.lang.Object>
+intf jakarta.data.repository.KeysetAwareSlice<{jakarta.data.repository.KeysetAwarePage%0}>
+intf jakarta.data.repository.Page<{jakarta.data.repository.KeysetAwarePage%0}>
+
+CLSS public abstract interface jakarta.data.repository.KeysetAwareSlice<%0 extends java.lang.Object>
+intf jakarta.data.repository.Slice<{jakarta.data.repository.KeysetAwareSlice%0}>
+meth public abstract jakarta.data.repository.Pageable nextPageable()
+meth public abstract jakarta.data.repository.Pageable previousPageable()
+meth public abstract jakarta.data.repository.Pageable$Cursor getKeysetCursor(int)
+
+CLSS public final jakarta.data.repository.Limit
+cons public init(int,long)
+meth public final boolean equals(java.lang.Object)
+meth public final int hashCode()
+meth public final java.lang.String toString()
+meth public int maxResults()
+meth public long startAt()
+meth public static jakarta.data.repository.Limit of(int)
+meth public static jakarta.data.repository.Limit range(long,long)
+supr java.lang.Record
+hfds DEFAULT_START_AT,maxResults,startAt
+
+CLSS public abstract interface !annotation jakarta.data.repository.OrderBy
+ anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.data.repository.OrderBy$List)
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD])
+innr public abstract interface static !annotation List
+intf java.lang.annotation.Annotation
+meth public abstract !hasdefault boolean descending()
+meth public abstract !hasdefault boolean ignoreCase()
+meth public abstract java.lang.String value()
+
+CLSS public abstract interface static !annotation jakarta.data.repository.OrderBy$List
+ outer jakarta.data.repository.OrderBy
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD])
+intf java.lang.annotation.Annotation
+meth public abstract jakarta.data.repository.OrderBy[] value()
+
+CLSS public abstract interface jakarta.data.repository.Page<%0 extends java.lang.Object>
+intf jakarta.data.repository.Slice<{jakarta.data.repository.Page%0}>
+meth public abstract long totalElements()
+meth public abstract long totalPages()
+
+CLSS public abstract interface jakarta.data.repository.Pageable
+innr public abstract interface static Cursor
+innr public final static !enum Mode
+meth public abstract !varargs jakarta.data.repository.Pageable afterKeyset(java.lang.Object[])
+meth public abstract !varargs jakarta.data.repository.Pageable beforeKeyset(java.lang.Object[])
+meth public abstract !varargs jakarta.data.repository.Pageable sortBy(jakarta.data.repository.Sort[])
+meth public abstract boolean equals(java.lang.Object)
+meth public abstract int size()
+meth public abstract jakarta.data.repository.Pageable afterKeysetCursor(jakarta.data.repository.Pageable$Cursor)
+meth public abstract jakarta.data.repository.Pageable beforeKeysetCursor(jakarta.data.repository.Pageable$Cursor)
+meth public abstract jakarta.data.repository.Pageable next()
+meth public abstract jakarta.data.repository.Pageable page(long)
+meth public abstract jakarta.data.repository.Pageable size(int)
+meth public abstract jakarta.data.repository.Pageable sortBy(java.lang.Iterable<jakarta.data.repository.Sort>)
+meth public abstract jakarta.data.repository.Pageable$Cursor cursor()
+meth public abstract jakarta.data.repository.Pageable$Mode mode()
+meth public abstract java.util.List<jakarta.data.repository.Sort> sorts()
+meth public abstract long page()
+meth public static jakarta.data.repository.Pageable ofPage(long)
+meth public static jakarta.data.repository.Pageable ofSize(int)
+
+CLSS public abstract interface static jakarta.data.repository.Pageable$Cursor
+ outer jakarta.data.repository.Pageable
+meth public abstract boolean equals(java.lang.Object)
+meth public abstract int hashCode()
+meth public abstract int size()
+meth public abstract java.lang.Object getKeysetElement(int)
+meth public abstract java.lang.String toString()
+
+CLSS public final static !enum jakarta.data.repository.Pageable$Mode
+ outer jakarta.data.repository.Pageable
+fld public final static jakarta.data.repository.Pageable$Mode CURSOR_NEXT
+fld public final static jakarta.data.repository.Pageable$Mode CURSOR_PREVIOUS
+fld public final static jakarta.data.repository.Pageable$Mode OFFSET
+meth public static jakarta.data.repository.Pageable$Mode valueOf(java.lang.String)
+meth public static jakarta.data.repository.Pageable$Mode[] values()
+supr java.lang.Enum<jakarta.data.repository.Pageable$Mode>
+
+CLSS public abstract interface jakarta.data.repository.PageableRepository<%0 extends java.lang.Object, %1 extends java.lang.Object>
+intf jakarta.data.repository.CrudRepository<{jakarta.data.repository.PageableRepository%0},{jakarta.data.repository.PageableRepository%1}>
+meth public abstract jakarta.data.repository.Page<{jakarta.data.repository.PageableRepository%0}> findAll(jakarta.data.repository.Pageable)
+
+CLSS public abstract interface !annotation jakarta.data.repository.Param
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[PARAMETER])
+intf java.lang.annotation.Annotation
+meth public abstract java.lang.String value()
+
+CLSS public abstract interface !annotation jakarta.data.repository.Query
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD])
+intf java.lang.annotation.Annotation
+meth public abstract !hasdefault java.lang.String count()
+meth public abstract java.lang.String value()
+
+CLSS public abstract interface !annotation jakarta.data.repository.Repository
+ anno 0 java.lang.annotation.Documented()
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
+fld public final static java.lang.String ANY_PROVIDER = ""
+fld public final static java.lang.String DEFAULT_DATA_STORE = ""
+intf java.lang.annotation.Annotation
+meth public abstract !hasdefault java.lang.String dataStore()
+meth public abstract !hasdefault java.lang.String provider()
+
+CLSS public abstract interface jakarta.data.repository.Slice<%0 extends java.lang.Object>
+intf jakarta.data.repository.Streamable<{jakarta.data.repository.Slice%0}>
+meth public abstract boolean hasContent()
+meth public abstract int numberOfElements()
+meth public abstract jakarta.data.repository.Pageable nextPageable()
+meth public abstract jakarta.data.repository.Pageable pageable()
+meth public abstract java.util.List<{jakarta.data.repository.Slice%0}> content()
+
+CLSS public final jakarta.data.repository.Sort
+cons public init(java.lang.String,boolean,boolean)
+meth public boolean ignoreCase()
+meth public boolean isAscending()
+meth public boolean isDescending()
+meth public final boolean equals(java.lang.Object)
+meth public final int hashCode()
+meth public final java.lang.String toString()
+meth public java.lang.String property()
+meth public static jakarta.data.repository.Sort asc(java.lang.String)
+meth public static jakarta.data.repository.Sort ascIgnoreCase(java.lang.String)
+meth public static jakarta.data.repository.Sort desc(java.lang.String)
+meth public static jakarta.data.repository.Sort descIgnoreCase(java.lang.String)
+meth public static jakarta.data.repository.Sort of(java.lang.String,jakarta.data.repository.Direction,boolean)
+supr java.lang.Record
+hfds ignoreCase,isAscending,property
+
+CLSS public abstract interface jakarta.data.repository.Streamable<%0 extends java.lang.Object>
+ anno 0 java.lang.FunctionalInterface()
+intf java.lang.Iterable<{jakarta.data.repository.Streamable%0}>
+meth public java.util.stream.Stream<{jakarta.data.repository.Streamable%0}> stream()
+
+CLSS abstract interface jakarta.data.repository.package-info
+
+CLSS public abstract interface java.io.Serializable
+
+CLSS public abstract interface java.lang.Comparable<%0 extends java.lang.Object>
+meth public abstract int compareTo({java.lang.Comparable%0})
+
+CLSS public abstract java.lang.Enum<%0 extends java.lang.Enum<{java.lang.Enum%0}>>
+cons protected init(java.lang.String,int)
+innr public final static EnumDesc
+intf java.io.Serializable
+intf java.lang.Comparable<{java.lang.Enum%0}>
+intf java.lang.constant.Constable
+meth protected final java.lang.Object clone() throws java.lang.CloneNotSupportedException
+meth protected final void finalize()
+ anno 0 java.lang.Deprecated(boolean forRemoval=true, java.lang.String since="18")
+meth public final boolean equals(java.lang.Object)
+meth public final int compareTo({java.lang.Enum%0})
+meth public final int hashCode()
+meth public final int ordinal()
+meth public final java.lang.Class<{java.lang.Enum%0}> getDeclaringClass()
+meth public final java.lang.String name()
+meth public final java.util.Optional<java.lang.Enum$EnumDesc<{java.lang.Enum%0}>> describeConstable()
+meth public java.lang.String toString()
+meth public static <%0 extends java.lang.Enum<{%%0}>> {%%0} valueOf(java.lang.Class<{%%0}>,java.lang.String)
+supr java.lang.Object
+hfds hash,name,ordinal
+
+CLSS public java.lang.Exception
+cons protected init(java.lang.String,java.lang.Throwable,boolean,boolean)
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr java.lang.Throwable
+hfds serialVersionUID
+
+CLSS public abstract interface !annotation java.lang.FunctionalInterface
+ anno 0 java.lang.annotation.Documented()
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
+intf java.lang.annotation.Annotation
+
+CLSS public abstract interface java.lang.Iterable<%0 extends java.lang.Object>
+meth public abstract java.util.Iterator<{java.lang.Iterable%0}> iterator()
+meth public java.util.Spliterator<{java.lang.Iterable%0}> spliterator()
+meth public void forEach(java.util.function.Consumer<? super {java.lang.Iterable%0}>)
+
+CLSS public java.lang.Object
+cons public init()
+meth protected java.lang.Object clone() throws java.lang.CloneNotSupportedException
+meth protected void finalize() throws java.lang.Throwable
+ anno 0 java.lang.Deprecated(boolean forRemoval=true, java.lang.String since="9")
+meth public boolean equals(java.lang.Object)
+meth public final java.lang.Class<?> getClass()
+meth public final void notify()
+meth public final void notifyAll()
+meth public final void wait() throws java.lang.InterruptedException
+meth public final void wait(long) throws java.lang.InterruptedException
+meth public final void wait(long,int) throws java.lang.InterruptedException
+meth public int hashCode()
+meth public java.lang.String toString()
+
+CLSS public abstract java.lang.Record
+cons protected init()
+meth public abstract boolean equals(java.lang.Object)
+meth public abstract int hashCode()
+meth public abstract java.lang.String toString()
+supr java.lang.Object
+
+CLSS public java.lang.RuntimeException
+cons protected init(java.lang.String,java.lang.Throwable,boolean,boolean)
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr java.lang.Exception
+hfds serialVersionUID
+
+CLSS public java.lang.Throwable
+cons protected init(java.lang.String,java.lang.Throwable,boolean,boolean)
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+intf java.io.Serializable
+meth public final java.lang.Throwable[] getSuppressed()
+meth public final void addSuppressed(java.lang.Throwable)
+meth public java.lang.StackTraceElement[] getStackTrace()
+meth public java.lang.String getLocalizedMessage()
+meth public java.lang.String getMessage()
+meth public java.lang.String toString()
+meth public java.lang.Throwable fillInStackTrace()
+meth public java.lang.Throwable getCause()
+meth public java.lang.Throwable initCause(java.lang.Throwable)
+meth public void printStackTrace()
+meth public void printStackTrace(java.io.PrintStream)
+meth public void printStackTrace(java.io.PrintWriter)
+meth public void setStackTrace(java.lang.StackTraceElement[])
+supr java.lang.Object
+hfds CAUSE_CAPTION,EMPTY_THROWABLE_ARRAY,NULL_CAUSE_MESSAGE,SELF_SUPPRESSION_MESSAGE,SUPPRESSED_CAPTION,SUPPRESSED_SENTINEL,UNASSIGNED_STACK,backtrace,cause,depth,detailMessage,serialVersionUID,stackTrace,suppressedExceptions
+hcls PrintStreamOrWriter,SentinelHolder,WrappedPrintStream,WrappedPrintWriter
+
+CLSS public abstract interface java.lang.annotation.Annotation
+meth public abstract boolean equals(java.lang.Object)
+meth public abstract int hashCode()
+meth public abstract java.lang.Class<? extends java.lang.annotation.Annotation> annotationType()
+meth public abstract java.lang.String toString()
+
+CLSS public abstract interface !annotation java.lang.annotation.Documented
+ anno 0 java.lang.annotation.Documented()
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[ANNOTATION_TYPE])
+intf java.lang.annotation.Annotation
+
+CLSS public abstract interface !annotation java.lang.annotation.Repeatable
+ anno 0 java.lang.annotation.Documented()
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[ANNOTATION_TYPE])
+intf java.lang.annotation.Annotation
+meth public abstract java.lang.Class<? extends java.lang.annotation.Annotation> value()
+
+CLSS public abstract interface !annotation java.lang.annotation.Retention
+ anno 0 java.lang.annotation.Documented()
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[ANNOTATION_TYPE])
+intf java.lang.annotation.Annotation
+meth public abstract java.lang.annotation.RetentionPolicy value()
+
+CLSS public abstract interface !annotation java.lang.annotation.Target
+ anno 0 java.lang.annotation.Documented()
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[ANNOTATION_TYPE])
+intf java.lang.annotation.Annotation
+meth public abstract java.lang.annotation.ElementType[] value()
+
+CLSS public abstract interface java.lang.constant.Constable
+meth public abstract java.util.Optional<? extends java.lang.constant.ConstantDesc> describeConstable()
+


### PR DESCRIPTION
Noticed some issues when compiling and running using Java 21. 
- Updated our CI build to use Java 21 to verify we do not introduce breaking changes
- Updates signature test files to have two versions, one for Java 17 and one for Java 21
- Improved the signature file generation to automatically convert JDK modules to classes
- Removed the need to export the signature plugin to a Jakarta Platform when running in EE mode