### PR TITLE
Document both scenarios that the Param annotation is used for

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Param.java
+++ b/api/src/main/java/jakarta/data/repository/Param.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,15 +24,41 @@ import java.lang.annotation.Target;
 
 
 /**
- * Annotation to bind method parameters to a {@link  Query} via a named parameter.
+ * <p>Maps a repository method parameter to a Query Language named parameter
+ * if the method is annotated with {@link Query}. Otherwise, specifies the name of an
+ * entity attribute to compare against the value of the annotated repository method parameter.</p>
+ *
+ * <p>Example usage for a {@code Person} entity with attributes
+ * {@code id}, {@code birthYear}, {@code firstName}, and {@code lastName}:</p>
+ *
+ * <pre>
+ * &#64;Repository
+ * public interface People extends BasicRepository&lt;Person, Long&gt; {
+ *
+ *     // Here, Param refers to the name of a Query Language named parameter,
+ *     &#64;Query("SELECT o FROM Person o WHERE ( EXTRACT(YEAR FROM CURRENT_DATE) - o.birthYear > :age )")
+ *     List&lt;Person&gt; olderThan(&#64;Param("age") int exclusiveMinAge, Sort... sorts);
+ *
+ *     // Here, Param refers to the name of an entity attribute with which to compare,
+ *     List&lt;Person&gt; findNamed(&#64;Param("firstName") String first,
+ *                            &#64;Param("lastName") String last);
+ * }
+ * </pre>
+ *
+ * <p>The {@code Param} annotation is unnecessary when the method parameter name
+ * matches the entity attribute name and the application is compiled with the
+ * {@code -parameters} compiler option that makes parameter names available
+ * at run time.</p>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)
 public @interface Param {
 
     /**
-     * Defines the name of the parameter to bind to.
-     * @return the parameter name
+     * The Query Language named parameter name when used with {@link Query} or
+     * otherwise the entity attribute name to compare with.
+     * @return the name of the Query Language named parameter
+     *         or the name of the entity attribute.
      */
     String value();
 }

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -24,6 +24,7 @@ import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Insert;
 import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
@@ -549,13 +550,16 @@ import java.util.List;
  * the method name begins with {@code find}
  * and must not include the {@code By} keyword.
  * The query conditions are defined by the method parameters.
- * Method parameter names must match the name of an entity attribute.
+ * You can annotate method parameters with the {@link Param} annotation
+ * to specify the name of the entity attribute that the parameter value
+ * is to be compared with. Otherwise, the method parameter name
+ * must match the name of an entity attribute and you must compile
+ * with the {@code -parameters} compiler option that makes parameter
+ * names available at run time.
  * The {@code _} character can be used in method parameter names to
  * reference embedded attributes. All conditions are considered to be
  * the equality condition. All conditions must match in order to
- * retrieve an entity.
- * The developer must compile with the {@code -parameters}
- * compiler option that makes parameter names available at run time.</p>
+ * retrieve an entity.</p>
  *
  * <p>The following examples illustrate the difference between
  * <i>Query By Method Name</i> and <i>Parameter-based Conditions</i> patterns.


### PR DESCRIPTION
This pull is an inferior solution versus #317 and it is preferable that #317 be merged and this pull closed without merging.  However, if #317 is not accepted, then this pull is needed to at least documente the confusing overloaded behavior that currently exists in the spec for using `@Param` to represent both Query Language named parameter names AND entity attribute names depending the presence or absence of an external annotation on the method of which one or more parameters are annotated with `@Param`.