### PR TITLE
make built-in repositories use the lifecycle annotations

### DIFF
--- a/api/src/main/java/jakarta/data/repository/BasicRepository.java
+++ b/api/src/main/java/jakarta/data/repository/BasicRepository.java
@@ -56,8 +56,7 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
      *         database differs from the version in the entity.
      * @throws NullPointerException If the provided entity is {@literal null}.
      */
-    // TODO Jakarta Validation-related doc was found to be inconsistent with the Jakarta Validation spec
-    //      so it is removed from the save methods for now. Pull #231 will be making corrections.
+    @Save
     <S extends T> S save(S entity);
 
     /**
@@ -81,6 +80,7 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
      *         that differs from the version in the database.
      * @throws NullPointerException If either the iterable is null or any element is null.
      */
+    @Save
     <S extends T> Iterable<S> saveAll(Iterable<S> entities);
 
     /**
@@ -152,6 +152,7 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
      *         or has a version for optimistic locking that is inconsistent with the version in the database.
      * @throws NullPointerException when the entity is null
      */
+    @Delete
     void delete(T entity);
 
     /**
@@ -174,6 +175,7 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
      *         or has a version for optimistic locking that is inconsistent with the version in the database.
      * @throws NullPointerException If either the iterable is null or contains null elements.
      */
+    @Delete
     void deleteAll(Iterable<? extends T> entities);
 
     /**

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -47,6 +47,7 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * @throws UnsupportedOperationException for Key-Value and Wide-Column databases
      *         that use an append model to write data.
      */
+    @Insert
     void insert(T entity);
 
     /**
@@ -60,6 +61,7 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * @throws UnsupportedOperationException for Key-Value and Wide-Column databases
      *         that use an append model to write data.
      */
+    @Insert
     void insertAll(Iterable<T> entities);
 
     /**
@@ -79,6 +81,7 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * @return true if a matching entity was found in the database to update, otherwise false.
      * @throws NullPointerException if the entity is null.
      */
+    @Update
     boolean update(T entity);
 
     /**
@@ -98,5 +101,6 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * @return the number of matching entities that were found in the database to update.
      * @throws NullPointerException if either the iterable is null or any element is null.
      */
+    @Update
     int updateAll(Iterable<T> entities);
 }


### PR DESCRIPTION
The built-in repositories need to be made compliant with the spec change to use the lifecycle annotation rather than a name prefix to designate insert/update/save/delete by adding the corresponding annotation to the built-in repository method.