### PR TITLE
Create a JPA domain

### DIFF
--- a/api/src/main/java/jakarta/data/repository/jpa/JPARepository.java
+++ b/api/src/main/java/jakarta/data/repository/jpa/JPARepository.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package jakarta.data.repository.jpa;
+
+import jakarta.data.repository.PageableRepository;
+
+public interface JPARepository<T, K> extends PageableRepository<T, K> {
+ //TODO https://github.com/jakartaee/data/issues/224
+ //TODO https://github.com/jakartaee/data/issues/225
+
+}

--- a/api/src/main/java/jakarta/data/repository/jpa/package-info.java
+++ b/api/src/main/java/jakarta/data/repository/jpa/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * This package contains interfaces and classes that facilitate working with repositories
+ * in the Jakarta Persistence API (JPA) context. JPA is a Java specification for * managing relational data in a database.
+ * Repositories in this package leverage JPA to provide easy and standardized access to persistent entities.
+ */
+package jakarta.data.repository.jpa;


### PR DESCRIPTION
JPA is a universe, and IMHO, having a unique domain in Jakarta Data makes sense.

I propose to have the JPA specialization and start to address these issues in this JPA specialization.

- https://github.com/jakartaee/data/issues/224
- https://github.com/jakartaee/data/issues/225

If it is okay, we can merge and request help from the Hibernate team to enhance those points.