### PR TITLE
review of the repository package JavaDoc

### DIFF
--- a/api/src/main/java/jakarta/data/repository/BasicRepository.java
+++ b/api/src/main/java/jakarta/data/repository/BasicRepository.java
@@ -22,22 +22,67 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
- * <p>A repository interface for performing basic operations on entities.</p>
+ * <p>A built-in repository supertype for performing basic operations on entities.</p>
  *
- * <p>This repository provides methods to interact with persistent entities of type <code>&lt;T&gt;</code>,
- * where <code>&lt;T&gt;</code> represents the entity bean type, and <code>&lt;K&gt;</code> represents the key type.</p>
+ * <p>The type parameters of {@code BasicRepository<T,K>} capture the primary entity type ({@code T})
+ * for the repository and the type of the Id entity attribute ({@code K}) that uniquely identifies each entity
+ * of that type.</p>
  *
- * @param <T> the entity bean type
- * @param <K> the key type.
+ * <p>The primary entity type is used for repository methods, such as {@code countBy...}
+ * and {@code deleteBy...}, which do not explicitly specify an entity type.</p>
+ *
+ * <p>Example entity:</p>
+ *
+ * <pre>
+ * {@code @Entity}
+ * public class Employee {
+ *     {@code @Id}
+ *     public int badgeNumber;
+ *     public String firstName;
+ *     public String lastName;
+ *     ...
+ * }
+ * </pre>
+ *
+ * <p>Example repository:</p>
+ *
+ * <pre>
+ * {@code @Repository}
+ * public interface Employees extends BasicRepository{@code <Employee, Integer>} {
+ *
+ *     boolean deleteByBadgeNumber(int badgeNum);
+ *
+ *     ...
+ * }
+ * </pre>
+ *
+ * <p>Example usage:</p>
+ *
+ * <pre>
+ * {@code @Inject}
+ * Employees employees;
+ *
+ * ...
+ *
+ * Employee emp = ...
+ * emp = employees.save(emp);
+ *
+ * boolean deleted = employees.deleteByBadgeNumber(emp.badgeNum);
+ * </pre>
+ *
+ * <p>The module JavaDoc provides an {@link jakarta.data/ overview} of Jakarta Data.</p>
+ *
+ * @param <T> the type of the primary entity class of the repository.
+ * @param <K> the type of the Id attribute of the primary entity.
  */
 public interface BasicRepository<T, K> extends DataRepository<T, K> {
 
     /**
-     * Saves a given entity to the database. If the entity has an ID or key that exists in the database,
+     * Saves a given entity to the database. If the entity has an Id or key that exists in the database,
      * the method will update the existing record. Otherwise, it will insert a new record.
      *
-     * <p>If the entity has a non-null ID, the method will attempt to
-     * update the existing record in the database. If the entity does not exist in the database or has a null ID,
+     * <p>If the entity has a non-null Id, the method will attempt to
+     * update the existing record in the database. If the entity does not exist in the database or has a null Id,
      * then this method will insert a new record into the database.</p>
      *
      * <p>The entity instance that is returned as a result value of this method
@@ -60,12 +105,12 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
     <S extends T> S save(S entity);
 
     /**
-     * Saves all given entities to the database. If an entity has a non-null ID that exists in the database,
+     * Saves all given entities to the database. If an entity has a non-null Id that exists in the database,
      * the method will update the existing record. Otherwise, it will insert a new record.
      *
-     * <p>If an entity has a non-null ID, this method will attempt to update the
+     * <p>If an entity has a non-null Id, this method will attempt to update the
      * existing record in the database. If an entity does not exist in the database
-     * or has a null ID, then this method inserts a new record into the database.</p>
+     * or has a null Id, then this method inserts a new record into the database.</p>
      *
      * <p>The entity instances that are returned as a result of this method
      * must be updated with all automatically generated values and incremented values
@@ -84,20 +129,20 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
     <S extends T> Iterable<S> saveAll(Iterable<S> entities);
 
     /**
-     * Retrieves an entity by its id.
+     * Retrieves an entity by its Id.
      *
      * @param id must not be {@literal null}.
-     * @return the entity with the given id or {@literal Optional#empty()} if none found.
-     * @throws NullPointerException when the id is null
+     * @return the entity with the given Id or {@literal Optional#empty()} if none found.
+     * @throws NullPointerException when the Id is {@code null}.
      */
     Optional<T> findById(K id);
 
     /**
-     * Returns whether an entity with the given id exists.
+     * Returns whether an entity with the given Id exists.
      *
      * @param id must not be {@literal null}.
-     * @return {@literal true} if an entity with the given id exists, {@literal false} otherwise.
-     * @throws NullPointerException when the ID is null
+     * @return {@literal true} if an entity with the given Id exists, {@literal false} otherwise.
+     * @throws NullPointerException when the Id is {@code null}.
      */
     boolean existsById(K id);
 
@@ -111,9 +156,9 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
     Stream<T> findAll();
 
     /**
-     * Returns all instances of the type {@code T} with the given IDs.
+     * Returns all instances of the type {@code T} with the given Ids.
      * <p>
-     * If some or all ids are not found, no entities are returned for these IDs.
+     * If some or all Ids are not found, no entities are returned for these Ids.
      * <p>
      * Note that the order of elements in the result is not guaranteed.
      *
@@ -133,12 +178,12 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
     long count();
 
     /**
-     * Deletes the entity with the given id.
+     * Deletes the entity with the given Id.
      * <p>
      * If the entity is not found in the persistence store it is silently ignored.
      *
      * @param id must not be {@literal null}.
-     * @throws NullPointerException when the id is null
+     * @throws NullPointerException when the Id is {@code null}.
      */
     void deleteById(K id);
 
@@ -156,24 +201,24 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
     void delete(T entity);
 
     /**
-     * Deletes all instances of the type {@code T} with the given IDs.
+     * Deletes all instances of the type {@code T} with the given Ids.
      * <p>
-     * Entities that aren't found in the persistence store are silently ignored.
+     * Entities that are not found in the persistent store are silently ignored.
      *
      * @param ids must not be {@literal null}. Must not contain {@literal null} elements.
-     * @throws NullPointerException when either the iterable is null or contains null elements
+     * @throws NullPointerException when the iterable is {@code null} or contains {@code null} elements.
      */
     void deleteByIdIn(Iterable<K> ids);
 
     /**
-     * Deletes the given entities. Deletion of each entity is performed by matching the ID, and if the entity is
+     * Deletes the given entities. Deletion of each entity is performed by matching the Id, and if the entity is
      * versioned (for example, with {@code jakarta.persistence.Version}), then also the version.
      * Other properties of the entity do not need to match.
      *
      * @param entities Must not be {@literal null}. Must not contain {@literal null} elements.
      * @throws OptimisticLockingFailureException If an entity is not found in the database for deletion
      *         or has a version for optimistic locking that is inconsistent with the version in the database.
-     * @throws NullPointerException If either the iterable is null or contains null elements.
+     * @throws NullPointerException If the iterable is {@code null} or contains {@code null} elements.
      */
     @Delete
     void deleteAll(Iterable<? extends T> entities);

--- a/api/src/main/java/jakarta/data/repository/By.java
+++ b/api/src/main/java/jakarta/data/repository/By.java
@@ -24,8 +24,8 @@ import java.lang.annotation.Target;
 
 
 /**
- * <p>Specifies the name of the entity attribute to compare against the
- * value of the repository method parameter that is annotated.</p>
+ * <p>Annotates a parameter of a repository method to specify the name of an
+ * entity attribute against which to compare.</p>
  *
  * <p>Example usage for a {@code Person} entity with attributes
  * {@code id}, {@code firstName}, and {@code lastName}:</p>

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -20,17 +20,66 @@ package jakarta.data.repository;
 import jakarta.data.exceptions.EntityExistsException;
 
 /**
- * <p>A repository interface that extends the capabilities of basic operations on entities, including insert and update operations.</p>
+ * <p>A built-in repository supertype for performing Create, Read, Update, and Delete (CRUD) operations on entities.</p>
  *
- * <p>This repository extends the {@link BasicRepository} interface, providing a comprehensive set of methods to interact with
- * persistent entities of type {@code <T>}, where {@code <T>} represents the entity bean type, and {@code <K>} represents the key type.</p>
- *
- * <p>It encompasses standard CRUD (Create, Read, Update, Delete) operations, allowing you to perform insert and update operations in
+ * <p>This repository extends the {@link BasicRepository} interface, allowing you to perform insert and update operations in
  * addition to basic retrieval and deletion. This interface combines the Data Access Object (DAO) aspect with the repository pattern,
- * offering a versatile and complete solution for managing persistent entities within your Java applications.</p>
+ * offering a versatile and complete solution for managing persistent entities within Java applications.</p>
  *
- * @param <T> the entity bean type
- * @param <K> the key type.
+ * <p>The type parameters of {@code CrudRepository<T,K>} capture the primary entity type ({@code T})
+ * for the repository and the type of the Id entity attribute ({@code K}) that uniquely identifies each entity
+ * of that type.</p>
+ *
+ * <p>The primary entity type is used for repository methods, such as {@code countBy...}
+ * and {@code deleteBy...}, which do not explicitly specify an entity type.</p>
+ *
+ * <p>Example entity:</p>
+ *
+ * <pre>
+ * {@code @Entity}
+ * public class Cars {
+ *     {@code @Id}
+ *     public long vin;
+ *     public String make;
+ *     public String model;
+ *     public int year;
+ *     ...
+ * }
+ * </pre>
+ *
+ * <p>Example repository:</p>
+ *
+ * <pre>
+ * {@code @Repository}
+ * public interface Cars extends CrudRepository{@code <Car, Long>} {
+ *
+ *     List{@code <Car>} findByMakeAndModel(String make, String model, Sort...);
+ *
+ *     ...
+ * }
+ * </pre>
+ *
+ * <p>Example usage:</p>
+ *
+ * <pre>
+ * {@code @Inject}
+ * Cars cars;
+ *
+ * ...
+ *
+ * Car car1 = ...
+ * car1 = cars.insert(car1);
+ *
+ * List{@code <Car>} found = findByMakeAndModel(car1.make,
+ *                                      car1.model,
+ *                                      Sort.desc("year"),
+ *                                      Sort.asc("vin"));
+ * </pre>
+ *
+ * <p>The module JavaDoc provides an {@link jakarta.data/ overview} of Jakarta Data.</p>
+ *
+ * @param <T> the type of the primary entity class of the repository.
+ * @param <K> the type of the Id attribute of the primary entity.
  * @see BasicRepository
  * @see DataRepository
  */

--- a/api/src/main/java/jakarta/data/repository/DataRepository.java
+++ b/api/src/main/java/jakarta/data/repository/DataRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,64 @@
 package jakarta.data.repository;
 
 /**
- * Parent repository interface for all repositories.
- * Central repository marker interface. Captures the domain type to manage and the domain type's id type.
- * @param <T> the domain type the repository manages
- * @param <K> the type of the id of the entity the repository manages
+ * <p>A built-in repository supertype that is the root of all other built-in repository supertype interfaces.</p>
+ *
+ * <p>The type parameters of {@code DataRepository<T,K>} capture the primary entity type ({@code T})
+ * for the repository and the type of the Id entity attribute ({@code K}) that uniquely identifies each entity
+ * of that type.</p>
+ *
+ * <p>The primary entity type is used for repository methods, such as {@code countBy...}
+ * and {@code deleteBy...}, which do not explicitly specify an entity type.</p>
+ *
+ * <p>Example entity:</p>
+ *
+ * <pre>
+ * {@code @Entity}
+ * public class DriverLicense {
+ *     {@code @Id}
+ *     public String licenseNum;
+ *     public LocalDate expiry;
+ *     ...
+ * }
+ * </pre>
+ *
+ * <p>Example repository:</p>
+ *
+ * <pre>
+ * {@code @Repository}
+ * public interface DriverLicenses extends DataRepository{@code <DriverLicense, String>} {
+ *
+ *     boolean existsByLicenseNumAndExpiryGreaterThan(String num, LocalDate minExpiry);
+ *
+ *     {@code @Insert}
+ *     DriverLicense register(DriverLicense l);
+ *
+ *     {@code @Update}
+ *     boolean renew(DriverLicense l);
+ *
+ *     ...
+ * }
+ * </pre>
+ *
+ * <p>Example usage:</p>
+ *
+ * <pre>
+ * {@code @Inject}
+ * DriverLicenses licenses;
+ *
+ * ...
+ *
+ * DriverLicense license = ...
+ * license = licenses.register(license);
+ *
+ * boolean isValid = licenses.existsByLicenseNumAndExpiryGreaterThan(license.licenseNum,
+ *                                                                   LocalDate.now());
+ * </pre>
+ *
+ * <p>The module JavaDoc provides an {@link jakarta.data/ overview} of Jakarta Data.</p>
+ *
+ * @param <T> the type of the primary entity class of the repository.
+ * @param <K> the type of the Id attribute of the primary entity.
  */
 public interface DataRepository<T, K> {
 

--- a/api/src/main/java/jakarta/data/repository/Delete.java
+++ b/api/src/main/java/jakarta/data/repository/Delete.java
@@ -25,8 +25,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
+ * <p>Annotates a repository method to perform delete operations.</p>
+ *
  * <p>The {@code Delete} annotation indicates that the annotated repository method requests one or more
- * entities to be removed from the database. This method must have a single parameter whose type must be one of the following:
+ * entities to be removed from the database. To request deletion of specific entity instances, the annotated
+ * repository method must have a single parameter whose type must be one of the following:
  * </p>
  * <ul>
  *     <li>The entity to be deleted.</li>

--- a/api/src/main/java/jakarta/data/repository/Insert.java
+++ b/api/src/main/java/jakarta/data/repository/Insert.java
@@ -25,6 +25,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
+ * <p>Annotates a repository method that inserts entities.</p>
+ *
  * <p>The {@code Insert} annotation indicates that the annotated repository method requests that one or more entities
  * be inserted into the database. This method must have a single parameter whose type must be one of the following:
  * </p>

--- a/api/src/main/java/jakarta/data/repository/OrderBy.java
+++ b/api/src/main/java/jakarta/data/repository/OrderBy.java
@@ -108,7 +108,7 @@ public @interface OrderBy {
     String value();
 
     /**
-     * Enables multiple <code>OrderBy</code> annotations on the same type.
+     * Enables multiple <code>OrderBy</code> annotations on the method.
      */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.METHOD)

--- a/api/src/main/java/jakarta/data/repository/PageableRepository.java
+++ b/api/src/main/java/jakarta/data/repository/PageableRepository.java
@@ -22,21 +22,73 @@ import jakarta.data.page.Page;
 import jakarta.data.page.Pageable;
 
 /**
- * Repository fragment to provide methods to retrieve entities using the pagination and sorting abstraction. In many
- * cases this will be combined with {@link BasicRepository} or similar or with manually added methods to provide CRUD
- * functionality.
- * @param <T> the domain type the repository manages
- * @param <K> the type of the id of the entity the repository manages
+ * <p>A built-in repository supertype with methods that use pagination and sorting to retreive entities.
+ * Methods that are inherited from {@link BasicRepository} provide additional basic built-in save, delete, and find
+ * functionality.</p>
+ *
+ * <p>The type parameters of {@code PageableRepository<T,K>} capture the primary entity type ({@code T})
+ * for the repository and the type of the Id entity attribute ({@code K}) that uniquely identifies each entity
+ * of that type.</p>
+ *
+ * <p>The primary entity type is used for repository methods, such as {@code countBy...}
+ * and {@code deleteBy...}, which do not explicitly specify an entity type.</p>
+ *
+ * <p>Example entity:</p>
+ *
+ * <pre>
+ * {@code @Entity}
+ * public class Person {
+ *     {@code @Id}
+ *     public long ssn;
+ *     public String firstName;
+ *     public String lastName;
+ *     ...
+ * }
+ * </pre>
+ *
+ * <p>Example repository:</p>
+ *
+ * <pre>
+ * {@code @Repository}
+ * public interface People extends PageableRepository{@code <Person, Long>} {
+ *
+ *     long countByFirstName(String name);
+ *
+ *     ...
+ * }
+ * </pre>
+ *
+ * <p>Example usage:</p>
+ *
+ * <pre>
+ * {@code @Inject}
+ * People people;
+ *
+ * ...
+ *
+ * Person person1 = ...
+ * person1 = people.save(person1);
+ *
+ * long howMany = people.countByFirstName(person1.firstName);
+ *
+ * Pagination page1Request = Pageable.ofSize(25).sortBy(Sort.asc("ssn"));
+ * Page{@code <Person>} page1 = people.findAll(page1Request);
+ * </pre>
+ *
+ * <p>The module JavaDoc provides an {@link jakarta.data/ overview} of Jakarta Data.</p>
+ *
+ * @param <T> the type of the primary entity class of the repository.
+ * @param <K> the type of the Id attribute of the primary entity.
  * @see BasicRepository
  */
 public interface PageableRepository<T, K> extends BasicRepository<T, K> {
 
     /**
-     * Returns a {@link Page} of entities meeting the paging restriction provided in the {@link Pageable} object.
+     * Returns a {@link Page} of entities according to the page request that is provided as the {@link Pageable} parameter.
      *
-     * @param pageable the pageable to request a paginated result, must not be null.
-     * @return a page of entities; will never be {@literal null}.
-     * @throws NullPointerException when pageable is null
+     * @param pageable the request for a paginated result; must not be {@code null}.
+     * @return a page of entities; will never be {@code null}.
+     * @throws NullPointerException when {@code pageable} is {@code null}.
      * @throws UnsupportedOperationException for Key-Value and Wide-Column databases when the {@link Pageable.Mode#CURSOR_NEXT}
      * or {@link Pageable.Mode#CURSOR_PREVIOUS} pagination mode is selected.
      * @see Pageable.Mode

--- a/api/src/main/java/jakarta/data/repository/Param.java
+++ b/api/src/main/java/jakarta/data/repository/Param.java
@@ -24,15 +24,36 @@ import java.lang.annotation.Target;
 
 
 /**
- * Annotation to bind method parameters to a {@link  Query} via a named parameter.
+ * <p>Annotates a parameter of a repository method to bind it to a named parameter of a {@link Query}.</p>
+ *
+ * <p>For example,</p>
+ *
+ * <pre>
+ * {@code @Repository}
+ * public interface Products extends BasicRepository{@code <Product, String>} {
+ *
+ *     {@code @Query("SELECT p from Products p WHERE (p.length * p.width * p.height <= :maxVolume)")}
+ *     {@code Page<Product>} freeShippingEligible({@code @Param}("maxVolume") float volumeLimit,
+ *                                        Pageable pageRequest);
+ *
+ *     ...
+ * }
+ * </pre>
+ *
+ * <p>The {@code Param} annotation is unnecessary when the method parameter name
+ * matches the query language named parameter name and the application is compiled with the
+ * {@code -parameters} compiler option that makes parameter names available
+ * at run time.</p>
+ *
+ * @see Query
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)
 public @interface Param {
 
     /**
-     * Defines the name of the parameter to bind to.
-     * @return the parameter name
+     * Defines the name of the query language named parameter to bind to.
+     * @return the name of the query language named parameter.
      */
     String value();
 }

--- a/api/src/main/java/jakarta/data/repository/Query.java
+++ b/api/src/main/java/jakarta/data/repository/Query.java
@@ -26,7 +26,47 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Defines the query string such as SQL, JPA-QL, Cypher etc. that should be executed.
+ * <p>Annotates a repository method to specify a query string such as SQL, JPQL, Cypher etc. to execute.</p>
+ *
+ * <p>Jakarta Data providers for relational databases must support
+ * JPQL queries if backed by a Jakarta Persistence provider,
+ * and otherwise must support SQL queries.</p>
+ *
+ * <p>The query language can used named parameters or positional parameters.</p>
+ *
+ * <p><b>Named parameters</b> are referred to by name within the query language.
+ * The {@link Param} annotation annotates method parameters to bind them to a named parameter name.
+ * The {@code Param} annotation is unnecessary for named parameters when the method parameter name
+ * matches the query language named parameter name and the application is compiled with the
+ * {@code -parameters} compiler option that makes parameter names available
+ * at run time. When the {@code Param} annotation is not used, the Jakarta Data provider must
+ * interpret the query by scanning for the delimiter that is used for positional parameters.
+ * If the delimiter appears for another purpose in a query that requries named parameters,
+ * it might be necessary for the application to explictly define the {@code Param} in order to
+ * disambiguate.</p>
+ *
+ * <p><b>Positional parameters</b> are referred to by a number that corresponds to the
+ * numerical position, starting with 1, of the repository method parameters.</p>
+ *
+ * <p>For example,</p>
+ *
+ * <pre>
+ * {@code @Repository}
+ * public interface People extends CrudRepository{@code <Person, Long>} {
+ *
+ *     // JPQL using positional parameters
+ *     {@code @Query("SELECT p from Person p WHERE (EXTRACT(YEAR FROM p.birthday) = ?1)")}
+ *     {@code List<Person>} bornIn(int year);
+ *
+ *     // JPQL using named parameters
+ *     {@code @Query("SELECT DISTINCT p.name from Person p WHERE (LENGTH(p.name) >= :min AND LENGTH(p.name) <= :max)")}
+ *     {@code List<String>} namesOfLength({@code @Param}("min") int minLength,
+ *                                {@code @Param}("max") int minLength,
+ *                                Sort... sorts);
+ *
+ *     ...
+ * }
+ * </pre>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/api/src/main/java/jakarta/data/repository/Repository.java
+++ b/api/src/main/java/jakarta/data/repository/Repository.java
@@ -24,7 +24,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * <p>Annotates a data repository interface that will be implemented by the container/runtime.</p>
+ * <p>Annotates a repository interface to be implemented by the container/runtime.</p>
  *
  * <p>This class is a CDI bean-defining annotation when CDI is available.
  * Regardless of whether CDI or custom dependency injection is used, the

--- a/api/src/main/java/jakarta/data/repository/Save.java
+++ b/api/src/main/java/jakarta/data/repository/Save.java
@@ -25,8 +25,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * <p>The {@code Save} annotation indicates that the annotated repository method
- * updates one or more entities if found in the database
+ * <p>Annotates a repository method that updates entities if found in the database
  * and inserts entities into the database that are not found.
  * This method must have a single parameter whose type must be one of the following:
  * </p>

--- a/api/src/main/java/jakarta/data/repository/Update.java
+++ b/api/src/main/java/jakarta/data/repository/Update.java
@@ -26,8 +26,11 @@ import java.lang.annotation.Target;
 
 
 /**
+ * <p>Annotates a repository method to perform update operations.</p>
+ *
  * <p>The {@code Update} annotation indicates that the annotated repository method requests that one or more entities
- * be updated if found in the database. This method must have a single parameter whose type must be one of the following:
+ * be updated if found in the database. To request updates to specific entity instances, the annotated
+ * repository method must have a single parameter whose type must be one of the following:
  * </p>
  * <ul>
  *     <li>The entity to be updated.</li>


### PR DESCRIPTION
Proofread and review the repository package JavaDoc.

I noticed we are inconsistently referring to the Id attribute as ID, id, and Id, sometimes all within the same class' JavaDoc.  Under this pull, I made them consistent, switching everything to Id, which matches the `@Id` entity annotation.

Documentation for Query and Param was sparse, so I added some.
I added code examples to those as well as to all of the built-in repository interfaces.
I have also added a brief first sentence (or revised an existing one for consistency) to appear on the package JavaDoc where it links to each class within the package.  The sentence indicates which are built-in repository interfaces, which are annotations, and where the annotations belong, along with the main purpose of the class.  This should help make it clear when browsing the package which classes will be of interest to what a user is trying to accomplish.
