### PR TITLE
Fix two CrudRepository method names that do not follow the spec rules

### DIFF
--- a/api/src/main/java/jakarta/data/repository/BasicRepository.java
+++ b/api/src/main/java/jakarta/data/repository/BasicRepository.java
@@ -122,7 +122,7 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
      * {@literal ids}.
      * @throws NullPointerException in case the given {@link Iterable ids} or one of its items is {@literal null}.
      */
-    Stream<T> findAllById(Iterable<K> ids);
+    Stream<T> findByIdIn(Iterable<K> ids);
 
     /**
      * Retrieves the total number of persistent entities of the specified type in the database.
@@ -162,7 +162,7 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
      * @param ids must not be {@literal null}. Must not contain {@literal null} elements.
      * @throws NullPointerException when either the iterable is null or contains null elements
      */
-    void deleteAllById(Iterable<K> ids);
+    void deleteByIdIn(Iterable<K> ids);
 
     /**
      * Deletes the given entities. Deletion of each entity is performed by matching the ID, and if the entity is

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/ReadOnlyRepository.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/ReadOnlyRepository.java
@@ -38,7 +38,7 @@ public interface ReadOnlyRepository<T, K> extends DataRepository<T, K>{
 
     Stream<T> findAll();
 
-    Stream<T> findAllById(Iterable<K> ids);
+    Stream<T> findByIdIn(Iterable<K> ids);
 
     long count();
 

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTest.java
@@ -187,7 +187,7 @@ public class EntityTest {
         assertEquals(true, numbers.existsById(80L));
 
         Stream<NaturalNumber> found;
-        found = numbers.findAllById(List.of(70L, 40L, -20L, 10L));
+        found = numbers.findByIdIn(List.of(70L, 40L, -20L, 10L));
         assertEquals(List.of(10L, 40L, 70L),
                      found.map(NaturalNumber::getId).sorted().collect(Collectors.toList()));
 

--- a/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/jakarta.data.sig_17
+++ b/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/jakarta.data.sig_17
@@ -54,13 +54,13 @@ meth public abstract <%0 extends {jakarta.data.repository.BasicRepository%0}> {%
 meth public abstract boolean existsById({jakarta.data.repository.BasicRepository%1})
 meth public abstract java.util.Optional<{jakarta.data.repository.BasicRepository%0}> findById({jakarta.data.repository.BasicRepository%1})
 meth public abstract java.util.stream.Stream<{jakarta.data.repository.BasicRepository%0}> findAll()
-meth public abstract java.util.stream.Stream<{jakarta.data.repository.BasicRepository%0}> findAllById(java.lang.Iterable<{jakarta.data.repository.BasicRepository%1}>)
+meth public abstract java.util.stream.Stream<{jakarta.data.repository.BasicRepository%0}> findByIdIn(java.lang.Iterable<{jakarta.data.repository.BasicRepository%1}>)
 meth public abstract long count()
 meth public abstract void delete({jakarta.data.repository.BasicRepository%0})
 meth public abstract void deleteAll()
 meth public abstract void deleteAll(java.lang.Iterable<? extends {jakarta.data.repository.BasicRepository%0}>)
-meth public abstract void deleteAllById(java.lang.Iterable<{jakarta.data.repository.BasicRepository%1}>)
 meth public abstract void deleteById({jakarta.data.repository.BasicRepository%1})
+meth public abstract void deleteByIdIn(java.lang.Iterable<{jakarta.data.repository.BasicRepository%1}>)
 
 CLSS public abstract interface jakarta.data.repository.DataRepository<%0 extends java.lang.Object, %1 extends java.lang.Object>
 

--- a/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/jakarta.data.sig_21
+++ b/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/jakarta.data.sig_21
@@ -54,13 +54,13 @@ meth public abstract <%0 extends {jakarta.data.repository.BasicRepository%0}> {%
 meth public abstract boolean existsById({jakarta.data.repository.BasicRepository%1})
 meth public abstract java.util.Optional<{jakarta.data.repository.BasicRepository%0}> findById({jakarta.data.repository.BasicRepository%1})
 meth public abstract java.util.stream.Stream<{jakarta.data.repository.BasicRepository%0}> findAll()
-meth public abstract java.util.stream.Stream<{jakarta.data.repository.BasicRepository%0}> findAllById(java.lang.Iterable<{jakarta.data.repository.BasicRepository%1}>)
+meth public abstract java.util.stream.Stream<{jakarta.data.repository.BasicRepository%0}> findByIdIn(java.lang.Iterable<{jakarta.data.repository.BasicRepository%1}>)
 meth public abstract long count()
 meth public abstract void delete({jakarta.data.repository.BasicRepository%0})
 meth public abstract void deleteAll()
 meth public abstract void deleteAll(java.lang.Iterable<? extends {jakarta.data.repository.BasicRepository%0}>)
-meth public abstract void deleteAllById(java.lang.Iterable<{jakarta.data.repository.BasicRepository%1}>)
 meth public abstract void deleteById({jakarta.data.repository.BasicRepository%1})
+meth public abstract void deleteByIdIn(java.lang.Iterable<{jakarta.data.repository.BasicRepository%1}>)
 
 CLSS public abstract interface jakarta.data.repository.DataRepository<%0 extends java.lang.Object, %1 extends java.lang.Object>
 


### PR DESCRIPTION
CrudRepository has two methods that don't follow the rules in the spec:
```
    findAllById(Iterable<K> ids);
    deleteAllById(Iterable<K> ids);
```

If a user added these methods to their own repository interface (which is something we explicitly state in the spec can be done), per the rules of the spec, it would mean an equality comparison where the id is equal to the Iterable, which isn't what is wanted.  What is really wanted here is provided by the `In` keyword, which matches any item in the collection.

Names that are consistent with the spec rules would be:

```
    findAllByIdIn(Iterable<K> ids);
    deleteAllByIdIn(Iterable<K> ids);
```

or

```
    findByIdIn(Iterable<K> ids);
    deleteByIdIn(Iterable<K> ids);
```

This pull updates to the latter.
