### PR TITLE
Update signatures after M1

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -287,6 +287,7 @@
               <packages>
                 jakarta.data,
                 jakarta.data.exceptions,
+                jakarta.data.model,
                 jakarta.data.page,
                 jakarta.data.repository
               </packages>

--- a/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/jakarta.data.sig_17
+++ b/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/jakarta.data.sig_17
@@ -93,6 +93,33 @@ hfds serialVersionUID
 
 CLSS abstract interface jakarta.data.exceptions.package-info
 
+CLSS public jakarta.data.model.Attribute
+meth public final boolean init(jakarta.data.model.AttributeInfo)
+meth public final jakarta.data.Sort asc()
+meth public final jakarta.data.Sort ascIgnoreCase()
+meth public final jakarta.data.Sort desc()
+meth public final jakarta.data.Sort descIgnoreCase()
+meth public final java.lang.String name()
+meth public final static jakarta.data.model.Attribute get()
+supr java.lang.Object
+hfds info
+
+CLSS public abstract interface jakarta.data.model.AttributeInfo
+meth public abstract jakarta.data.Sort asc()
+meth public abstract jakarta.data.Sort ascIgnoreCase()
+meth public abstract jakarta.data.Sort desc()
+meth public abstract jakarta.data.Sort descIgnoreCase()
+meth public abstract java.lang.String name()
+
+CLSS public abstract interface !annotation jakarta.data.model.StaticMetamodel
+ anno 0 java.lang.annotation.Documented()
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
+intf java.lang.annotation.Annotation
+meth public abstract java.lang.Class<?> value()
+
+CLSS abstract interface jakarta.data.model.package-info
+
 CLSS abstract interface jakarta.data.package-info
 
 CLSS public abstract interface jakarta.data.page.KeysetAwarePage<%0 extends java.lang.Object>
@@ -325,7 +352,8 @@ meth public void printStackTrace(java.io.PrintStream)
 meth public void printStackTrace(java.io.PrintWriter)
 meth public void setStackTrace(java.lang.StackTraceElement[])
 supr java.lang.Object
-hfds ZeroElementArray,ZeroStackTraceElementArray,cause,detailMessage,disableWritableStackTrace,serialVersionUID,stackTrace,suppressedExceptions,walkback
+hfds CAUSE_CAPTION,EMPTY_THROWABLE_ARRAY,NULL_CAUSE_MESSAGE,SELF_SUPPRESSION_MESSAGE,SUPPRESSED_CAPTION,SUPPRESSED_SENTINEL,UNASSIGNED_STACK,backtrace,cause,depth,detailMessage,serialVersionUID,stackTrace,suppressedExceptions
+hcls PrintStreamOrWriter,SentinelHolder,WrappedPrintStream,WrappedPrintWriter
 
 CLSS public abstract interface java.lang.annotation.Annotation
 meth public abstract boolean equals(java.lang.Object)

--- a/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/jakarta.data.sig_21
+++ b/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/jakarta.data.sig_21
@@ -93,6 +93,33 @@ hfds serialVersionUID
 
 CLSS abstract interface jakarta.data.exceptions.package-info
 
+CLSS public jakarta.data.model.Attribute
+meth public final boolean init(jakarta.data.model.AttributeInfo)
+meth public final jakarta.data.Sort asc()
+meth public final jakarta.data.Sort ascIgnoreCase()
+meth public final jakarta.data.Sort desc()
+meth public final jakarta.data.Sort descIgnoreCase()
+meth public final java.lang.String name()
+meth public final static jakarta.data.model.Attribute get()
+supr java.lang.Object
+hfds info
+
+CLSS public abstract interface jakarta.data.model.AttributeInfo
+meth public abstract jakarta.data.Sort asc()
+meth public abstract jakarta.data.Sort ascIgnoreCase()
+meth public abstract jakarta.data.Sort desc()
+meth public abstract jakarta.data.Sort descIgnoreCase()
+meth public abstract java.lang.String name()
+
+CLSS public abstract interface !annotation jakarta.data.model.StaticMetamodel
+ anno 0 java.lang.annotation.Documented()
+ anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
+ anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
+intf java.lang.annotation.Annotation
+meth public abstract java.lang.Class<?> value()
+
+CLSS abstract interface jakarta.data.model.package-info
+
 CLSS abstract interface jakarta.data.package-info
 
 CLSS public abstract interface jakarta.data.page.KeysetAwarePage<%0 extends java.lang.Object>


### PR DESCRIPTION
I intentionally left out signatures for the `jakarta.data.model` package from the M1 TCK release because: 
1. There was ongoing discussions about this API
2. TCKs are not even required for M1 releases

Opening this PR now to make sure this package is accounted for in future pulls. 

Related #267 #296 