### PR TITLE
TCK needs to know which exception to catch for constraint violations

### DIFF
--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -30,8 +30,11 @@ import java.util.stream.Stream;
 public interface CrudRepository<T, K> extends DataRepository<T, K> {
 
     /**
-     * Saves a given entity. Use the returned instance for further operations as the save operation might have changed the
-     * entity instance completely.
+     * <p>Saves a given entity. Use the returned instance for further operations as the save operation might have changed the
+     * entity instance completely.</p>
+     *
+     * <p>This method raises {@code jakarta.validation.ConstraintViolationException} prior to saving the entity to the database
+     * if a Jakarta Validation provider is present and the entity is in violation of one or more validation constraints.</p>
      *
      * @param entity the entity to be saved
      * @param <S> type of entity to save
@@ -43,7 +46,10 @@ public interface CrudRepository<T, K> extends DataRepository<T, K> {
     <S extends T> S save(S entity);
 
     /**
-     * Saves all given entities.
+     * <p>Saves all given entities.</p>
+     *
+     * <p>This method raises {@code jakarta.validation.ConstraintViolationException} prior to saving the entities to the database
+     * if a Jakarta Validation provider is present and any of the entities are in violation of one or more validation constraints.</p>
      *
      * @param entities an iterable of entities
      * @param <S> type of entity to save

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -509,6 +509,13 @@ import jakarta.data.repository.Sort;
  *                                 Sort.asc("name"));
  * </pre>
  *
+ * <h2>Jakarta Validation</h2>
+ *
+ * <p>When a Jakarta Validation provider is present, validation constraints that are defined for entities
+ * are automatically applied by the {@code save} and {@code saveAll} repository operations prior to saving
+ * entities to the database. These methods raise {@code jakarta.validation.ConstraintViolationException}
+ * if an entity is in violation of one or more validation constraints.</p>
+ *
  * <h2>Jakarta Transactions</h2>
  *
  * <p>Repository methods can participate in global transactions.


### PR DESCRIPTION
In order for the TCK to be able to test constraint violations, we need to specify what exception is raised in that case - whether TCK tests should trap for `jakarta.validation.ConstraintViolationException` or `DataException` with a chained `jakarta.validation.ConstraintViolationException` or other.   Just `jakarta.validation.ConstraintViolationException` seems like the cleanest and most direct, so that's what I put under this pull.