### PR TITLE
TCK tests are missing the Save annotation on lifecycle methods

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
@@ -26,6 +26,7 @@ import jakarta.data.page.Page;
 import jakarta.data.page.Pageable;
 import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Repository;
+import jakarta.data.repository.Save;
 
 /**
  * This is a read only repository that represents the set of AsciiCharacters from 0-256.
@@ -67,5 +68,6 @@ public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long>, I
                         .filter(c -> Character.isLetterOrDigit(c.getThisCharacter()));
     }
 
+    @Save
     Iterable<AsciiCharacter> saveAll(Iterable<AsciiCharacter> characters);
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/ReadOnlyRepository.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/ReadOnlyRepository.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import jakarta.data.repository.DataRepository;
+import jakarta.data.repository.Save;
 
 //FIXME - Are user defined repository interfaces like this allowed via the Specification? 
 // Currently failing in test environment
@@ -29,6 +30,7 @@ public interface ReadOnlyRepository<T, K> extends DataRepository<T, K>{
 
     // WRITE - default method
     // Necessary for pre-population
+    @Save
     <S extends T> Iterable<S> saveAll(Iterable<S> entities);
 
     // READ - default methods

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/nosql/example/Catalog.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/nosql/example/Catalog.java
@@ -19,10 +19,12 @@ import java.util.List;
 
 import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Repository;
+import jakarta.data.repository.Save;
 
 @Repository
 public interface Catalog extends DataRepository<Product, Long> {
-    
+
+    @Save
     void save(Product product);
     void deleteById(Long id);
     

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/Catalog.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/Catalog.java
@@ -27,6 +27,7 @@ import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
+import jakarta.data.repository.Save;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 import ee.jakarta.tck.data.standalone.persistence.Product.Department;
@@ -34,6 +35,7 @@ import ee.jakarta.tck.data.standalone.persistence.Product.Department;
 @Repository
 public interface Catalog extends DataRepository<Product, String> {
 
+    @Save
     void save(Product product);
 
     void deleteById(String productNum);


### PR DESCRIPTION
A couple of TCK tests that were written prior to the spec changes to define lifecycle methods are lacking the `@Save` annotation.  It needs to be added so that the tests can be valid per the requirements of the spec.