### PR TITLE
review of pagination JavaDoc

### DIFF
--- a/api/src/main/java/jakarta/data/page/KeysetAwarePage.java
+++ b/api/src/main/java/jakarta/data/page/KeysetAwarePage.java
@@ -18,11 +18,12 @@
 package jakarta.data.page;
 
 /**
- * <p>A page of results from a repository query that performs
- * {@link KeysetAwareSlice keyset pagination}.</p>
+ * <p>A page of data with the ability to create a cursor from the keyset
+ * of each entity in the page. This class inherits from {@link KeysetAwareSlice},
+ * which is where most of the documentation on keyset curosr-based pagination
+ * can be found.</p>
  *
- * <p>The concept of {@link Page} differs from {@link Slice} in that slices
- * do not have awareness of a total number of pages or results. Page numbers
+ * <p>Page numbers
  * and total numbers of pages and results cannot be accurately known
  * with keyset pagination, which allows entities to be added and removed
  * in between traversal of slices or pages. When keyset pagination is used,

--- a/api/src/main/java/jakarta/data/page/KeysetAwareSlice.java
+++ b/api/src/main/java/jakarta/data/page/KeysetAwareSlice.java
@@ -20,13 +20,16 @@ package jakarta.data.page;
 import jakarta.data.repository.OrderBy;
 
 /**
+ * <p>A slice of data with the ability to create a cursor from the
+ * keyset of each entity in the slice.</p>
+ *
  * <p>Keyset pagination is a form of pagination that aims to reduce the
  * possibility of missed or duplicate results by making the request for
  * each subsequent page relative to the observed values of entity properties
  * from the current page. This list of values is referred to as the keyset
- * and only includes values of entity properties that are in the sort criteria
+ * and consists of the values of entity properties that are in the sort criteria
  * of the repository method. The combination of sort criteria must uniquely
- * identify each entity. The keyset values can be from the last entity
+ * identify each entity. The keyset values can be from the last entity on the page
  * (for pagination in a forward direction) or first entity on the page
  * (if requesting pages in a reverse direction),
  * or can be any other desired list of values which serve as a new starting
@@ -46,7 +49,7 @@ import jakarta.data.repository.OrderBy;
  * KeysetAwareSlice&lt;Employee&gt; findByHoursWorkedGreaterThan(int hours, Pageable pagination);
  * </pre>
  *
- * <p>You can use a normal {@link Pageable} to request an initial page,</p>
+ * <p>You can use an offset-based {@link Pageable} to request an initial page,</p>
  *
  * <pre>
  * page = employees.findByHoursWorkedGreaterThan(1500, Pageable.ofSize(50));
@@ -59,12 +62,12 @@ import jakarta.data.repository.OrderBy;
  * page = employees.findByHoursWorkedGreaterThan(1500, page.nextPageable());
  * </pre>
  *
- * <p>Because the page is keyset aware, the {@link Pageable}
+ * <p>Because the page is keyset aware, the {@link Pageable page request}
  * that it returns from the call to {@link KeysetAwareSlice#nextPageable}
- * above is based upon a keyset from that page to use as a starting point
+ * above is based upon a keyset cursor from that page to use as a starting point
  * after which the results for the next page are to be found.</p>
  *
- * <p>You can also construct a {@link Pageable} with a {@link Pageable.Cursor Cursor} directly, which
+ * <p>You can also construct a {@link Pageable page request} with a {@link Pageable.Cursor Cursor} directly, which
  * allows you to make it relative to a specific list of values. The number and
  * order of values must match that of the {@link OrderBy} annotations,
  * {@link Pageable#sortBy(jakarta.data.Sort...)} or {@link Pageable#sortBy(Iterable)} parameters,
@@ -109,6 +112,10 @@ import jakarta.data.repository.OrderBy;
  * KeysetAwareSlice&lt;Customer&gt; getTopBuyers(int minOrders, float minSpent, Pageable pagination);
  * </pre>
  *
+ * <p>Queries that are used with keyset pagination must return entities
+ * because keyset cursors are created from the entity attribute values that
+ * form the keyset.</p>
+ *
  * <h2>Page Numbers and Totals</h2>
  *
  * <p>Page numbers, total numbers of elements across all pages, and total
@@ -135,11 +142,11 @@ public interface KeysetAwareSlice<T> extends Slice<T> {
     Pageable.Cursor getKeysetCursor(int index);
 
     /**
-     * <p>Returns pagination information for requesting the next page
+     * <p>Creates a request for the next page
      * in a forward direction from the current page. This method computes a
-     * keyset from the last entity of the current page and includes the
-     * keyset in the pagination information so that it can be used to
-     * obtain the next slice in a forward direction according to the
+     * keyset cursor from the last entity of the current page and includes the
+     * cursor in the pagination information so that it can be used to
+     * obtain the next page in a forward direction according to the
      * sort criteria and relative to that entity.</p>
      *
      * @return pagination information for requesting the next page, or
@@ -150,10 +157,10 @@ public interface KeysetAwareSlice<T> extends Slice<T> {
     Pageable nextPageable();
 
     /**
-     * <p>Returns pagination information for requesting the previous page
+     * <p>Creates a request for the previous page
      * in a reverse direction from the current page. This method computes a
-     * keyset from the first entity of the current page and includes the
-     * keyset in the pagination information so that it can be used to
+     * keyset cursor from the first entity of the current page and includes the
+     * cursor in the pagination information so that it can be used to
      * obtain the previous slice in a reverse direction to the sort criteria
      * and relative to that entity. Within a single page, results are not
      * reversed and remain ordered according to the sort criteria.</p>

--- a/api/src/main/java/jakarta/data/page/Page.java
+++ b/api/src/main/java/jakarta/data/page/Page.java
@@ -18,7 +18,15 @@
 package jakarta.data.page;
 
 /**
- * <p>A page is a sublist of results. It provides information about its position relative to the entire list.</p>
+ * <p>A page contains the data that is retrieved for a page request
+ * and has awareness of the total number of pages.</p>
+ *
+ * <p>A page is a sublist of results. It provides information about its position relative to the entire list.
+ * A page is obtained by supplying a {@link Pageable} parameter to a repository method. For example,</p>
+ *
+ * <pre>
+ * {@code Page<Employee>} findByYearHired(int year, Pageable pageRequest);
+ * </pre>
  *
  * <p>Repository methods that are declared to return <code>Page</code> or
  * {@link KeysetAwarePage} must raise {@link UnsupportedOperationException} if the
@@ -26,13 +34,16 @@ package jakarta.data.page;
  * in which case a return type of {@link Slice} or {@link KeysetAwareSlice}
  * should be used instead.</p>
  *
+ * <p>For a lighter weight subset of query results that does not have awareness of the
+ * total number of pages, {@link Slice} can be used instead of page.</p>
+ *
  * @param <T> the type of elements in this page 
  */
 public interface Page<T> extends Slice<T> {
 
     /**
-     * Returns the total amount of elements.
-     * @return the total amount of elements.
+     * Returns the total number of elements across all pages that can be requested for the query.
+     * @return the total number of elements across all pages.
      */
     long totalElements();
 

--- a/api/src/main/java/jakarta/data/page/Pageable.java
+++ b/api/src/main/java/jakarta/data/page/Pageable.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * <p>This class represents pagination information.</p>
+ * <p>A request for a page or slice.</p>
  *
  * <p><code>Pageable</code> is optionally specified as a parameter to a
  * repository method in one of the parameter positions after the
@@ -64,7 +64,7 @@ import java.util.Optional;
 public interface Pageable {
 
     /**
-     * Creates a new <code>Pageable</code> with the given page number and with a default size of 10.
+     * Creates a new page request with the given page number and with a default size of 10.
      *
      * @param pageNumber The page number.
      * @return a new instance of <code>Pageable</code>. This method never returns <code>null</code>.
@@ -75,7 +75,7 @@ public interface Pageable {
     }
 
     /**
-     * Creates a new <code>Pageable</code> for requesting pages of the
+     * Creates a new page request for requesting pages of the
      * specified size, starting with the first page number, which is 1.
      *
      * @param maxPageSize The number of query results in a full page.
@@ -182,7 +182,7 @@ public interface Pageable {
     int size();
 
     /**
-     * Return the order collection if it was specified on this <code>Pageable</code>, otherwise an empty list.
+     * Return the order collection if it was specified on this page request, otherwise an empty list.
      *
      * @return the order collection; will never be {@literal null}.
      */
@@ -205,7 +205,7 @@ public interface Pageable {
     Pageable next();
 
     /**
-     * <p>Creates a new <code>Pageable</code> instance representing the same
+     * <p>Creates a new page request with the same
      * pagination information, except with the specified page number.</p>
      *
      * @param pageNumber The page number
@@ -214,8 +214,11 @@ public interface Pageable {
     Pageable page(long pageNumber);
 
     /**
-     * <p>Creates a new <code>Pageable</code> instance representing the same
-     * pagination information, except with the specified maximum page size.</p>
+     * <p>Creates a new page request with the same
+     * pagination information, except with the specified maximum page size.
+     * When a page is retrieved from the database, the number of elements in the page
+     * must be equal to the maximum page size unless there is an insufficient number
+     * of elements to retrieve from the database from the start of the page.</p>
      *
      * @param maxPageSize the number of query results in a full page.
      * @return a new instance of <code>Pageable</code>. This method never returns <code>null</code>.
@@ -223,7 +226,7 @@ public interface Pageable {
     Pageable size(int maxPageSize);
 
     /**
-     * <p>Creates a new <code>Pageable</code> instance representing the same
+     * <p>Creates a new page request with the same
      * pagination information, except using the specified sort criteria.
      * The order of precedence for sort criteria is that of any statically
      * specified sort criteria (from the <code>OrderBy</code> keyword,
@@ -237,7 +240,7 @@ public interface Pageable {
     Pageable sortBy(Iterable<Sort> sorts);
 
     /**
-     * <p>Creates a new <code>Pageable</code> instance representing the same
+     * <p>Creates a new page request with the same
      * pagination information, except using the specified sort criteria.
      * The order of precedence for sort criteria is that of any statically
      * specified sort criteria (from the <code>OrderBy</code> keyword,
@@ -252,25 +255,21 @@ public interface Pageable {
     Pageable sortBy(Sort... sorts);
 
     /**
-     * The type of pagination, which can be offset pagination or
-     * keyset cursor pagination which includes a direction.
+     * The type of pagination: offset-based or
+     * keyset cursor-based, which includes a direction.
      */
     enum Mode {
         /**
          * Indicates forward keyset pagination, which follows the
-         * direction of the {@link OrderBy} annotations,
-         * {@link Pageable#sortBy(Sort...)} or {@link Pageable#sortBy(Iterable)}
-         * parameters, repository method {@link Sort} parameters,
-         * or <code>OrderBy</code> name pattern of the repository method.
+         * direction of the sort criteria, using a cursor that is
+         * formed from the keyset of the last entity on the current page.
          */
         CURSOR_NEXT,
 
         /**
          * Indicates a request for a page with keyset pagination
-         * in the reverse direction of the {@link OrderBy} annotations,
-         * {@link Pageable#sortBy(Sort...)} or {@link Pageable#sortBy(Iterable)}
-         * parameters, repository method {@link Sort} parameters,
-         * or <code>OrderBy</code> name pattern of the repository method.
+         * in the reverse direction of the sort criteria, using a cursor
+         * that is formed from the keyset of first entity on the current page.
          * The order of results on each page follows the sort criteria
          * and is not reversed.
          */
@@ -286,19 +285,21 @@ public interface Pageable {
     }
 
     /**
-     * Represents keyset values, which can be a starting point for
-     * requesting a next or previous page.
+     * A cursor that is formed from a keyset, relative to which a next
+     * or previous page can be requested.
      */
     interface Cursor {
         /**
-         * Returns whether or not the keyset values of this instance
-         * are equal to those of the supplied instance.
-         * Cursor implementation classes must also match to be equal.
+         * Returns whether or not the keyset values of this cursor
+         * are equal to those of the supplied cursor.
+         * Both instances must also have the same cursor implementation class
+         * in order to be considered equal.
          *
+         * @param cursor a keyset cursor against which to compare.
          * @return true or false.
          */
         @Override
-        boolean equals(Object o);
+        boolean equals(Object cursor);
 
         /**
          * Returns the keyset value at the specified position.

--- a/api/src/main/java/jakarta/data/page/Slice.java
+++ b/api/src/main/java/jakarta/data/page/Slice.java
@@ -50,7 +50,7 @@ public interface Slice<T> extends Streamable<T> {
      * sorting first by the sort criteria of the repository method,
      * and then by the sort criteria of the page request.
      *
-     * @return the page content as a {@link List}; will never be {@literal null}.
+     * @return the page content as a {@link List}; will never be {@code null}.
      */
     List<T> content();
 

--- a/api/src/main/java/jakarta/data/page/Slice.java
+++ b/api/src/main/java/jakarta/data/page/Slice.java
@@ -21,16 +21,36 @@ import jakarta.data.Streamable;
 import java.util.List;
 
 /**
- * A slice of data that indicates whether there's a next or previous slice available.
+ * <p>A slice contains the data that is retrieved for a page request.
+ * A slice is obtained by supplying a {@link Pageable} parameter to a repository method.
+ * For example,</p>
  *
- * @param <T> the type of elements in this slice 
+ * <pre>
+ * {@code Slice<Vehicle>} find({@code @By("make")} String make,
+ *                     {@code @By("model")} String model,
+ *                     {@code @By("year")} int designYear,
+ *                     Pageable pagination);
+ * </pre>
+ *
+ * <p>Unlike {@link Page}, a {@code Slice} does not have awareness of the total number of pages
+ * that can be retrieved for the query.</p>
+ *
+ * <p>The lowercase terms, <i>slice</i> and <i>page</i>, are used interchangeably
+ * throughout this specification. Wherever a distinction needs to be made between them,
+ * the class name, {@code Slice} or {@code Page}, is used.</p>
+ *
+ * @param <T> the type of elements in this slice.
  */
 public interface Slice<T> extends Streamable<T> {
 
     /**
-     * Returns the page content as {@link List}.
+     * Returns the page content as a {@link List}.
+     * The list is sorted according to the combined sort criteria of the repository method
+     * and the sort criteria of the page request that is supplied to the repository method,
+     * sorting first by the sort criteria of the repository method,
+     * and then by the sort criteria of the page request.
      *
-     * @return the page content as {@link List}; will never be {@literal null}.
+     * @return the page content as a {@link List}; will never be {@literal null}.
      */
     List<T> content();
 
@@ -42,23 +62,28 @@ public interface Slice<T> extends Streamable<T> {
     boolean hasContent();
 
     /**
-     * Returns the number of elements currently on this Slice.
+     * Returns the number of elements in this Slice,
+     * which must be no larger than the maximum
+     * {@link Pageable#size() size} of the page request.
+     * If the number of elements in the slice is less than the maximum page size,
+     * then there are no subsequent slices of data to read.
      *
-     * @return the number of elements currently on this Slice.
+     * @return the number of elements in this Slice.
      */
     int numberOfElements();
 
     /**
-     * Returns the current {@link Pageable}
+     * Returns the {@link Pageable page request} for which this
+     * slice was obtained.
      *
-     * @return the current Pageable; will never be {@literal null}.
+     * @return the request for the current page; will never be {@literal null}.
      */
     Pageable pageable();
 
     /**
-     * Returns the next {@link Pageable#next()}, or <code>null</code> if it is known that there is no next page.
+     * Returns a request for the {@link Pageable#next() next} page, or <code>null</code> if it is known that there is no next page.
      *
-     * @return the next pageable.
+     * @return a request for the next page.
      */
     Pageable nextPageable();
 }

--- a/api/src/main/java/jakarta/data/page/package-info.java
+++ b/api/src/main/java/jakarta/data/page/package-info.java
@@ -44,10 +44,10 @@
  * but does not offer a total count of results across all slices. Using slice
  * rather than page is more efficient when a total count of results is not needed.</p>
  *
- * <p>Slices and pages can be determined based on fixed positional index
+ * <p>Slices and pages can be determined based on fixed positional offset
  * or relative to a cursor.</p>
  *
- * <p>{@link jakarta.data.page.Slice} and {@link jakarta.data.page.Page} are computed based on their positional index
+ * <p>{@link jakarta.data.page.Slice} and {@link jakarta.data.page.Page} are computed based on their positional offset
  * within the list of results. For example, if you are on the first page of 10
  * and request the next page, the database identifies the matching entities
  * for the query at positions 11 through 20 and retrieves them. Results are

--- a/api/src/main/java/jakarta/data/repository/OrderBy.java
+++ b/api/src/main/java/jakarta/data/repository/OrderBy.java
@@ -113,6 +113,12 @@ public @interface OrderBy {
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.METHOD)
     @interface List {
+        /**
+         * Returns a list of annotations with the first taking precedence,
+         * followed by the second, and so forth.
+         *
+         * @return list of annotations.
+         */
         OrderBy[] value();
     }
 }

--- a/api/src/test/java/jakarta/data/page/KeysetPageableTest.java
+++ b/api/src/test/java/jakarta/data/page/KeysetPageableTest.java
@@ -194,9 +194,9 @@ class KeysetPageableTest {
     @Test
     @DisplayName("Should raise IllegalArgumentException when keyset values are absent")
     void shouldRaiseErrorForMissingKeysetValues() {
-        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.ofSize(60).afterKeyset(null));
+        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.ofSize(60).afterKeyset((Object[]) null));
         assertThatIllegalArgumentException().isThrownBy(() -> Pageable.ofSize(70).afterKeyset(new Object[0]));
-        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.ofSize(80).beforeKeyset(null));
+        assertThatIllegalArgumentException().isThrownBy(() -> Pageable.ofSize(80).beforeKeyset((Object[]) null));
         assertThatIllegalArgumentException().isThrownBy(() -> Pageable.ofSize(90).beforeKeyset(new Object[0]));
     }
 

--- a/spec/src/main/asciidoc/chapters/introduction/introduction.asciidoc
+++ b/spec/src/main/asciidoc/chapters/introduction/introduction.asciidoc
@@ -60,6 +60,8 @@ These clarifications emphasize Jakarta Data's role as a complementary and simpli
 
 === Conventions
 
+The terms, _entity attribute_ and _entity property_, are used interchangeably throughout the specification.
+
 The lower case terms, _slice_ and _page_, are used interchangeably throughout the specification. Where there is a need to distinguish, the class name, `Slice` or `Page`, is used.
 
 include::project_team.adoc[]

--- a/spec/src/main/asciidoc/chapters/introduction/introduction.asciidoc
+++ b/spec/src/main/asciidoc/chapters/introduction/introduction.asciidoc
@@ -60,4 +60,6 @@ These clarifications emphasize Jakarta Data's role as a complementary and simpli
 
 === Conventions
 
+The lower case terms, _slice_ and _page_, are used interchangeably throughout the specification. Where there is a need to distinguish, the class name, `Slice` or `Page`, is used.
+
 include::project_team.adoc[]


### PR DESCRIPTION
Proofread all of the JavaDoc in the jakarta.data.page package.
I also cleaned up a few compile warnings that I noticed in unit test (missing cast of null value to varargs method parameter type) and another annotation class (missing JavaDoc).