### PR TITLE
TCK tests for primary entity type and By

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
@@ -24,6 +24,7 @@ import jakarta.data.Sort;
 import jakarta.data.Streamable;
 import jakarta.data.page.Page;
 import jakarta.data.page.Pageable;
+import jakarta.data.repository.By;
 import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
@@ -41,6 +42,9 @@ public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long>, I
     boolean existsByThisCharacter(char ch);
 
     AsciiCharacter find(char thisCharacter);
+
+    Optional<AsciiCharacter> find(@By("thisCharacter") char ch,
+                                  @By("hexadecimal") String hex);
 
     Collection<AsciiCharacter> findByHexadecimalContainsAndIsControlNot(String substring, boolean isPrintable);
 

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/CustomRepository.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/CustomRepository.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.framework.read.only;
+
+import java.util.List;
+import java.util.Set;
+
+import jakarta.data.repository.Delete;
+import jakarta.data.repository.Insert;
+import jakarta.data.repository.Repository;
+
+/**
+ * Do not add methods or inheritance to this interface.
+ * Its purpose is to test that without inheriting from a built-in repository,
+ * the life cycle methods with the same entity class are what identifies the
+ * primary entity class to use for the count and exist methods.
+ */
+@Repository
+public interface CustomRepository {
+
+    @Insert
+    void add(List<NaturalNumber> list);
+
+    int countByIdIn(Set<Long> ids);
+
+    boolean existsByIdIn(Set<Long> ids);
+
+    @Delete
+    void remove(List<NaturalNumber> list);
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -45,6 +45,7 @@ import ee.jakarta.tck.data.framework.junit.anno.Standalone;
 import ee.jakarta.tck.data.framework.read.only.AsciiCharacter;
 import ee.jakarta.tck.data.framework.read.only.AsciiCharacters;
 import ee.jakarta.tck.data.framework.read.only.AsciiCharactersPopulator;
+import ee.jakarta.tck.data.framework.read.only.CustomRepository;
 import ee.jakarta.tck.data.framework.read.only.NaturalNumber;
 import ee.jakarta.tck.data.framework.read.only.NaturalNumbers;
 import ee.jakarta.tck.data.framework.read.only.NaturalNumbersPopulator;
@@ -84,6 +85,9 @@ public class EntityTests {
 
     @Inject
     PositiveIntegers positives; // shares same read-only data with NaturalNumbers
+
+    @Inject
+    CustomRepository customRepo; // shares same read-only data with NaturalNumbers
 
     @Inject
     AsciiCharacters characters;
@@ -159,6 +163,17 @@ public class EntityTests {
         assertEquals(0, slice.stream().count());
         assertEquals(false, slice.hasContent());
         assertEquals(false, slice.iterator().hasNext());
+    }
+
+    @Assertion(id = "133", strategy = "Use a parameter-based find operation that uses the By annotation to identify the entity attribute names.")
+    public void testBy() {
+        AsciiCharacter ch = characters.find('L', "4c").orElseThrow();
+        assertEquals('L', ch.getThisCharacter());
+        assertEquals("4c", ch.getHexadecimal());
+        assertEquals(76L, ch.getId());
+        assertEquals(false, ch.isControl());
+
+        assertEquals(true, characters.find('M', "4b").isEmpty());
     }
 
     @Assertion(id = "133", strategy = "Use a repository that inherits some if its methods from another interface.")
@@ -1030,6 +1045,15 @@ public class EntityTests {
         assertEquals(false, page.iterator().hasNext());
         assertEquals(0L, page.totalElements());
         assertEquals(0L, page.totalPages());
+    }
+
+    @Assertion(id = "133", strategy = "Use count and exists methods where the primary entity class is inferred from the life cycle methods.")
+    public void testPrimaryEntityClassDeterminedByLifeCycleMethods() {
+        assertEquals(4, customRepo.countByIdIn(Set.of(2L, 15L, 37L, -5L, 60L)));
+
+        assertEquals(true, customRepo.existsByIdIn(Set.of(17L, 14L, -1L)));
+
+        assertEquals(false, customRepo.existsByIdIn(Set.of(-10L, -12L, -14L)));
     }
 
     @Assertion(id = "133", strategy = "Use a repository method that returns a single entity value where a single result is found.")


### PR DESCRIPTION
Add TCK tests:

Use count and exists methods where the primary entity class is inferred from the life cycle methods.

Use a parameter-based find operation that uses the By annotation to identify the entity attribute names.

