### PR TITLE
Updating jruby version

### DIFF
--- a/tck-dist/pom.xml
+++ b/tck-dist/pom.xml
@@ -42,7 +42,10 @@
   <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
   <asciidoctorj.version>2.5.10</asciidoctorj.version>
   <asciidoctorj.pdf.version>2.3.9</asciidoctorj.pdf.version>
-  <jruby.version>9.2.20.1</jruby.version>
+  <!-- jruby 9.4.3.0 is not working, keeping this on the 9.3.x stream since 9.4 seems to implement a newer ruby version
+  which is causing issues with asciidoctor, even though asciidoctorj considers it compatible.
+  Looks like this may work with the asciidoctorj 3.0.0 stream when it releases-->
+  <jruby.version>9.3.10.0</jruby.version>  
  </properties>
 
  <dependencies>


### PR DESCRIPTION
The jruby version needs to be updated manually, since dependabot recommends an incompatible version. This PR updates to the latest version on the 9.3 stream. 

After merging this, PR #168 can be canceled.