### PR TITLE
TCK tests for life cycle methods

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Delete.java
+++ b/api/src/main/java/jakarta/data/repository/Delete.java
@@ -50,8 +50,8 @@ import java.lang.annotation.Target;
  *     Car unpark(Car car);
  * }
  * </pre>
- * * <p>If this annotation is combined with other operation annotations (e.g., {@code @Insert}, {@code @Update},
- *  * {@code @Save}), it will throw an {@link UnsupportedOperationException} as only one operation type can be specified.</p>
+ * <p>If this annotation is combined with other operation annotations (e.g., {@code @Insert}, {@code @Update},
+ * {@code @Save}), it will throw an {@link UnsupportedOperationException} as only one operation type can be specified.</p>
  * <p>If the unique identifier of an entity is not found in the database or its version does not match, and the return
  * type of the annotated method is {@code void} or {@code Void}, the method must
  * raise {@link jakarta.data.exceptions.OptimisticLockingFailureException}.

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/Catalog.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/Catalog.java
@@ -23,17 +23,38 @@ import java.util.stream.Stream;
 import jakarta.data.Sort;
 import jakarta.data.Streamable;
 import jakarta.data.repository.DataRepository;
+import jakarta.data.repository.Delete;
+import jakarta.data.repository.Insert;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
+import jakarta.data.repository.Update;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 import ee.jakarta.tck.data.standalone.persistence.Product.Department;
 
 @Repository
 public interface Catalog extends DataRepository<Product, String> {
+
+    @Insert
+    Product add(Product product);
+
+    @Insert
+    Product[] addMultiple(Product... products);
+
+    @Update
+    Product modify(Product product);
+
+    @Update
+    Product[] modifyMultiple(Product... products);
+
+    @Delete
+    boolean remove(Product product);
+
+    @Delete
+    void removeMultiple(Product... products);
 
     @Save
     void save(Product product);

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/PersistenceEntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/PersistenceEntityTests.java
@@ -197,6 +197,7 @@ public class PersistenceEntityTests {
         Product[] added = catalog.addMultiple(Product.of("blueberries", 2.49, "TEST-PROD-95", Department.GROCERY),
                                               Product.of("strawberries", 2.29, "TEST-PROD-96", Department.GROCERY),
                                               Product.of("raspberries", 2.39, "TEST-PROD-97", Department.GROCERY));
+assertEquals(3, added.length);
 
         // The position of resulting entities must match the parameter
         assertEquals("blueberries", added[0].getName());

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/PersistenceEntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/PersistenceEntityTests.java
@@ -136,7 +136,7 @@ public class PersistenceEntityTests {
         assertEquals(5L, catalog.deleteByProductNumLike("TEST-PROD-%"));
     }
 
-    @Assertion(id = "133", strategy = "Attempt to insert and entity that already exists in the database and expect EntityExistsException.")
+    @Assertion(id = "133", strategy = "Attempt to insert an entity that already exists in the database and expect EntityExistsException.")
     public void testInsertEntityThatAlreadyExists() {
         catalog.deleteByProductNumLike("TEST-PROD-%");
 


### PR DESCRIPTION
Add TCK for Insert, Update, and Delete life cycle methods.
Cover both single entity as well as multiple entities in the parameter.
Use an entity with a generated version and confirm it gets updated and is used to make updates.
Confirm that exceptions are raised per the spec requirements.

I also removed two extra `*` characters that I noticed in JavaDoc.