### PR TITLE
tests for StaticMetamodel

### DIFF
--- a/api/src/main/resources/checkstyle.xml
+++ b/api/src/main/resources/checkstyle.xml
@@ -49,7 +49,8 @@
         <module name="ParameterName"/>
         <module name="StaticVariableName"/>
         <module name="TypeName">
-            <property name="format" value="^_?[A-Z][a-zA-Z0-9]*$"/>
+            <!-- The trailing underscore is a common pattern for StaticMetamodel classes -->
+            <property name="format" value="^_?[A-Z][a-zA-Z0-9_]*$"/>
         </module>
 
         <module name="AvoidStarImport">

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacter_.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacter_.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.framework.read.only;
+
+import jakarta.data.model.Attribute;
+import jakarta.data.model.StaticMetamodel;
+
+@StaticMetamodel(AsciiCharacter.class)
+public interface AsciiCharacter_ {
+    public static final Attribute id = Attribute.get();
+    public static final Attribute hexadecimal = Attribute.get();
+    public static final Attribute isControl = Attribute.get();
+    public static final Attribute numericValue = Attribute.get();
+    public static final Attribute thisCharacter = Attribute.get();
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTest.java
@@ -43,6 +43,7 @@ import ee.jakarta.tck.data.framework.junit.anno.Assertion;
 import ee.jakarta.tck.data.framework.junit.anno.ReadOnlyTest;
 import ee.jakarta.tck.data.framework.junit.anno.Standalone;
 import ee.jakarta.tck.data.framework.read.only.AsciiCharacter;
+import ee.jakarta.tck.data.framework.read.only.AsciiCharacter_;
 import ee.jakarta.tck.data.framework.read.only.AsciiCharacters;
 import ee.jakarta.tck.data.framework.read.only.AsciiCharactersPopulator;
 import ee.jakarta.tck.data.framework.read.only.NaturalNumber;
@@ -1050,6 +1051,46 @@ public class EntityTest {
         assertEquals(false, slice.hasContent());
         assertEquals(0, slice.content().size());
         assertEquals(0, slice.numberOfElements());
+    }
+
+    @Assertion(id = "133", strategy = "Use the StaticMetamodel to obtain ascending Sorts for an entity attribute a type-safe manner.")
+    public void testStaticMetamodelAscendingSorts() {
+        assertEquals(Sort.asc("id"), AsciiCharacter_.id.asc());
+        assertEquals(Sort.asc("isControl"), AsciiCharacter_.isControl.asc());
+        assertEquals(Sort.ascIgnoreCase("hexadecimal"), AsciiCharacter_.hexadecimal.ascIgnoreCase());
+        assertEquals(Sort.ascIgnoreCase("thisCharacter"), AsciiCharacter_.thisCharacter.ascIgnoreCase());
+
+        Pageable pageRequest = Pageable.ofSize(6).sortBy(AsciiCharacter_.numericValue.asc());
+        Page<AsciiCharacter> page1 = characters.findByNumericValueBetween(68, 90, pageRequest);
+
+        assertEquals(List.of('D', 'E', 'F', 'G', 'H', 'I'),
+                     page1.stream()
+                                     .map(AsciiCharacter::getThisCharacter)
+                                     .collect(Collectors.toList()));
+    }
+
+    @Assertion(id = "133", strategy = "Use the StaticMetamodel to refer to entity attribute names in a type-safe manner.")
+    public void testStaticMetamodelAttributeNames() {
+        assertEquals("hexadecimal", AsciiCharacter_.hexadecimal.name());
+        assertEquals("id", AsciiCharacter_.id.name());
+        assertEquals("isControl", AsciiCharacter_.isControl.name());
+        assertEquals("numericValue", AsciiCharacter_.numericValue.name());
+        assertEquals("thisCharacter", AsciiCharacter_.thisCharacter.name());
+    }
+
+    @Assertion(id = "133", strategy = "Use the StaticMetamodel to obtain descending Sorts for an entity attribute a type-safe manner.")
+    public void testStaticMetamodelDescendingSorts() {
+        assertEquals(Sort.desc("id"), AsciiCharacter_.id.desc());
+        assertEquals(Sort.desc("isControl"), AsciiCharacter_.isControl.desc());
+        assertEquals(Sort.descIgnoreCase("hexadecimal"), AsciiCharacter_.hexadecimal.descIgnoreCase());
+        assertEquals(Sort.descIgnoreCase("thisCharacter"), AsciiCharacter_.thisCharacter.descIgnoreCase());
+
+        Sort sort = AsciiCharacter_.numericValue.desc();
+        AsciiCharacter[] found = characters.findFirst3ByNumericValueGreaterThanEqualAndHexadecimalEndsWith(30, "1", sort);
+        assertEquals(3, found.length);
+        assertEquals('q', found[0].getThisCharacter());
+        assertEquals('a', found[1].getThisCharacter());
+        assertEquals('Q', found[2].getThisCharacter());
     }
 
     @Assertion(id = "133", strategy = "Use a repository method that returns Streamable and verify the results.")


### PR DESCRIPTION
Add tests for StaticMetamodel, used to obtain entity attribute names in a type-safe manner and ascending/descending Sort from the Attribute, also in a type-safe manner.