### PR TITLE
Make insert and update method work also with NoSQL databases

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,10 +11,13 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 === Added
 
 - Define Jakarta Data extensions
+- Create BasicRepository
+- Include insert and update methods in CrudRepository
+
 
 === Changed
 
-* Rename CrudRepository to BasicRepository
+* Move the basic repository methods to the `BasicRepository` interface
 
 == [1.0.0-b3] - 2022-07-24
 

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -47,7 +47,7 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * @throws UnsupportedOperationException for Key-Value and Wide-Column databases
      *         that use an append model to write data.
      */
-    void insert(T entity);
+    <S extends T> S insert(S entity);
 
     /**
      * <p>Inserts multiple entities into the database. If an entity of this type with the same
@@ -60,7 +60,7 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * @throws UnsupportedOperationException for Key-Value and Wide-Column databases
      *         that use an append model to write data.
      */
-    void insertAll(Iterable<T> entities);
+    <S extends T> Iterable<S> insertAll(Iterable<S> entities);
 
     /**
      * <p>Modifies an entity that already exists in the database.</p>
@@ -79,7 +79,7 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * @return true if a matching entity was found in the database to update, otherwise false.
      * @throws NullPointerException if the entity is null.
      */
-    boolean update(T entity);
+    <S extends T> S update(S entity);
 
     /**
      * <p>Modifies entities that already exists in the database.</p>
@@ -98,5 +98,5 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * @return the number of matching entities that were found in the database to update.
      * @throws NullPointerException if either the iterable is null or any element is null.
      */
-    int updateAll(Iterable<T> entities);
+    <S extends T> Iterable<S> updateAll(Iterable<S> entities);
 }

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -48,7 +48,7 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      *
      * @param entity the entity to insert. Must not be {@code null}.
      * @param <S> Type of the entity to insert.
-     * @return the inserted entity, which may or may not be a different instance depending on the Jakarta Data provider.
+     * @return the inserted entity, which may or may not be a different instance depending on whether the insert caused values to be generated or automatically incremented.
      * @throws EntityExistsException if the entity is already present in the database (in ACID-supported databases).
      * @throws NullPointerException if the entity is null.
      */

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -104,8 +104,7 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      *
      * <p>For an update to be made to an entity, a matching entity with the same unique identifier
      * must be present in the database. In databases that use an append model to write data or
-     * follow the BASE model, this method  behavior as the {@link #insertAll} method,
-     * especially if the database does not support ACID transactions.</p>
+     * follow the BASE model, this method behaves the same as the {@link #insertAll} method.</p>
      *
      * <p>If the entity is versioned (for example, with {@code jakarta.persistence.Version} or by
      * another convention from the entity model such as having an attribute named {@code version}),

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -95,7 +95,7 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      *
      * <p>Non-matching entities are ignored and do not cause an error to be raised.</p>
      *
-     * @param entity the entity to update. Must not be {@code null}.
+     * @return true if a matching entity was found in the database to update, otherwise false.
 @return true if a matching entity was found in the database to update, otherwise false.
      * @throws NullPointerException if the entity is null.
      */

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -38,27 +38,38 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
 
     /**
      * <p>Inserts an entity into the database. If an entity of this type with the same
-     * unique identifier already exists in the database, then this method raises
-     * {@link EntityExistsException}.</p>
+     * unique identifier already exists in the database and the database supports ACID transactions,
+     * then this method raises {@link EntityExistsException}. In databases that follow the BASE model
+     * or use an append model to write data, this exception may not be thrown.</p>
+     *
+     * <p>The entity instance returned as a result of this method may be the same instance as the one
+     * supplied as a parameter, especially in non-Java record classes. However, for Jakarta Data providers
+     * that support Java records, a different instance may be returned.</p>
      *
      * @param entity the entity to insert. Must not be {@code null}.
-     * @throws EntityExistsException if the entity is already present in the database.
+     * @param <S> Type of the entity to insert.
+     * @return the inserted entity, which may or may not be a different instance depending on the Jakarta Data provider.
+     * @throws EntityExistsException if the entity is already present in the database (in ACID-supported databases).
      * @throws NullPointerException if the entity is null.
-     * @throws UnsupportedOperationException for Key-Value and Wide-Column databases
-     *         that use an append model to write data.
      */
     <S extends T> S insert(S entity);
 
     /**
-     * <p>Inserts multiple entities into the database. If an entity of this type with the same
-     * unique identifier as any of the given entities already exists in the database,
-     * then this method raises {@link EntityExistsException}.</p>
+     * <p>Inserts multiple entities into the database. If any entity of this type with the same
+     * unique identifier as any of the given entities already exists in the database and the database
+     * supports ACID transactions, then this method raises {@link EntityExistsException}.
+     * In databases that follow the BASE model or use an append model to write data, this exception
+     * may not be thrown.</p>
+     *
+     * <p>The entities within the returned iterable may be the same instances as those supplied
+     * as parameters, especially in non-Java record classes. However, for Jakarta Data providers
+     * that support Java records, different instances may be returned.</p>
      *
      * @param entities entities to insert.
-     * @throws EntityExistsException if any of the entities are already present in the database.
-     * @throws NullPointerException if either the iterable is null or any element is null.
-     * @throws UnsupportedOperationException for Key-Value and Wide-Column databases
-     *         that use an append model to write data.
+     * @param <S> Type of the entities to insert.
+     * @return an iterable containing the inserted entities, which may or may not be different instances depending on the Jakarta Data provider.
+     * @throws EntityExistsException if any of the entities are already present in the database (in ACID-supported databases).
+     * @throws NullPointerException if the iterable is null or any element is null.
      */
     <S extends T> Iterable<S> insertAll(Iterable<S> entities);
 

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -96,10 +96,7 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * <p>Non-matching entities are ignored and do not cause an error to be raised.</p>
      *
      * @param entity the entity to update. Must not be {@code null}.
-     * @param <S> Type of the entity to update.
-     * @return the updated entity. The entity instance returned as a result of this method may be the same
-     * instance as the one supplied as a parameter, especially in non-Java record classes. However,
-     * for Jakarta Data providers that support Java records, a different instance may be returned.
+@return true if a matching entity was found in the database to update, otherwise false.
      * @throws NullPointerException if the entity is null.
      */
     @Update

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -67,7 +67,7 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      *
      * @param entities entities to insert.
      * @param <S> Type of the entities to insert.
-     * @return an iterable containing the inserted entities, which may or may not be different instances depending on the Jakarta Data provider.
+     * @return an iterable containing the inserted entities, which may or may not be different instances depending on whether the insert caused values to be generated or automatically incremented.
      * @throws EntityExistsException if any of the entities are already present in the database (in ACID-supported databases).
      * @throws NullPointerException if the iterable is null or any element is null.
      */

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -120,10 +120,7 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * <p>Non-matching entities are ignored and do not cause an error to be raised.</p>
      *
      * @param entities entities to update.
-     * @param <S> Type of the entities to update.
-     * @return an iterable containing the updated entities. In the case of Jakarta Data providers
-     *         that support Java records, this may return a different instance from the input,
-     *         preserving immutability.
+     * @return the number of matching entities that were found in the database to update.
      * @throws NullPointerException if either the iterable is null or any element is null.
      */
     @Update

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -121,6 +121,6 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * @throws NullPointerException if either the iterable is null or any element is null.
      */
     @Update
-    <S extends T> Iterable<S> updateAll(Iterable<S> entities);
+    int updateAll(Iterable<T> entities);
 
 }

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -42,9 +42,11 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * then this method raises {@link EntityExistsException}. In databases that follow the BASE model
      * or use an append model to write data, this exception is not thrown.</p>
      *
-     * <p>The entity instance returned as a result of this method may be the same instance as the one
-     * supplied as a parameter, especially in non-Java record classes. However, for Jakarta Data providers
-     * that support Java records, a different instance may be returned.</p>
+     * <p>The entity instance returned as a result of this method must include all values that were
+     * written to the database, including all automatically generated values and incremented values
+     * that changed due to the insert. After invoking this method, do not continue to use the instance
+     * that is supplied as a parameter. This method makes no guarantees about the state of the
+     * instance that is supplied as a parameter.</p>
      *
      * @param entity the entity to insert. Must not be {@code null}.
      * @param <S> Type of the entity to insert.

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -78,7 +78,7 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      *
      * <p>For an update to be made, a matching entity with the same unique identifier
      * must be present in the database. In databases that use an append model to write data or
-     * follow the BASE model, this method behaves similarly to the {@link #insert} method,
+     * follow the BASE model, this method behaves as the {@link #insert} method,
      * particularly in cases where the database does not support ACID transactions.</p>
      *
      * <p>If the entity is versioned (for example, with {@code jakarta.persistence.Version} or by
@@ -102,7 +102,7 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      *
      * <p>For an update to be made to an entity, a matching entity with the same unique identifier
      * must be present in the database. In databases that use an append model to write data or
-     * follow the BASE model, this method will work similarly to the {@link #insertAll} method,
+     * follow the BASE model, this method  behavior as the {@link #insertAll} method,
      * especially if the database does not support ACID transactions.</p>
      *
      * <p>If the entity is versioned (for example, with {@code jakarta.persistence.Version} or by

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -59,7 +59,7 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * unique identifier as any of the given entities already exists in the database and the database
      * supports ACID transactions, then this method raises {@link EntityExistsException}.
      * In databases that follow the BASE model or use an append model to write data, this exception
-     * may not be thrown.</p>
+     * is not thrown.</p>
      *
      * <p>The entities within the returned iterable may be the same instances as those supplied
      * as parameters, especially in non-Java record classes. However, for Jakarta Data providers

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -40,7 +40,7 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * <p>Inserts an entity into the database. If an entity of this type with the same
      * unique identifier already exists in the database and the database supports ACID transactions,
      * then this method raises {@link EntityExistsException}. In databases that follow the BASE model
-     * or use an append model to write data, this exception may not be thrown.</p>
+     * or use an append model to write data, this exception is not thrown.</p>
      *
      * <p>The entity instance returned as a result of this method may be the same instance as the one
      * supplied as a parameter, especially in non-Java record classes. However, for Jakarta Data providers

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -100,7 +100,7 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * @throws NullPointerException if the entity is null.
      */
     @Update
-    <S extends T> S update(S entity);
+    boolean update(T entity);
 
     /**
      * <p>Modifies entities that already exist in the database.</p>

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -80,8 +80,7 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      *
      * <p>For an update to be made, a matching entity with the same unique identifier
      * must be present in the database. In databases that use an append model to write data or
-     * follow the BASE model, this method behaves as the {@link #insert} method,
-     * particularly in cases where the database does not support ACID transactions.</p>
+     * follow the BASE model, this method behaves the same as the {@link #insert} method.</p>
      *
      * <p>If the entity is versioned (for example, with {@code jakarta.persistence.Version} or by
      * another convention from the entity model such as having an attribute named {@code version}),

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -73,7 +73,8 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      *
      * @param entities entities to insert.
      * @param <S> Type of the entities to insert.
-     * @return an iterable containing the inserted entities, which may or may not be different instances depending on whether the insert caused values to be generated or automatically incremented.
+     * @return an iterable containing the inserted entities, which may or may not be different instances depending
+     * on whether the insert caused values to be generated or automatically incremented.
      * @throws EntityExistsException if any of the entities are already present in the database (in ACID-supported databases).
      * @throws NullPointerException if the iterable is null or any element is null.
      */

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -78,8 +78,8 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      *
      * <p>For an update to be made, a matching entity with the same unique identifier
      * must be present in the database. In databases that use an append model to write data or
-     * follow the BASE model, this method will work similarly to the {@link #insert} method,
-     * especially if the database does not support ACID transactions.</p>
+     * follow the BASE model, this method behaves similarly to the {@link #insert} method,
+     * particularly in cases where the database does not support ACID transactions.</p>
      *
      * <p>If the entity is versioned (for example, with {@code jakarta.persistence.Version} or by
      * another convention from the entity model such as having an attribute named {@code version}),
@@ -88,7 +88,7 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      *
      * <p>Non-matching entities are ignored and do not cause an error to be raised.</p>
      *
-     * @param entity the entity to update.
+     * @param entity the entity to update. Must not be {@code null}.
      * @param <S> Type of the entity to update.
      * @return the updated entity. The entity instance returned as a result of this method may be the same
      * instance as the one supplied as a parameter, especially in non-Java record classes. However,

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -77,7 +77,9 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * <p>Modifies an entity that already exists in the database.</p>
      *
      * <p>For an update to be made, a matching entity with the same unique identifier
-     * must be present in the database.</p>
+     * must be present in the database. In databases that use an append model to write data or
+     * follow the BASE model, this method will work similarly to the {@link #insert} method,
+     * especially if the database does not support ACID transactions.</p>
      *
      * <p>If the entity is versioned (for example, with {@code jakarta.persistence.Version} or by
      * another convention from the entity model such as having an attribute named {@code version}),
@@ -87,16 +89,21 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * <p>Non-matching entities are ignored and do not cause an error to be raised.</p>
      *
      * @param entity the entity to update.
-     * @return true if a matching entity was found in the database to update, otherwise false.
+     * @param <S> Type of the entity to update.
+     * @return the updated entity. The entity instance returned as a result of this method may be the same
+     * instance as the one supplied as a parameter, especially in non-Java record classes. However,
+     * for Jakarta Data providers that support Java records, a different instance may be returned.
      * @throws NullPointerException if the entity is null.
      */
     <S extends T> S update(S entity);
 
     /**
-     * <p>Modifies entities that already exists in the database.</p>
+     * <p>Modifies entities that already exist in the database.</p>
      *
      * <p>For an update to be made to an entity, a matching entity with the same unique identifier
-     * must be present in the database.</p>
+     * must be present in the database. In databases that use an append model to write data or
+     * follow the BASE model, this method will work similarly to the {@link #insertAll} method,
+     * especially if the database does not support ACID transactions.</p>
      *
      * <p>If the entity is versioned (for example, with {@code jakarta.persistence.Version} or by
      * another convention from the entity model such as having an attribute named {@code version}),
@@ -106,7 +113,10 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * <p>Non-matching entities are ignored and do not cause an error to be raised.</p>
      *
      * @param entities entities to update.
-     * @return the number of matching entities that were found in the database to update.
+     * @param <S> Type of the entities to update.
+     * @return an iterable containing the updated entities. In the case of Jakarta Data providers
+     *         that support Java records, this may return a different instance from the input,
+     *         preserving immutability.
      * @throws NullPointerException if either the iterable is null or any element is null.
      */
     <S extends T> Iterable<S> updateAll(Iterable<S> entities);

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -95,8 +95,8 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      *
      * <p>Non-matching entities are ignored and do not cause an error to be raised.</p>
      *
+     * @param entity the entity to update. Must not be {@code null}.
      * @return true if a matching entity was found in the database to update, otherwise false.
-@return true if a matching entity was found in the database to update, otherwise false.
      * @throws NullPointerException if the entity is null.
      */
     @Update

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -63,9 +63,13 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * In databases that follow the BASE model or use an append model to write data, this exception
      * is not thrown.</p>
      *
-     * <p>The entities within the returned iterable may be the same instances as those supplied
-     * as parameters, especially in non-Java record classes. However, for Jakarta Data providers
-     * that support Java records, different instances may be returned.</p>
+     * <p>The entities within the returned {@link Iterable} must include all values that were
+     * written to the database, including all automatically generated values and incremented values
+     * that changed due to the insert. After invoking this method, do not continue to use
+     * the entity instances that are supplied in the parameter. This method makes no guarantees
+     * about the state of the entity instances that are supplied in the parameter.
+     * The position of entities within the {@code Iterable} return value must correspond to the
+     * position of entities in the parameter based on the unique identifier of the entity.</p>
      *
      * @param entities entities to insert.
      * @param <S> Type of the entities to insert.


### PR DESCRIPTION
# Changes

- Make the return an instance instead of a void or boolean
- Enhance documentation explaining that returning the same instance to both methods is ok.
- Enable Data-driven domain-supporting records in all methods.
- Explaining more about the exceptions when the database does not support ACID.


## Challenges

- It would be amazing to have support to record even if JPA does not support it.
- Non-ACID databases can have insert and update methods but with different consistency strategies, such as clock-vector, read-repair, or any async handshake.
- I cannot assume anymore the NoSQL type as we did with the data structure, 

⚠️ it is a Pandora's. I need as much help as possible to support both database engines.
