### PR TITLE
Modify method signature to handle with changes in the database

### DIFF
--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -96,11 +96,12 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * <p>Non-matching entities are ignored and do not cause an error to be raised.</p>
      *
      * @param entity the entity to update. Must not be {@code null}.
+     * @param <S> Type of the entities to update.
      * @return true if a matching entity was found in the database to update, otherwise false.
      * @throws NullPointerException if the entity is null.
      */
     @Update
-    boolean update(T entity);
+    <S extends T> S update(S entity);
 
     /**
      * <p>Modifies entities that already exist in the database.</p>
@@ -115,12 +116,12 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * the update.</p>
      *
      * <p>Non-matching entities are ignored and do not cause an error to be raised.</p>
-     *
+     *@param <S> Type of the entities to update.
      * @param entities entities to update.
      * @return the number of matching entities that were found in the database to update.
      * @throws NullPointerException if either the iterable is null or any element is null.
      */
     @Update
-    int updateAll(Iterable<T> entities);
+    <S extends T> Iterable<S> updateAll(Iterable<S> entities);
 
 }

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -50,7 +50,8 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      *
      * @param entity the entity to insert. Must not be {@code null}.
      * @param <S> Type of the entity to insert.
-     * @return the inserted entity, which may or may not be a different instance depending on whether the insert caused values to be generated or automatically incremented.
+     * @return the inserted entity, which may or may not be a different instance depending on whether the insert caused
+     * values to be generated or automatically incremented.
      * @throws EntityExistsException if the entity is already present in the database (in ACID-supported databases).
      * @throws NullPointerException if the entity is null.
      */
@@ -81,6 +82,7 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      */
     @Insert
     <S extends T> Iterable<S> insertAll(Iterable<S> entities);
+
     /**
      * <p>Modifies an entity that already exists in the database.</p>
      *
@@ -95,9 +97,17 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      *
      * <p>Non-matching entities are ignored and do not cause an error to be raised.</p>
      *
+     * <p>It's important to note that the update operation may change the entity instance,
+     * especially when certain database controls, such as Optimistic Locking and the {@code @Version} annotation
+     * in Jakarta Persistence, are in place. In these cases, the entity may be modified to reflect
+     * newly generated values or automatically incremented version information. Therefore, the updated entity
+     * returned by this method may or may not be a different instance depending on whether the update
+     * caused values to be generated or automatically incremented.</p>
+     *
      * @param entity the entity to update. Must not be {@code null}.
      * @param <S> Type of the entities to update.
-     * @return true if a matching entity was found in the database to update, otherwise false.
+     * @return the updated entity, which may or may not be a different instance depending on whether the update caused
+     * values to be generated or automatically incremented
      * @throws NullPointerException if the entity is null.
      */
     @Update
@@ -116,7 +126,7 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * the update.</p>
      *
      * <p>Non-matching entities are ignored and do not cause an error to be raised.</p>
-     *@param <S> Type of the entities to update.
+     * @param <S> Type of the entities to update.
      * @param entities entities to update.
      * @return the number of matching entities that were found in the database to update.
      * @throws NullPointerException if either the iterable is null or any element is null.

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -126,6 +126,12 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * the update.</p>
      *
      * <p>Non-matching entities are ignored and do not cause an error to be raised.</p>
+     *
+     * <p>It's important to note that the update operation may change the entity instances,
+     * especially when certain database controls, such as Optimistic Locking and the {@code @Version} annotation
+     * in Jakarta Persistence, are in place. In these cases, the entities may be modified to reflect
+     * newly generated values or automatically incremented version information.</p>
+     *
      * @param <S> Type of the entities to update.
      * @param entities entities to update.
      * @return the number of matching entities that were found in the database to update.


### PR DESCRIPTION
# Change

- modify the update methods to return an instance instead of int.


⚠️ The challenge here is that Persistence can impact performance with Jakarta. However, the API has support for `Version` that implies changes during the update method.
