### PR TITLE
help users locate the main Jakarta Data overview page in JavaDoc

### DIFF
--- a/api/src/main/java/jakarta/data/package-info.java
+++ b/api/src/main/java/jakarta/data/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,9 @@
  */
 
 /**
- *Jakarta Data provides an API that makes data access easy. A Java developer can split the persistence
- * from the model with several features, such as the ability to compose custom query methods
- * on a Repository interface where the framework will implement it.
+ * <p>Jakarta Data provides an API that simplifies data access. It enables the Java developer to
+ * focus on the data model, while delegating away the complexities of data persistence.</p>
+ *
+ * <p>The module JavaDoc provides an {@link jakarta.data/ overview} of Jakarta Data.</p>
  */
 package jakarta.data;

--- a/api/src/main/java/jakarta/data/page/package-info.java
+++ b/api/src/main/java/jakarta/data/page/package-info.java
@@ -64,5 +64,7 @@
  * {@link jakarta.data.page.KeysetAwareSlice} and {@link jakarta.data.page.KeysetAwarePage}. In this approach,
  * queries for the next or previous page are performed relative to the last
  * or first entry of the current page.</p>
+ *
+ * <p>The module JavaDoc provides an {@link jakarta.data/ overview} of Jakarta Data.</p>
  */
 package jakarta.data.page;

--- a/api/src/main/java/jakarta/data/repository/Repository.java
+++ b/api/src/main/java/jakarta/data/repository/Repository.java
@@ -55,6 +55,8 @@ import java.lang.annotation.Target;
  * found = products.findByNameLike("%Printer%");
  * numUpdated = products.putOnSale(0.15f, 20.0f);
  * </pre>
+ *
+ * <p>The module JavaDoc provides an {@link jakarta.data/ overview} of Jakarta Data.</p>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/jakarta/data/repository/package-info.java
+++ b/api/src/main/java/jakarta/data/repository/package-info.java
@@ -16,9 +16,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 /**
- * In Domain-driven design, DDD, a repository is an object that participates in the domain but abstracts away storage
- * and infrastructure details. Most systems have persistent storage,
- * like a database, for their full functioning. Applying repositories happens
- * by integrating and synchronizing with existing aggregate objects in the system.
+ * <p>A repository is an interface annotated with {@link Repository} that defines
+ * operations on entities. Entities represent data in the persistent store.
+ * In Domain-driven design, a repository participates in the domain but abstracts away storage
+ * and infrastructure details.</p>
+ *
+ * <p>Repository interfaces can optionally inherit from built-in interfaces within this package,</p>
+ *
+ * <ul>
+ * <li>{@link DataRepository} - root of the hierarchy, allows the entity type to be specified as a type parameter.</li>
+ * <li>{@link BasicRepository} - provides common find, delete, and save operations.</li>
+ * <li>{@link CrudRepository} - extends the {@code BasicRepository} to add {@link CrudRepository#insert(S) insert}
+ *     and {@link CrudRepository#update(T) update} operations.</li>
+ * <li>{@link PageableRepository} - extends the {@code BasicRepository} with a built-in method that uses pagination.</li>
+ * </ul>
+ *
+ * <p>Repository interfaces can also define their own life cycle methods using the
+ * {@link Insert}, {@link Update}, {@link Save}, and {@link Delete} annotations,
+ * as well as a variety of other methods following the Query by Method Name pattern,
+ * the Parameter-based Conditions pattern, and the {@link Query} annotation.</p>
+ *
+ * <p>The module JavaDoc provides an {@link jakarta.data/ overview} of Jakarta Data.</p>
  */
 package jakarta.data.repository;


### PR DESCRIPTION
It is likely that users will find the JavaDoc via a number of different entry points, such as google searches for a particular spec interface.  This pull cleans up some package level JavaDoc and adds links to our main overview JavaDoc page to help users be able to locate it even if they had a different starting point and it doesn't otherwise occur to them to click on the link to the Module javadoc.