### PR TITLE
tests for findFirst, CrudRepository and PageableRepository

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
@@ -21,6 +21,7 @@ import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Page;
 import jakarta.data.repository.Pageable;
 import jakarta.data.repository.Repository;
+import jakarta.data.repository.Sort;
 import jakarta.data.repository.Streamable;
 
 /**
@@ -44,6 +45,10 @@ public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long> {
     Page<AsciiCharacter> findByNumericValueBetween(int min, int max, Pageable pagination);
 
     Streamable<AsciiCharacter> findByNumericValueLessThanEqualAndNumericValueGreaterThanEqual(int max, int min);
+
+    AsciiCharacter[] findFirst3ByNumericValueGreaterThanEqualAndHexadecimalEndsWith(long minValue, String lastHexDigit, Sort sort);
+
+    Optional<AsciiCharacter> findFirstByHexadecimalStartsWithAndIsControlOrderByIdAsc(String firstHexDigit, boolean isControlChar);
 
     Iterable<AsciiCharacter> saveAll(Iterable<AsciiCharacter> characters);
 

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/PositiveIntegers.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/PositiveIntegers.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.framework.read.only;
+
+import jakarta.data.repository.PageableRepository;
+import jakarta.data.repository.Repository;
+
+/**
+ * This is a read only repository that shares the same data (and entity type)
+ * as the NaturalNumbers repository: the positive integers 1-100.
+ * This repository is pre-populated at test startup and verified prior to running tests.
+ */
+@Repository
+public interface PositiveIntegers extends PageableRepository<NaturalNumber, Long> {
+}


### PR DESCRIPTION
Test for these TCK scenarios from #133

- Use the findAll method of a repository that inherits from PageableRepository to request a Page 2 of size 12, specifying a Pageable that requires a mixture of ascending and descending sort. Verify the page contains all 12 expected entities, sorted according to the mixture of ascending and descending sort orders specified.
- Use a repository that inherits from CrudRepository and adds some methods of its own. Use both built-in methods and the additional methods.
- Use a repository method findFirstBy... that returns the first entity value where multiple results would otherwise be found.
- Use a repository method findFirst3By... that returns the first 3 results.