### PR TITLE
document persistence context requirements for initial version of spec

### DIFF
--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -759,6 +759,26 @@ import java.util.List;
  * }
  * </pre>
  *
+ * <h2>Jakarta Persistence</h2>
+ *
+ * <h3>Persistence Context</h3>
+ *
+ * <p>When the Jakarta Data provider is backed by a Jakarta Persistence provider,
+ * repository operations must behave as though backed by a stateless Entity Manager
+ * in that persistence context is not preserved across the end of repository methods.
+ * If you retrieve an entity via a repository and then modify the entity,
+ * the modifications are not persisted to the database unless you explicitly invoke
+ * a {@link Save} or {@link Update} operation in order to persist it.</p>
+ *
+ * <p>Here is an example with {@link BasicRepository#findById(K)} and
+ * {@link BasicRepository#save(S)} operations:</p>
+ *
+ * <pre>
+ * product = products.findById(prodNum).orElseThrow();
+ * product.price = produce.price + 0.50;
+ * product = products.save(product);
+ * </pre>
+ *
  * <h2>Jakarta Transactions</h2>
  *
  * <p>Repository methods can participate in global transactions.

--- a/spec/src/main/asciidoc/jakarta-ee.adoc
+++ b/spec/src/main/asciidoc/jakarta-ee.adoc
@@ -89,6 +89,10 @@ A Jakarta Data provider that supports Jakarta Persistence allows you to define r
 
 By supporting Jakarta Persistence annotations, Jakarta Data providers enable Java developers to utilize familiar and standardized mapping techniques when defining entities in repositories, ensuring compatibility and interoperability with the respective technologies.
 
+==== Persistence Context
+
+Repository operations must behave as though backed by a stateless Entity Manager in that persistence context is not preserved across the end of repository methods. All entities that are returned by repository methods must be in a detached state such that modifications to these entities are not persisted to the database unless the application explicitly invokes a `Save` or `Update` life cycle method for the entity.
+
 === Jakarta NoSQL
 
 When integrating Jakarta Data with Jakarta NoSQL, developers can use the NoSQL annotations to define the mapping of entities in repositories. Entities in Jakarta NoSQL are typically annotated with `jakarta.nosql.Entity` to indicate their suitability for persistence in NoSQL databases.


### PR DESCRIPTION
Fixes #224 for Jakarta Data 1.0.  Subsequent versions of the specification can look into whether we would like to have modes that would externalize the concept of persistence context to applications.