### PR TITLE
TCK tests for find queries using parameter names

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -149,6 +149,9 @@
         <configuration>
           <source>17</source>
           <target>17</target>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
         </configuration>
       </plugin>
       <plugin>

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
@@ -39,6 +39,8 @@ public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long>, I
 
     boolean existsByThisCharacter(char ch);
 
+    AsciiCharacter find(char thisCharacter);
+
     Collection<AsciiCharacter> findByHexadecimalContainsAndIsControlNot(String substring, boolean isPrintable);
 
     Stream<AsciiCharacter> findByHexadecimalIgnoreCaseBetweenAndHexadecimalNotIn(String minHex,

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/PositiveIntegers.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/PositiveIntegers.java
@@ -15,13 +15,17 @@
  */
 package ee.jakarta.tck.data.framework.read.only;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import ee.jakarta.tck.data.framework.read.only.NaturalNumber.NumberType;
 import jakarta.data.Limit;
+import jakarta.data.Sort;
 import jakarta.data.Streamable;
 import jakarta.data.page.KeysetAwarePage;
+import jakarta.data.page.Page;
 import jakarta.data.page.Pageable;
 import jakarta.data.repository.PageableRepository;
 import jakarta.data.repository.Repository;
@@ -48,4 +52,10 @@ public interface PositiveIntegers extends PageableRepository<NaturalNumber, Long
     Stream<NaturalNumber> findByNumTypeInOrderByIdAsc(Set<NumberType> types, Limit limit);
 
     Stream<NaturalNumber> findByNumTypeOrFloorOfSquareRoot(NumberType type, long floor);
+
+    Page<NaturalNumber> findMatching(long floorOfSquareRoot, Short numBitsRequired, NumberType numType, Pageable pagination);
+
+    Optional<NaturalNumber> findNumber(long id);
+
+    List<NaturalNumber> findOdd(boolean isOdd, NumberType numType, Limit limit, Sort... sorts);
 }


### PR DESCRIPTION
This area of the specification should be consistent in how is currently written and Gavin's pull to make changes, so we should be able to add TCK tests.  The following scenarios are included in this pull:

 - Find a single entity, querying by entity attributes with names that match the method parameter names.
 - Find a single entity that might or might not exist (return type of Optional), querying by entity attributes with names that match the method parameter names.
 - Find a list of entities, querying by entity attributes with names that match the method parameter names, with results capped by a Limit parameter and sorted according to a variable arguments Sort parameter.
 - Find a page of entities, with entity attributes identified by the parameter names and matching the parameter values.
