### PR TITLE
Tests for default methods, common interfaces, Not

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
@@ -33,13 +33,13 @@ import jakarta.data.repository.Streamable;
  * This interface is required to inherit only from DataRepository in order to satisfy a TCK scenario.
  */
 @Repository
-public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long> {
+public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long>, IdOperations<AsciiCharacter> {
 
     int countByHexadecimalNotNull();
 
     boolean existsByThisCharacter(char ch);
 
-    Collection<AsciiCharacter> findByHexadecimalContainsAndNotIsControl(String substring);
+    Collection<AsciiCharacter> findByHexadecimalContainsAndIsControlNot(String substring, boolean isPrintable);
 
     Stream<AsciiCharacter> findByHexadecimalIgnoreCaseBetweenAndHexadecimalNotIn(String minHex,
                                                                                  String maxHex,
@@ -60,6 +60,10 @@ public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long> {
 
     Optional<AsciiCharacter> findFirstByHexadecimalStartsWithAndIsControlOrderByIdAsc(String firstHexDigit, boolean isControlChar);
 
-    Iterable<AsciiCharacter> saveAll(Iterable<AsciiCharacter> characters);
+    default Stream<AsciiCharacter> retrieveAlphaNumericIn(long minId, long maxId) {
+        return findByIdBetween(minId, maxId, Sort.asc("id"))
+                        .filter(c -> Character.isLetterOrDigit(c.getThisCharacter()));
+    }
 
+    Iterable<AsciiCharacter> saveAll(Iterable<AsciiCharacter> characters);
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/IdOperations.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/IdOperations.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.framework.read.only;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.stream.Stream;
+
+import jakarta.data.repository.Limit;
+import jakarta.data.repository.Sort;
+
+/**
+ * This interface contains common operations for the NaturalNumbers and AsciiCharacters repositories.
+ *
+ * @param <T> type of entity.
+ */
+public interface IdOperations<T> {
+    Stream<T> findByIdBetween(long minimum, long maximum, Sort sort);
+
+    Collection<T> findByIdGreaterThanEqual(long minimum,
+                                           Limit limit,
+                                           Sort... sorts);
+
+    T[] findByIdLessThan(long exclusiveMax, Sort primarySort, Sort secondarySort);
+
+    ArrayList<T> findByIdLessThanEqual(long maximum, Sort... sorts);
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers.java
@@ -15,8 +15,6 @@
  */
 package ee.jakarta.tck.data.framework.read.only;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.stream.Stream;
 
 import jakarta.data.repository.CrudRepository;
@@ -36,24 +34,14 @@ import ee.jakarta.tck.data.framework.read.only.NaturalNumber.NumberType;
  * TODO figure out a way to make this a ReadOnlyRepository instead.
  */
 @Repository
-public interface NaturalNumbers extends CrudRepository<NaturalNumber, Long> {
+public interface NaturalNumbers extends CrudRepository<NaturalNumber, Long>, IdOperations<NaturalNumber> {
 
     KeysetAwareSlice<NaturalNumber> findByFloorOfSquareRootOrderByIdAsc(long sqrtFloor,
                                                                         Pageable pagination);
 
-    Stream<NaturalNumber> findByIdBetween(long minimum, long maximum, Sort sort);
-
     Stream<NaturalNumber> findByIdBetweenOrderByNumTypeAsc(long minimum,
                                                            long maximum,
                                                            Sort... sorts);
-
-    Collection<NaturalNumber> findByIdGreaterThanEqual(long minimum,
-                                                       Limit limit,
-                                                       Sort... sorts);
-
-    NaturalNumber[] findByIdLessThan(long exclusiveMax, Sort primarySort, Sort secondarySort);
-
-    ArrayList<NaturalNumber> findByIdLessThanEqual(long maximum, Sort... sorts);
 
     Slice<NaturalNumber> findByIdLessThanOrderByFloorOfSquareRootDesc(long exclusiveMax,
                                                                       Pageable pagination);
@@ -61,6 +49,8 @@ public interface NaturalNumbers extends CrudRepository<NaturalNumber, Long> {
     KeysetAwareSlice<NaturalNumber> findByNumTypeAndNumBitsRequiredLessThan(NumberType type,
                                                                             short bitsUnder,
                                                                             Pageable pagination);
+
+    NaturalNumber[] findByNumTypeNot(NumberType notThisType, Limit limit, Sort... sorts);
 
     Slice<NaturalNumber> findByNumTypeAndFloorOfSquareRootLessThanEqual(NumberType type,
                                                                         long maxSqrtFloor,

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTest.java
@@ -140,9 +140,34 @@ public class EntityTest {
         assertEquals(false, slice.iterator().hasNext());
     }
 
+    @Assertion(id = "133", strategy = "Use a repository that inherits some if its methods from another interface.")
+    public void testCommonInterfaceQueries() {
+        assertEquals(List.of('d', 'c', 'b', 'a'),
+                     characters.findByIdBetween(97L, 100L, Sort.desc("thisCharacter"))
+                                     .map(AsciiCharacter::getThisCharacter)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(List.of(87L, 88L, 89L, 90L),
+                     numbers.findByIdBetween(87L, 90L, Sort.asc("id"))
+                                     .map(NaturalNumber::getId)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(List.of('D', 'E', 'F', 'G', 'H'),
+                     characters.findByIdGreaterThanEqual(68L, Limit.of(5), Sort.asc("numericValue"), Sort.asc("id"))
+                                     .stream()
+                                     .map(AsciiCharacter::getThisCharacter)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(List.of(71L, 73L, 79L, 83L, 89L),
+                     numbers.findByIdGreaterThanEqual(68L, Limit.of(5), Sort.asc("numType"), Sort.asc("id"))
+                                     .stream()
+                                     .map(NaturalNumber::getId)
+                                     .collect(Collectors.toList()));
+    }
+
     @Assertion(id = "133", strategy = "Use a repository method with Contains to query for a substring of a String attribute.")
     public void testContainsInString() {
-        Collection<AsciiCharacter> found = characters.findByHexadecimalContainsAndNotIsControl("4");
+        Collection<AsciiCharacter> found = characters.findByHexadecimalContainsAndIsControlNot("4", true);
 
         assertEquals(List.of("24", "34",
                              "40", "41", "42", "43",
@@ -193,6 +218,14 @@ public class EntityTest {
         assertEquals(false, d.isControl());
 
         assertEquals(true, characters.existsByThisCharacter('D'));
+    }
+
+    @Assertion(id = "133", strategy = "Use a default method from a repository interface where the default method invokes other repository methods.")
+    public void testDefaultMethod() {
+        assertEquals(List.of('W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd'),
+                     characters.retrieveAlphaNumericIn(87L, 100L)
+                                     .map(AsciiCharacter::getThisCharacter)
+                                     .collect(Collectors.toList()));
     }
 
     @Assertion(id = "133",
@@ -667,6 +700,20 @@ public class EntityTest {
             x.printStackTrace(System.out);
             // test passes
         }
+    }
+
+    @Assertion(id = "133", strategy = "Use a repository method with the Not keyword.")
+    public void testNot() {
+        NaturalNumber[] n = numbers.findByNumTypeNot(NumberType.COMPOSITE, Limit.of(8), Sort.asc("id"));
+        assertEquals(8, n.length);
+        assertEquals(1L, n[0].getId());
+        assertEquals(2L, n[1].getId());
+        assertEquals(3L, n[2].getId());
+        assertEquals(5L, n[3].getId());
+        assertEquals(7L, n[4].getId());
+        assertEquals(11L, n[5].getId());
+        assertEquals(13L, n[6].getId());
+        assertEquals(17L, n[7].getId());
     }
 
     @Assertion(id = "133", strategy = "Use a repository method with Or, expecting MappingException if the underlying database is not capable.")


### PR DESCRIPTION
Adds the following tests from #133

- Use a repository that inherits some if its methods from another interface.
- Use a default method from a repository interface where the default method invokes other repository methods.
- Use a repository method with Not
