### PR TITLE
Tests for KeysetAwarePage

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/PositiveIntegers.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/PositiveIntegers.java
@@ -19,7 +19,9 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import ee.jakarta.tck.data.framework.read.only.NaturalNumber.NumberType;
+import jakarta.data.repository.KeysetAwarePage;
 import jakarta.data.repository.Limit;
+import jakarta.data.repository.Pageable;
 import jakarta.data.repository.PageableRepository;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Streamable;
@@ -34,6 +36,10 @@ public interface PositiveIntegers extends PageableRepository<NaturalNumber, Long
     long countByIdLessThan(long number);
 
     boolean existsByIdGreaterThan(Long number);
+
+    KeysetAwarePage<NaturalNumber> findByFloorOfSquareRootNotAndIdLessThanOrderByBitsRequiredDesc(long excludeSqrt,
+                                                                                                  long eclusiveMax,
+                                                                                                  Pageable pagination);
 
     Iterable<NaturalNumber> findByIsOddTrueAndIdLessThanEqualOrderByIdDesc(long max);
 


### PR DESCRIPTION
Write TCK tests for the following scenarios from #133

- Request the first KeysetAwarePage of 8 results, expecting to find all 8, then request the next KeysetAwarePage after the keyset of the last entry of the page, expecting to find the next 8. Or validate that UnsupportedOperationException is raised to indicate that the underlying database is incapable of keyset pagination.

- Request a KeysetAwarePage of 7 results after the keyset of the 20th result, expecting to find the next 7 results. Then request the KeysetAwarePage before the keyset of the first entry of the page, expecting to find the previous 7 results. Then request the KeysetAwarePage after the last entry of the page, expecting to find the next 7. Or validate that UnsupportedOperationException is raised to indicate that the underlying database is incapable of keyset pagination.

- Request a KeysetAwarePage of results where none match the query, expecting an empty KeysetAwarePage with 0 results. Or validate that UnsupportedOperationException is raised to indicate that the underlying database is incapable of keyset pagination.