### PR TITLE
review of JavaDoc in the jakarta.data package

### DIFF
--- a/api/src/main/java/jakarta/data/Limit.java
+++ b/api/src/main/java/jakarta/data/Limit.java
@@ -20,22 +20,22 @@ package jakarta.data;
 import jakarta.data.page.Pageable;
 
 /**
- * <p>Limits the number of results of a single invocation of a
- * repository find method to a maximum amount or to within a
- * positional range.</p>
+ * <p>Limits how many results are retrieved by a repository find method.
+ * Results of a single invocation of a repository find method
+ * can be capped to a maximum amount
+ * or be limited to a given positional range.</p>
  *
  * <p><code>Limit</code> is optionally specified as a parameter to a
  * repository method in one of the parameter positions after the
  * query parameters. For example,</p>
  *
  * <pre>
- * &#64;Query("SELECT o FROM Products o WHERE o.weight &lt;= ?1 AND o.width * o.length * o.height &lt;= ?2 ORDER BY o.price DESC")
- * Product[] freeShippingEligible(float maxWeight, float maxVolume, Limit limit);
+ * Product[] findByNameLike(String namePattern, Limit limit, Sort... sorts);
  * 
  * ...
- * mostExpensive50 = products.freeShippingEligible(6.0f, 360.0f, Limit.of(50));
+ * mostExpensive50 = products.findByNameLike(pattern, Limit.of(50), Sort.desc("price"));
  * ...
- * secondMostExpensive50 = products.freeShippingEligible(6.0f, 360.0f, Limit.range(51, 100));
+ * secondMostExpensive50 = products.findByNameLike(pattern, Limit.range(51, 100), Sort.desc("price"));
  * </pre>
  *
  * <p>A repository method will fail if</p>
@@ -100,8 +100,8 @@ public record Limit(int maxResults, long startAt) {
      * specified maximum, starting from the first result.</p>
      *
      * @param maxResults maximum number of results.
-     * @return limit that can be supplied to a <code>find...By</code>
-     *         or <code>&#64;Query</code> method; will never be {@literal null}.
+     * @return limit that can be supplied to a find method
+     *         or <code>&#64;Query</code> method that performs a find operation; will never be {@literal null}.
      * @throws IllegalArgumentException if maxResults is less than 1.
      */
     public static Limit of(int maxResults) {
@@ -117,8 +117,8 @@ public record Limit(int maxResults, long startAt) {
      * @param startAt position at which to start including results.
      *                The first query result is position 1.
      * @param endAt   position after which to cease including results.
-     * @return limit that can be supplied to a <code>find...By</code>
-     *         or <code>&#64;Query</code> method; will never be {@literal null}.
+     * @return limit that can be supplied to a find method or
+     *         or a <code>&#64;Query</code> method that performs a find operation; will never be {@literal null}.
      * @throws IllegalArgumentException if <code>startAt</code> is less than 1
      *         or <code>endAt</code> is less than <code>startAt</code>,
      *         or the range from <code>startAt</code> to <code>endAt</code>

--- a/api/src/main/java/jakarta/data/Sort.java
+++ b/api/src/main/java/jakarta/data/Sort.java
@@ -23,6 +23,8 @@ import jakarta.data.repository.Query;
 import java.util.Objects;
 
 /**
+ * <p>Requests sorting on a given entity attribute.</p>
+ *
  * <p><code>Sort</code> allows the application to dynamically provide
  * sort criteria which includes a case sensitivity request,
  * a {@link Direction} and a property.</p>
@@ -49,6 +51,11 @@ import java.util.Objects;
  * {@link Query} with an <code>ORDER BY</code> clause), the static
  * sort criteria is applied first, followed by the dynamic sort criteria
  * that is defined by <code>Sort</code> instances in the order listed.</p>
+ *
+ * <p>In the example above, the matching employees are sorted first by salary
+ * from highest to lowest. Employees with the same salary are then sorted
+ * alphabetically by last name. Employees with the same salary and last name
+ * are then sorted alphabetically by first name.</p>
  *
  * <p>A repository method will fail with a
  * {@link jakarta.data.exceptions.DataException DataException}
@@ -141,7 +148,7 @@ public record Sort(String property, boolean isAscending, boolean ignoreCase) {
     }
 
     /**
-     * Create a {@link Sort} instance with ascending direction {@link  Direction#ASC}
+     * Create a {@link Sort} instance with {@link Direction#ASC ascending direction}
      * that does not request case insensitive ordering.
      *
      * @param property the property name to order by
@@ -153,7 +160,7 @@ public record Sort(String property, boolean isAscending, boolean ignoreCase) {
     }
 
     /**
-     * Create a {@link Sort} instance with ascending direction {@link  Direction#ASC}
+     * Create a {@link Sort} instance with {@link Direction#ASC ascending direction}
      * and case insensitive ordering.
      *
      * @param property the property name to order by.
@@ -165,7 +172,7 @@ public record Sort(String property, boolean isAscending, boolean ignoreCase) {
     }
 
     /**
-     * Create a {@link Sort} instance with descending direction {@link  Direction#DESC}
+     * Create a {@link Sort} instance with {@link Direction#DESC descending direction}
      * that does not request case insensitive ordering.
      *
      * @param property the property name to order by
@@ -177,7 +184,7 @@ public record Sort(String property, boolean isAscending, boolean ignoreCase) {
     }
 
     /**
-     * Create a {@link Sort} instance with descending direction {@link  Direction#DESC}
+     * Create a {@link Sort} instance with {@link Direction#DESC descending direction}
      * and case insensitive ordering.
      *
      * @param property the property name to order by.

--- a/api/src/main/java/jakarta/data/Streamable.java
+++ b/api/src/main/java/jakarta/data/Streamable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,13 +21,15 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 /**
- * <p>Simple interface to ease streamability of {@link Iterable}s.
- * This is an interface and can therefore be used as the assignment target for a lambda expression or method reference.
+ * <p>An interface for sequential streaming of an {@link Iterable}.
+ * This is a functional interface and can therefore be used as the assignment target for a lambda expression or method reference.
  * </p>
  *
  * <p>Data is fetched once per <code>Streamable</code> instance;
  * it is not re-fetched with each invocation of {@link #stream()}
  * and {@link #iterator()}.</p>
+ *
+ * @param <T> the element type.
  */
 @FunctionalInterface
 public interface Streamable<T> extends Iterable<T> {


### PR DESCRIPTION
Proofreading of JavaDoc in the jakarta.data package.
I noticed that the code example for the Limit class had a long JPQL query on it that obscures some of the detail that the example tries to get across, so I switched it to a more concise automatic query method.  Hopefully this makes it easier to focus on the Limit aspects of it.