### PR TITLE
TCK test for metamodel class generated at build time

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -67,6 +67,12 @@
             <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>${jakarta.annotation.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/api/src/main/java/jakarta/data/model/StaticMetamodel.java
+++ b/api/src/main/java/jakarta/data/model/StaticMetamodel.java
@@ -73,7 +73,8 @@ import jakarta.data.Sort;
  *                                          Person_.ssn.asc());
  * </pre>
  *
- * <p>When a class is annotated as a {@code StaticMetamodel}, Jakarta Data providers
+ * <p>When a class is annotated with {@code StaticMetamodel} and the
+ * {@link jakarta.annotation.Generated} annotation is not present, Jakarta Data providers
  * that provide a repository for the entity type must assign the value of each field
  * that meets the following criteria:</p>
  *
@@ -99,6 +100,11 @@ import jakarta.data.Sort;
  * entity type, no guarantees are made of the order in which the Jakarta Data providers
  * initialize the {@code Attribute} fields of the class that is annotated with
  * {@code StaticMetamodel}.</p>
+ *
+ * <p>Alternatively, an annotation processor might generate fully implemented
+ * static metamodel classes for your entities during compile time. The generated
+ * classes must be annotated with the {@link jakarta.annotation.Generated} annotation,
+ * which signals the Jakarta Data provider to avoid initializing the classes at run time.</p>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <maven.checkstyle.plugin.version>3.3.0</maven.checkstyle.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <jakarta.annotation.version>1.3.5</jakarta.annotation.version>
+        <jakarta.annotation.version>2.1.1</jakarta.annotation.version>
         <jakarta.enterprise.cdi.version>4.0.1</jakarta.enterprise.cdi.version>   
         <jakarta.inject.version>2.0.1</jakarta.inject.version>     
         <jakarta.json.bind.version>1.0.2</jakarta.json.bind.version>

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -646,11 +646,11 @@ In instances where a Jakarta Data provider for NoSQL databases encounters a recu
 
 Jakarta Data provides a static metamodel that allows entity attributes to be accessed by applications in a type-safe manner.
 
-For each entity class, the application developer can choose to define a separate class, referred to as the metamodel class, following a prescribed set of conventions. The application developer annotates the metamodel class with `@StaticMetamodel`, specifying the entity class as its `value`. The metamodel class must contain one or more fields of type `jakarta.data.model.Attribute` with modifiers `public`, `static`, `final`, with each field named after an entity attribute. The application sets the value of each field to an uninitialized instance obtained from the `Attribute.get` method. A Jakarta Data provider that provides a repository for the entity class must initialize each `Attribute` field for which the field name corresponds to an entity attribute name.
+For each entity class, the application developer or a compile-time annotation processor can define a corresponding metamodel class following a prescribed set of conventions. The metamodel class must be annotated with `@StaticMetamodel`, specifying the entity class as its `value`. The metamodel class must contain one or more fields of type `jakarta.data.model.Attribute` with modifiers `public`, `static`, `final`, with each field named after an entity attribute. Generated metamodel classes for which the implementation is also provided must be annotated with the `jakarta.annotation.Generated` annotation. Otherwise, the value of each field must be set to an uninitialized instance obtained from the `Attribute.get` method. A Jakarta Data provider that provides a repository for the entity class must initialize each `Attribute` field for which the field name corresponds to an entity attribute name.
 
 ===== Application Requirements for a Metamodel Class
 
-For each entity class for which the application wishes to access the metamodel,
+For each entity class for which the application wishes to provide the metamodel,
 
 - The application defines a class (the metamodel class) and annotates it with the `@StaticMetamodel` annotation.
 - The application specifies the `value` of the `@StaticMetamodel` annotation to be an entity class that the application uses in a repository as the result type of a find method or the parameter type of an insert, update, save, or delete method.
@@ -672,9 +672,13 @@ The application can use the field values of the metamodel class to obtain artifa
 
 If the application defines repositories for the same entity class across multiple Jakarta Data providers, no guarantee is made of the order in which the fields of the metamodel class are assigned by the Jakarta Data providers.
 
+===== Compile-time Annotation Processor Requirements for a Metamodel Class
+
+A compile-time annotation processor that generates a metamodel class must follow the same requirements as stated for the Application under "Application Requirements for a Metamodel Class". If the metamodel class is also initialized with implementation, then the metamodel class must also be annotated with the `jakarta.annotation.Generated`. This signals the Jakarta Data providers to avoid attempting to initialize the class.
+
 ===== Jakarta Data Provider Requirements for a Metamodel Class
 
-The Jakarta Data provider observes classes that are annotated with the `@StaticMetamodel` annotation. If the `value` of the `@StaticMetamodel` annotation is an entity class for which the Jakarta Data provides a repository implementation, then the Jakarta Data provider must initialize, via the `Attribute.init` method, the value of each field meeting the criteria that is defined in the "Application Requirements for a Metamodel Class" above with the corresponding entity attribute name. The value of the field that is named `id`, if present, must be initialized by the Jakarta Data provider with the attribute information for the unique identifier if the unique identifier is a single entity attribute.
+The Jakarta Data provider observes classes that are annotated with the `@StaticMetamodel` annotation where the `jakarta.annotation.Generated` is not also present. If the `value` of the `@StaticMetamodel` annotation is an entity class for which the Jakarta Data provides a repository implementation, then the Jakarta Data provider must initialize, via the `Attribute.init` method, the value of each field meeting the criteria that is defined in the "Application Requirements for a Metamodel Class" above with the corresponding entity attribute name. The value of the field that is named `id`, if present, must be initialized by the Jakarta Data provider with the attribute information for the unique identifier if the unique identifier is a single entity attribute.
 
 ===== Example Metamodel Class and Usage
 

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -71,6 +71,13 @@
 
     <!-- Provided Jakarta APIs -->
     <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <version>${jakarta.annotation.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
       <version>${jakarta.servlet.version}</version>

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiChar_.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiChar_.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.framework.read.only;
+
+import jakarta.data.model.Attribute;
+import jakarta.data.model.StaticMetamodel;
+
+/**
+ * This static metamodel class represents what a user might explicitly provide,
+ * in which case the Jakarta Data provider will need to initialize the attributes.
+ */
+@StaticMetamodel(AsciiCharacter.class)
+public interface AsciiChar_ {
+    Attribute id = Attribute.get();
+    Attribute hexadecimal = Attribute.get();
+    Attribute isControl = Attribute.get();
+    Attribute numericValue = Attribute.get();
+    Attribute thisCharacter = Attribute.get();
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacter_.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacter_.java
@@ -15,14 +15,40 @@
  */
 package ee.jakarta.tck.data.framework.read.only;
 
+import jakarta.annotation.Generated;
+import jakarta.data.Sort;
 import jakarta.data.model.Attribute;
+import jakarta.data.model.AttributeInfo;
 import jakarta.data.model.StaticMetamodel;
 
+/**
+ * This static metamodel class represents what an annotation processor-based approach
+ * might generate.
+ */
+@Generated("ee.jakarta.tck.data.mock.generator")
 @StaticMetamodel(AsciiCharacter.class)
-public interface AsciiCharacter_ {
+public class AsciiCharacter_ {
     public static final Attribute id = Attribute.get();
     public static final Attribute hexadecimal = Attribute.get();
     public static final Attribute isControl = Attribute.get();
     public static final Attribute numericValue = Attribute.get();
     public static final Attribute thisCharacter = Attribute.get();
+
+    private static record Attr(String name, Sort asc, Sort ascIgnoreCase, Sort desc, Sort descIgnoreCase)
+                    implements AttributeInfo {
+        private Attr(String name) {
+            this(name, Sort.asc(name), Sort.ascIgnoreCase(name), Sort.desc(name), Sort.descIgnoreCase(name));
+        }
+    };
+
+    static {
+        id.init(new Attr("id"));
+        hexadecimal.init(new Attr("hexadecimal"));
+        isControl.init(new Attr("isControl"));
+        numericValue.init(new Attr("numericValue"));
+        thisCharacter.init(new Attr("thisCharacter"));
+    }
+
+    private AsciiCharacter_() {
+    }
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -42,6 +42,7 @@ import ee.jakarta.tck.data.framework.junit.anno.AnyEntity;
 import ee.jakarta.tck.data.framework.junit.anno.Assertion;
 import ee.jakarta.tck.data.framework.junit.anno.ReadOnlyTest;
 import ee.jakarta.tck.data.framework.junit.anno.Standalone;
+import ee.jakarta.tck.data.framework.read.only.AsciiChar_;
 import ee.jakarta.tck.data.framework.read.only.AsciiCharacter;
 import ee.jakarta.tck.data.framework.read.only.AsciiCharacter_;
 import ee.jakarta.tck.data.framework.read.only.AsciiCharacters;
@@ -1053,14 +1054,14 @@ public class EntityTests {
         assertEquals(0, slice.numberOfElements());
     }
 
-    @Assertion(id = "133", strategy = "Use the StaticMetamodel to obtain ascending Sorts for an entity attribute a type-safe manner.")
+    @Assertion(id = "133", strategy = "Use the StaticMetamodel to obtain ascending Sorts for an entity attribute in a type-safe manner.")
     public void testStaticMetamodelAscendingSorts() {
-        assertEquals(Sort.asc("id"), AsciiCharacter_.id.asc());
-        assertEquals(Sort.asc("isControl"), AsciiCharacter_.isControl.asc());
-        assertEquals(Sort.ascIgnoreCase("hexadecimal"), AsciiCharacter_.hexadecimal.ascIgnoreCase());
-        assertEquals(Sort.ascIgnoreCase("thisCharacter"), AsciiCharacter_.thisCharacter.ascIgnoreCase());
+        assertEquals(Sort.asc("id"), AsciiChar_.id.asc());
+        assertEquals(Sort.asc("isControl"), AsciiChar_.isControl.asc());
+        assertEquals(Sort.ascIgnoreCase("hexadecimal"), AsciiChar_.hexadecimal.ascIgnoreCase());
+        assertEquals(Sort.ascIgnoreCase("thisCharacter"), AsciiChar_.thisCharacter.ascIgnoreCase());
 
-        Pageable pageRequest = Pageable.ofSize(6).sortBy(AsciiCharacter_.numericValue.asc());
+        Pageable pageRequest = Pageable.ofSize(6).sortBy(AsciiChar_.numericValue.asc());
         Page<AsciiCharacter> page1 = characters.findByNumericValueBetween(68, 90, pageRequest);
 
         assertEquals(List.of('D', 'E', 'F', 'G', 'H', 'I'),
@@ -1069,8 +1070,33 @@ public class EntityTests {
                                      .collect(Collectors.toList()));
     }
 
+    @Assertion(id = "133", strategy = "Use a pre-generated StaticMetamodel to obtain ascending Sorts for an entity attribute in a type-safe manner.")
+    public void testStaticMetamodelAscendingSortsPreGenerated() {
+        assertEquals(Sort.ascIgnoreCase("thisCharacter"), AsciiCharacter_.thisCharacter.ascIgnoreCase());
+        assertEquals(Sort.ascIgnoreCase("hexadecimal"), AsciiCharacter_.hexadecimal.ascIgnoreCase());
+        assertEquals(Sort.asc("isControl"), AsciiCharacter_.isControl.asc());
+        assertEquals(Sort.asc("id"), AsciiCharacter_.id.asc());
+
+        Pageable pageRequest = Pageable.ofSize(7).sortBy(AsciiCharacter_.numericValue.asc());
+        Page<AsciiCharacter> firstPage = characters.findByNumericValueBetween(100, 122, pageRequest);
+
+        assertEquals(List.of('d', 'e', 'f', 'g', 'h', 'i', 'j'),
+                     firstPage.stream()
+                                     .map(AsciiCharacter::getThisCharacter)
+                                     .collect(Collectors.toList()));
+    }
+
     @Assertion(id = "133", strategy = "Use the StaticMetamodel to refer to entity attribute names in a type-safe manner.")
     public void testStaticMetamodelAttributeNames() {
+        assertEquals("hexadecimal", AsciiChar_.hexadecimal.name());
+        assertEquals("id", AsciiChar_.id.name());
+        assertEquals("isControl", AsciiChar_.isControl.name());
+        assertEquals("numericValue", AsciiChar_.numericValue.name());
+        assertEquals("thisCharacter", AsciiChar_.thisCharacter.name());
+    }
+
+    @Assertion(id = "133", strategy = "Use a pre-generated StaticMetamodel to refer to entity attribute names in a type-safe manner.")
+    public void testStaticMetamodelAttributeNamesPreGenerated() {
         assertEquals("hexadecimal", AsciiCharacter_.hexadecimal.name());
         assertEquals("id", AsciiCharacter_.id.name());
         assertEquals("isControl", AsciiCharacter_.isControl.name());
@@ -1080,17 +1106,32 @@ public class EntityTests {
 
     @Assertion(id = "133", strategy = "Use the StaticMetamodel to obtain descending Sorts for an entity attribute a type-safe manner.")
     public void testStaticMetamodelDescendingSorts() {
-        assertEquals(Sort.desc("id"), AsciiCharacter_.id.desc());
-        assertEquals(Sort.desc("isControl"), AsciiCharacter_.isControl.desc());
-        assertEquals(Sort.descIgnoreCase("hexadecimal"), AsciiCharacter_.hexadecimal.descIgnoreCase());
-        assertEquals(Sort.descIgnoreCase("thisCharacter"), AsciiCharacter_.thisCharacter.descIgnoreCase());
+        assertEquals(Sort.desc("id"), AsciiChar_.id.desc());
+        assertEquals(Sort.desc("isControl"), AsciiChar_.isControl.desc());
+        assertEquals(Sort.descIgnoreCase("hexadecimal"), AsciiChar_.hexadecimal.descIgnoreCase());
+        assertEquals(Sort.descIgnoreCase("thisCharacter"), AsciiChar_.thisCharacter.descIgnoreCase());
 
-        Sort sort = AsciiCharacter_.numericValue.desc();
+        Sort sort = AsciiChar_.numericValue.desc();
         AsciiCharacter[] found = characters.findFirst3ByNumericValueGreaterThanEqualAndHexadecimalEndsWith(30, "1", sort);
         assertEquals(3, found.length);
         assertEquals('q', found[0].getThisCharacter());
         assertEquals('a', found[1].getThisCharacter());
         assertEquals('Q', found[2].getThisCharacter());
+    }
+
+    @Assertion(id = "133", strategy = "Use a pre-generated StaticMetamodel to obtain descending Sorts for an entity attribute a type-safe manner.")
+    public void testStaticMetamodelDescendingSortsPreGenerated() {
+        assertEquals(Sort.descIgnoreCase("thisCharacter"), AsciiCharacter_.thisCharacter.descIgnoreCase());
+        assertEquals(Sort.descIgnoreCase("hexadecimal"), AsciiCharacter_.hexadecimal.descIgnoreCase());
+        assertEquals(Sort.desc("isControl"), AsciiCharacter_.isControl.desc());
+        assertEquals(Sort.desc("id"), AsciiCharacter_.id.desc());
+
+        Sort sort = AsciiCharacter_.numericValue.desc();
+        AsciiCharacter[] found = characters.findFirst3ByNumericValueGreaterThanEqualAndHexadecimalEndsWith(30, "4", sort);
+        assertEquals(3, found.length);
+        assertEquals('t', found[0].getThisCharacter());
+        assertEquals('d', found[1].getThisCharacter());
+        assertEquals('T', found[2].getThisCharacter());
     }
 
     @Assertion(id = "133", strategy = "Use a repository method that returns Streamable and verify the results.")


### PR DESCRIPTION
This pull adds a TCK test to include a generated static metamodel class.  It also adds spec language to require the `@Generated` annotation on such classes so that Jakarta Data providers can optimize not to attempt initialization of generated metamodel classes that already have implementation.
