### PR TITLE
Fix TCK signature testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
         <checkstyle.excludes></checkstyle.excludes>
         <jacoco.maven.version>0.8.10</jacoco.maven.version>
         <sigtest.version>1.6</sigtest.version> <!-- TODO update to 1.8 once this fix is added https://github.com/jtulach/netbeans-apitest/commit/72a3d3507202357589d77b293cb1e29349a0096e -->
+        <shrinkwrap.resolver.version>3.2.1</shrinkwrap.resolver.version>
         <sonar.jacoco.reportPath>../target/jacoco.exec</sonar.jacoco.reportPath>
         <sonar.maven.version>3.9.1.2184</sonar.maven.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,6 @@
         <checkstyle.excludes></checkstyle.excludes>
         <jacoco.maven.version>0.8.10</jacoco.maven.version>
         <sigtest.version>1.6</sigtest.version> <!-- TODO update to 1.8 once this fix is added https://github.com/jtulach/netbeans-apitest/commit/72a3d3507202357589d77b293cb1e29349a0096e -->
-        <shrinkwrap.resolver.version>3.2.1</shrinkwrap.resolver.version>
         <sonar.jacoco.reportPath>../target/jacoco.exec</sonar.jacoco.reportPath>
         <sonar.maven.version>3.9.1.2184</sonar.maven.version>
     </properties>

--- a/tck-dist/src/main/asciidoc/sections/05inventory.adoc
+++ b/tck-dist/src/main/asciidoc/sections/05inventory.adoc
@@ -49,9 +49,10 @@ Signature tests exist at the standalone level which means they will run in any m
 
 ===== API Signature Files
 
-One signature file exists for both Java {JavaVersion1} and {JavaVersion2}:
+One signature file exists per Java version {JavaVersion1} and {JavaVersion2}:
 
-1. `artifacts/jakarta.data.sig`
+1. `artifacts/jakarta.data.sig_{JavaVersion1}`
+1. `artifacts/jakarta.data.sig_{JavaVersion2}`
 
 This signature file is for reference only.
 A copy of the signature file is included in the {APILongName} TCK test jar.

--- a/tck-dist/src/main/assembly/assembly.xml
+++ b/tck-dist/src/main/assembly/assembly.xml
@@ -67,7 +67,7 @@
       <directory>${project.parent.basedir}/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/</directory>
       <outputDirectory>/artifacts</outputDirectory>
       <includes>
-      	<include>**/*.sig*</include>
+          <include>**/*.sig*</include>
       </includes>
     </fileSet>
   </fileSets>

--- a/tck-dist/src/main/starter/ee-pom.xml
+++ b/tck-dist/src/main/starter/ee-pom.xml
@@ -172,9 +172,9 @@
      </systemPropertyVariables>
      <!-- end::systemProperties[] -->
      <!-- Supported tags 
-     	Profiles:[core|web|full] 
-     	Entities:[nosql|persistence] 
-     	Other:   [signature] -->
+         Profiles:[core|web|full] 
+         Entities:[nosql|persistence] 
+         Other:   [signature] -->
      <groups>[TODO]</groups>
      <!-- If running back-to-back tests at different levels 
      use this to distinguish the results -->

--- a/tck-dist/src/main/starter/se-pom.xml
+++ b/tck-dist/src/main/starter/se-pom.xml
@@ -159,8 +159,8 @@
      </systemPropertyVariables>
      <!-- end::systemProperties[] -->
      <!-- Supported tags 
-     	Entities:[nosql|persistence] 
-     	Other:   [signature] -->
+         Entities:[nosql|persistence] 
+         Other:   [signature] -->
      <groups>standalone</groups>
      <!-- If running back-to-back tests at different levels
       use this to distinguish the results -->

--- a/tck-dist/src/main/starter/src/test/resources/arquillian.xml
+++ b/tck-dist/src/main/starter/src/test/resources/arquillian.xml
@@ -15,23 +15,23 @@
  ~ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
   -->
 <arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns="http://jboss.org/schema/arquillian"
-	xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
-	
-	<engine>
-		<property name="deploymentExportPath">target/</property>
-	</engine>
-	
-	<container qualifier="[YOUR-CONTAINER-IMPL]" default="true">
-		<configuration>
-			<!-- Each variable used is set in surefire config in running pom.xml -->
-			<property name="serverName">${tck_server}</property>
-			<property name="hostName">${tck_hostname}</property>
-			<property name="username">${tck_username}</property>
-			<property name="password">${tck_password}</property>
-			<property name="httpPort">${tck_port}</property>
-			<property name="httpsPort">${tck_port_secure}</property>
-			<!-- Add additional properties for your container impl -->
-		</configuration>
-	</container>
+    xmlns="http://jboss.org/schema/arquillian"
+    xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+    
+    <engine>
+        <property name="deploymentExportPath">target/</property>
+    </engine>
+    
+    <container qualifier="[YOUR-CONTAINER-IMPL]" default="true">
+        <configuration>
+            <!-- Each variable used is set in surefire config in running pom.xml -->
+            <property name="serverName">${tck_server}</property>
+            <property name="hostName">${tck_hostname}</property>
+            <property name="username">${tck_username}</property>
+            <property name="password">${tck_password}</property>
+            <property name="httpPort">${tck_port}</property>
+            <property name="httpsPort">${tck_port_secure}</property>
+            <!-- Add additional properties for your container impl -->
+        </configuration>
+    </container>
 </arquillian> 

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -104,7 +104,12 @@
       <groupId>org.netbeans.tools</groupId>
       <artifactId>sigtest-maven-plugin</artifactId>
       <version>${sigtest.version}</version>
-      <scope>test</scope>
+    </dependency>
+    
+     <dependency>
+        <groupId>org.jboss.shrinkwrap.resolver</groupId>
+        <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+        <version>${shrinkwrap.resolver.version}</version>
     </dependency>
   </dependencies>
 

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -51,10 +51,10 @@
     
     <!-- Data API -->
     <dependency>
-    	<groupId>jakarta.data</groupId>
-    	<artifactId>jakarta-data-api</artifactId>
-    	<version>${jakarta.data.version}</version>
-    	<scope>provided</scope>
+        <groupId>jakarta.data</groupId>
+        <artifactId>jakarta-data-api</artifactId>
+        <version>${jakarta.data.version}</version>
+        <scope>provided</scope>
     </dependency>
 
     <!-- EE Server Integration framework -->

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -109,7 +109,6 @@
      <dependency>
         <groupId>org.jboss.shrinkwrap.resolver</groupId>
         <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-        <version>${shrinkwrap.resolver.version}</version>
     </dependency>
   </dependencies>
 

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/arquillian/extensions/TCKArchiveProcessor.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/arquillian/extensions/TCKArchiveProcessor.java
@@ -73,7 +73,7 @@ public class TCKArchiveProcessor implements ApplicationArchiveProcessor {
             
             // Add signature packages to signature tests
             if (testClass.isAnnotationPresent(Signature.class)) {
-                log.info("Application Archive [" + applicationName + "] is being appended with packages [" + signaturePackage +", com.sun.tdk, org.netbeans.apitest]");
+                log.info("Application Archive [" + applicationName + "] is being appended with packages [" + signaturePackage + ", com.sun.tdk, org.netbeans.apitest]");
                 log.info("Application Archive [" + applicationName + "] is being appended with resources " + Arrays.asList(DataSignatureTestRunner.SIG_RESOURCES));
                 ((ClassContainer<?>) applicationArchive).addPackage(signaturePackage);
                 // These are the packages from the sig-test plugin that are needed to run the test.

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/arquillian/extensions/TCKArchiveProcessor.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/arquillian/extensions/TCKArchiveProcessor.java
@@ -55,8 +55,8 @@ public class TCKArchiveProcessor implements ApplicationArchiveProcessor {
     @Override
     public void process(Archive<?> applicationArchive, TestClass testClass) {
         String applicationName = applicationArchive.getName() == null 
-        		? applicationArchive.getId() 
-        		: applicationArchive.getName();
+                ? applicationArchive.getId() 
+                : applicationArchive.getName();
         
         // NOTE: ClassContainer is a superclass of ResourceContainer
         if (applicationArchive instanceof ClassContainer) {
@@ -100,7 +100,7 @@ public class TCKArchiveProcessor implements ApplicationArchiveProcessor {
             log.info("Application Archive [" + applicationName + "] is being appended with resources "
                     + Arrays.asList(DataSignatureTestRunner.SIG_RESOURCES));
             ((ResourceContainer<?>) applicationArchive).addAsResources(signaturePackage,
-            		DataSignatureTestRunner.SIG_MAP_NAME, DataSignatureTestRunner.SIG_PKG_NAME);
+                    DataSignatureTestRunner.SIG_MAP_NAME, DataSignatureTestRunner.SIG_PKG_NAME);
             ((ResourceContainer<?>) applicationArchive).addAsResource(signaturePackage,
                     // Get local resource based on JDK level
                     isJava21orAbove ? DataSignatureTestRunner.SIG_FILE_NAME + "_21"

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/arquillian/extensions/TCKArchiveProcessor.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/arquillian/extensions/TCKArchiveProcessor.java
@@ -15,6 +15,7 @@
  */
 package ee.jakarta.tck.data.framework.arquillian.extensions;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.logging.Logger;
 
@@ -22,7 +23,9 @@ import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArch
 import org.jboss.arquillian.test.spi.TestClass;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.container.ClassContainer;
+import org.jboss.shrinkwrap.api.container.LibraryContainer;
 import org.jboss.shrinkwrap.api.container.ResourceContainer;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 
 import ee.jakarta.tck.data.framework.junit.anno.Full;
 import ee.jakarta.tck.data.framework.junit.anno.Signature;
@@ -47,14 +50,13 @@ public class TCKArchiveProcessor implements ApplicationArchiveProcessor {
     private static final Logger log = Logger.getLogger(TCKArchiveProcessor.class.getCanonicalName());
 
     private static final Package servletPackage = TestServlet.class.getPackage();
-    private static final Package signaturePackage = DataSignatureTestRunner.class.getPackage();
     private static final Package readOnlyPackage = Populator.class.getPackage();
-    
-    boolean isJava21orAbove = Integer.parseInt(System.getProperty("java.specification.version")) >= 21;
     
     @Override
     public void process(Archive<?> applicationArchive, TestClass testClass) {
-        String applicationName = applicationArchive.getName() == null ? applicationArchive.getId() : applicationArchive.getName();
+        String applicationName = applicationArchive.getName() == null 
+        		? applicationArchive.getId() 
+        		: applicationArchive.getName();
         
         // NOTE: ClassContainer is a superclass of ResourceContainer
         if (applicationArchive instanceof ClassContainer) {
@@ -71,22 +73,40 @@ public class TCKArchiveProcessor implements ApplicationArchiveProcessor {
                 ((ClassContainer<?>) applicationArchive).addPackage(servletPackage);
             }
             
-            // Add signature packages to signature tests
-            if (testClass.isAnnotationPresent(Signature.class)) {
-                log.info("Application Archive [" + applicationName + "] is being appended with packages [" + signaturePackage + ", com.sun.tdk, org.netbeans.apitest]");
-                log.info("Application Archive [" + applicationName + "] is being appended with resources " + Arrays.asList(DataSignatureTestRunner.SIG_RESOURCES));
-                ((ClassContainer<?>) applicationArchive).addPackage(signaturePackage);
-                // These are the packages from the sig-test plugin that are needed to run the test.
-                ((ClassContainer<?>) applicationArchive).addPackages(true, "com.sun.tdk", "org.netbeans.apitest");
-                ((ResourceContainer<?>) applicationArchive).addAsResources(signaturePackage,
-                        DataSignatureTestRunner.SIG_MAP_NAME,
-                        DataSignatureTestRunner.SIG_PKG_NAME);
-                ((ResourceContainer<?>) applicationArchive).addAsResource(signaturePackage,
-                        //Get local resource based on JDK level
-                        isJava21orAbove ? DataSignatureTestRunner.SIG_FILE_NAME + "_21" : DataSignatureTestRunner.SIG_FILE_NAME + "_17",
-                        //Target same package as test
-                        signaturePackage.getName().replace(".", "/") + "/" + DataSignatureTestRunner.SIG_FILE_NAME);
-            }
+            appendSignaturePackages(applicationArchive, testClass, applicationName);
+        }
+    }
+    
+    private static void appendSignaturePackages(final Archive<?> applicationArchive, final TestClass testClass, final String applicationName) {
+        if (!testClass.isAnnotationPresent(Signature.class)) {
+            return; //Nothing to append
+        }
+        
+        final boolean isJava21orAbove = Integer.parseInt(System.getProperty("java.specification.version")) >= 21;
+        final Package signaturePackage = DataSignatureTestRunner.class.getPackage();
+
+        if (applicationArchive instanceof ClassContainer) {
+            
+            // Add the Concurrency runner
+            log.info("Application Archive [" + applicationName + "] is being appended with packages [" + signaturePackage + "]");
+            ((ClassContainer<?>) applicationArchive).addPackage(signaturePackage);
+
+            // Add the sigtest plugin library
+            File sigTestDep = Maven.resolver().resolve("org.netbeans.tools:sigtest-maven-plugin:1.6").withoutTransitivity().asSingleFile();
+            log.info("Application Archive [" + applicationName + "] is being appended with library " + sigTestDep.getName());
+            ((LibraryContainer<?>) applicationArchive).addAsLibrary(sigTestDep);
+            
+            // Add signature resources
+            log.info("Application Archive [" + applicationName + "] is being appended with resources "
+                    + Arrays.asList(DataSignatureTestRunner.SIG_RESOURCES));
+            ((ResourceContainer<?>) applicationArchive).addAsResources(signaturePackage,
+            		DataSignatureTestRunner.SIG_MAP_NAME, DataSignatureTestRunner.SIG_PKG_NAME);
+            ((ResourceContainer<?>) applicationArchive).addAsResource(signaturePackage,
+                    // Get local resource based on JDK level
+                    isJava21orAbove ? DataSignatureTestRunner.SIG_FILE_NAME + "_21"
+                            : DataSignatureTestRunner.SIG_FILE_NAME + "_17",
+                    // Target same package as test
+                    signaturePackage.getName().replace(".", "/") + "/" + DataSignatureTestRunner.SIG_FILE_NAME);
         }
     }
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/signature/DataSignatureTestRunner.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/signature/DataSignatureTestRunner.java
@@ -226,9 +226,9 @@ public class DataSignatureTestRunner extends SigTestEE {
             log.info("Exception while creating temp files :" + ex);
         }
 
-        String[] packagesUnderTest = getPackages(testInfo.getVehicle());
-        String[] classesUnderTest = getClasses(testInfo.getVehicle());
-        String optionalPkgToIgnore = testInfo.getOptionalTechPackagesToIgnore();
+        String[] packagesUnderTest = getPackages(SigTestData.getVehicle());
+        String[] classesUnderTest = getClasses(SigTestData.getVehicle());
+        String optionalPkgToIgnore = SigTestData.getOptionalTechPackagesToIgnore();
 
         // unlisted optional packages are technology packages for those optional
         // technologies (e.g. jsr-88) that might not have been specified by the

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/signature/README.md
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/signature/README.md
@@ -19,26 +19,26 @@ The plugin that generates the signature file has been copied below for reference
 
 ```xml
 <plugin>
-	<groupId>org.netbeans.tools</groupId>
-	<artifactId>sigtest-maven-plugin</artifactId>
-	<version>${sigtest.version}</version>
-	<executions>
-		<execution>
-			<id>createSigFile</id>
-			<goals>
-				<goal>generate</goal>
-			</goals>
-		</execution>
-	</executions>
-	<configuration>
-		<classes>${project.build.directory}/jakarta-data-api</classes>
-		<packages>
-			jakarta.data,
-			jakarta.data.repository
-		</packages>
-		<attach>false</attach>
-		<sigfile>${project.build.directory}/jakarta.data.sig_${project.version}</sigfile>
-	</configuration>
+    <groupId>org.netbeans.tools</groupId>
+    <artifactId>sigtest-maven-plugin</artifactId>
+    <version>${sigtest.version}</version>
+    <executions>
+        <execution>
+            <id>createSigFile</id>
+            <goals>
+                <goal>generate</goal>
+            </goals>
+        </execution>
+    </executions>
+    <configuration>
+        <classes>${project.build.directory}/jakarta-data-api</classes>
+        <packages>
+            jakarta.data,
+            jakarta.data.repository
+        </packages>
+        <attach>false</attach>
+        <sigfile>${project.build.directory}/jakarta.data.sig_${project.version}</sigfile>
+    </configuration>
 </plugin>
 ```
 

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/signature/SigTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/signature/SigTest.java
@@ -65,7 +65,7 @@ public abstract class SigTest {
      * @return String The path and name of the package list file.
      */
     protected String getPackageFile() {
-        return getSigTestDriver().getPackageFileImpl(testInfo.getBinDir());
+        return getSigTestDriver().getPackageFileImpl(SigTestData.getBinDir());
     }
 
     /**
@@ -82,7 +82,7 @@ public abstract class SigTest {
      * @return String The path and name of the signature map file.
      */
     protected String getMapFile() {
-        return getSigTestDriver().getMapFileImpl(testInfo.getBinDir());
+        return getSigTestDriver().getMapFileImpl(SigTestData.getBinDir());
     }
 
     /**
@@ -95,7 +95,7 @@ public abstract class SigTest {
      * @return String The signature repository directory.
      */
     protected String getRepositoryDir() {
-        return getSigTestDriver().getRepositoryDirImpl(testInfo.getTSHome());
+        return getSigTestDriver().getRepositoryDirImpl(SigTestData.getTSHome());
     }
 
     /**
@@ -160,8 +160,6 @@ public abstract class SigTest {
 
     } // END getClasses
 
-    protected SigTestData testInfo; // holds the bin.dir property
-
     /**
      * Called by the test framework to initialize this test. The method simply
      * retrieves some state information that is necessary to run the test when when
@@ -170,7 +168,6 @@ public abstract class SigTest {
     public void setup() {
         try {
             System.out.println("$$$ SigTest.setup() called");
-            this.testInfo = new SigTestData();
             System.out.println("$$$ SigTest.setup() complete");
         } catch (Exception e) {
             System.out.println("Unexpected exception " + e.getMessage());

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/signature/SigTestData.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/signature/SigTestData.java
@@ -15,8 +15,6 @@
  */
 package ee.jakarta.tck.data.framework.signature;
 
-import java.util.Properties;
-
 import ee.jakarta.tck.data.framework.utilities.TestProperty;
 
 /**
@@ -24,48 +22,41 @@ import ee.jakarta.tck.data.framework.utilities.TestProperty;
  * setup phase. This allows us to keep the passed data separate and reuse the
  * data between the signature test framework base classes.
  */
-@Deprecated //TODO remove and relay on TestProperty class instead.
-public class SigTestData {
+public final class SigTestData {
+	
+	private SigTestData() {
+		//Utility Class
+	}
 
-    private Properties props;
-
-    public SigTestData() {
-        this.props = System.getProperties();
+    public static String getVehicle() {
+    	return "";
     }
 
-    public String getVehicle() {
-        return props.getProperty("vehicle", "");
+    public static String getBinDir() {
+        return "";
     }
 
-    public String getBinDir() {
-        return props.getProperty("bin.dir", "");
+    public static String getTSHome() {
+        return "";
     }
 
-    public String getTSHome() {
-        return props.getProperty("ts_home", "");
+    public static String getJavaeeLevel() {
+        return "";
     }
 
-    public String getTestClasspath() {
-        return TestProperty.signatureClasspath.getValue();
+    public static String getCurrentKeywords() {
+        return "";
     }
 
-    public String getJavaeeLevel() {
-        return props.getProperty("javaee.level", "");
+    public static String getProperty(String prop) {
+        return System.getProperty(prop);
     }
 
-    public String getCurrentKeywords() {
-        return props.getProperty("current.keywords", "");
+    public static String getOptionalTechPackagesToIgnore() {
+        return "";
     }
 
-    public String getProperty(String prop) {
-        return props.getProperty(prop);
-    }
-
-    public String getOptionalTechPackagesToIgnore() {
-        return props.getProperty("optional.tech.packages.to.ignore", "");
-    }
-
-    public String getJtaJarClasspath() {
-        return props.getProperty("jtaJarClasspath", "");
+    public static String getJtaJarClasspath() {
+        return "";
     }
 } // end class SigTestData

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/signature/SigTestData.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/signature/SigTestData.java
@@ -23,13 +23,13 @@ import ee.jakarta.tck.data.framework.utilities.TestProperty;
  * data between the signature test framework base classes.
  */
 public final class SigTestData {
-	
-	private SigTestData() {
-		//Utility Class
-	}
+    
+    private SigTestData() {
+        //Utility Class
+    }
 
     public static String getVehicle() {
-    	return "";
+        return "";
     }
 
     public static String getBinDir() {

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/signature/SigTestData.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/signature/SigTestData.java
@@ -15,8 +15,6 @@
  */
 package ee.jakarta.tck.data.framework.signature;
 
-import ee.jakarta.tck.data.framework.utilities.TestProperty;
-
 /**
  * This class holds the data passed to a signature test invocation during the
  * setup phase. This allows us to keep the passed data separate and reuse the

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/signature/SigTestEE.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/signature/SigTestEE.java
@@ -79,7 +79,7 @@ public abstract class SigTestEE {
      * @return String The path and name of the package list file.
      */
     protected String getPackageFile() {
-        return getSigTestDriver().getPackageFileImpl(testInfo.getBinDir());
+        return getSigTestDriver().getPackageFileImpl(SigTestData.getBinDir());
     }
 
     /**
@@ -98,7 +98,7 @@ public abstract class SigTestEE {
      * @return String The path and name of the signature map file.
      */
     protected String getMapFile() {
-        return getSigTestDriver().getMapFileImpl(testInfo.getBinDir());
+        return getSigTestDriver().getMapFileImpl(SigTestData.getBinDir());
     }
 
     /**
@@ -113,7 +113,7 @@ public abstract class SigTestEE {
      * @return String The signature repository directory.
      */
     protected String getRepositoryDir() {
-        return getSigTestDriver().getRepositoryDirImpl(testInfo.getTSHome());
+        return getSigTestDriver().getRepositoryDirImpl(SigTestData.getTSHome());
     }
 
     /**
@@ -204,9 +204,6 @@ public abstract class SigTestEE {
 
     } // END getClasses
 
-
-    protected SigTestData testInfo; // holds the bin.dir and vehicle properties
-
     /**
      * Called by the test framework to initialize this test. The method simply
      * retrieves some state information that is necessary to run the test when when
@@ -215,7 +212,6 @@ public abstract class SigTestEE {
     public void setup() {
         try {
             System.out.println("$$$ SigTestEE.setup() called");
-            this.testInfo = new SigTestData();
             System.out.println("$$$ SigTestEE.setup() complete");
         } catch (Exception e) {
             System.out.println("Unexpected exception " + e.getMessage());
@@ -235,11 +231,11 @@ public abstract class SigTestEE {
         SigTestResult results = null;
         String mapFile = getMapFile();
         String repositoryDir = getRepositoryDir();
-        String[] packages = getPackages(testInfo.getVehicle());
-        String[] classes = getClasses(testInfo.getVehicle());
+        String[] packages = getPackages(SigTestData.getVehicle());
+        String[] classes = getClasses(SigTestData.getVehicle());
         String packageFile = getPackageFile();
-        String testClasspath = testInfo.getTestClasspath();
-        String optionalPkgToIgnore = testInfo.getOptionalTechPackagesToIgnore();
+        String testClasspath = TestProperty.signatureClasspath.getValue();
+        String optionalPkgToIgnore = SigTestData.getOptionalTechPackagesToIgnore();
 
         // unlisted optional packages are technology packages for those optional
         // technologies (e.g. jsr-88) that might not have been specified by the

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/signature/SignatureTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/signature/SignatureTests.java
@@ -17,7 +17,7 @@ package ee.jakarta.tck.data.standalone.signature;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import ee.jakarta.tck.data.framework.junit.anno.AnyEntity;
 import ee.jakarta.tck.data.framework.junit.anno.Assertion;
@@ -30,8 +30,8 @@ import ee.jakarta.tck.data.framework.signature.DataSignatureTestRunner;
 @Signature
 public class SignatureTests {
     @Deployment
-    public static JavaArchive createDeployment() {
-        return ShrinkWrap.create(JavaArchive.class);
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class);
     }
 
     @Assertion(id = "26", strategy = "Uses the sigtest-maven-plugin to execute signature tests on a Standalone JVM or on a Jakarta EE Server")


### PR DESCRIPTION
Discovered a bug in the TCK where we were automatically appending the packages from the Signature Test plugin library to the application before being deployed to the Jakarta Profile. 

I didn't realize that message files were not being included, this change will add the entire signature test plugin library under the `lib` directory of the .war archive. 

This change has no affect on Standalone mode. 

(also fixed some whitespace inconsistencies in the TCK)