### PR TITLE
Replace @literal with @code in javadoc

### DIFF
--- a/api/src/main/java/jakarta/data/Limit.java
+++ b/api/src/main/java/jakarta/data/Limit.java
@@ -101,7 +101,7 @@ public record Limit(int maxResults, long startAt) {
      *
      * @param maxResults maximum number of results.
      * @return limit that can be supplied to a find method
-     *         or <code>&#64;Query</code> method that performs a find operation; will never be {@literal null}.
+     *         or <code>&#64;Query</code> method that performs a find operation; will never be {@code null}.
      * @throws IllegalArgumentException if maxResults is less than 1.
      */
     public static Limit of(int maxResults) {
@@ -118,7 +118,7 @@ public record Limit(int maxResults, long startAt) {
      *                The first query result is position 1.
      * @param endAt   position after which to cease including results.
      * @return limit that can be supplied to a find method or
-     *         or a <code>&#64;Query</code> method that performs a find operation; will never be {@literal null}.
+     *         or a <code>&#64;Query</code> method that performs a find operation; will never be {@code null}.
      * @throws IllegalArgumentException if <code>startAt</code> is less than 1
      *         or <code>endAt</code> is less than <code>startAt</code>,
      *         or the range from <code>startAt</code> to <code>endAt</code>

--- a/api/src/main/java/jakarta/data/Sort.java
+++ b/api/src/main/java/jakarta/data/Sort.java
@@ -95,7 +95,7 @@ public record Sort(String property, boolean isAscending, boolean ignoreCase) {
     /**
      * Name of the property to order by.
      *
-     * @return The property name to order by; will never be {@literal null}.
+     * @return The property name to order by; will never be {@code null}.
      */
     public String property() {
         return property;

--- a/api/src/main/java/jakarta/data/page/Pageable.java
+++ b/api/src/main/java/jakarta/data/page/Pageable.java
@@ -184,7 +184,7 @@ public interface Pageable {
     /**
      * Return the order collection if it was specified on this page request, otherwise an empty list.
      *
-     * @return the order collection; will never be {@literal null}.
+     * @return the order collection; will never be {@code null}.
      */
     List<Sort> sorts();
 

--- a/api/src/main/java/jakarta/data/page/Slice.java
+++ b/api/src/main/java/jakarta/data/page/Slice.java
@@ -76,7 +76,7 @@ public interface Slice<T> extends Streamable<T> {
      * Returns the {@link Pageable page request} for which this
      * slice was obtained.
      *
-     * @return the request for the current page; will never be {@literal null}.
+     * @return the request for the current page; will never be {@code null}.
      */
     Pageable pageable();
 

--- a/api/src/main/java/jakarta/data/repository/BasicRepository.java
+++ b/api/src/main/java/jakarta/data/repository/BasicRepository.java
@@ -94,12 +94,12 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
      * <p>If the entity uses optimistic locking and the version differs from the version in the database,
      * an {@link OptimisticLockingFailureException} will be thrown.</p>
      *
-     * @param entity The entity to be saved. Must not be {@literal null}.
+     * @param entity The entity to be saved. Must not be {@code null}.
      * @param <S> Type of the entity to save.
-     * @return The saved entity; never {@literal null}.
+     * @return The saved entity; never {@code null}.
      * @throws OptimisticLockingFailureException If the entity uses optimistic locking and the version in the
      *         database differs from the version in the entity.
-     * @throws NullPointerException If the provided entity is {@literal null}.
+     * @throws NullPointerException If the provided entity is {@code null}.
      */
     @Save
     <S extends T> S save(S entity);
@@ -120,7 +120,7 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
      *
      * @param entities An iterable of entities.
      * @param <S> Type of entity to save.
-     * @return The saved entities; will never be {@literal null}.
+     * @return The saved entities; will never be {@code null}.
      * @throws OptimisticLockingFailureException If an entity has a version for optimistic locking
      *         that differs from the version in the database.
      * @throws NullPointerException If either the iterable is null or any element is null.
@@ -131,8 +131,8 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
     /**
      * Retrieves an entity by its Id.
      *
-     * @param id must not be {@literal null}.
-     * @return the entity with the given Id or {@literal Optional#empty()} if none found.
+     * @param id must not be {@code null}.
+     * @return the entity with the given Id or {@code Optional#empty()} if none found.
      * @throws NullPointerException when the Id is {@code null}.
      */
     Optional<T> findById(K id);
@@ -140,8 +140,8 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
     /**
      * Returns whether an entity with the given Id exists.
      *
-     * @param id must not be {@literal null}.
-     * @return {@literal true} if an entity with the given Id exists, {@literal false} otherwise.
+     * @param id must not be {@code null}.
+     * @return {@code true} if an entity with the given Id exists, {@code false} otherwise.
      * @throws NullPointerException when the Id is {@code null}.
      */
     boolean existsById(K id);
@@ -149,7 +149,7 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
     /**
      * Retrieves all persistent entities of the specified type from the database.
      *
-     * @return a stream of all entities; will never be {@literal null}.
+     * @return a stream of all entities; will never be {@code null}.
      * @throws UnsupportedOperationException  for Key-Value and Wide-Column databases that are not capable
      * of the {@code findAll} operation.
      */
@@ -162,10 +162,10 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
      * <p>
      * Note that the order of elements in the result is not guaranteed.
      *
-     * @param ids must not be {@literal null} nor contain any {@literal null} values.
-     * @return guaranteed to be not {@literal null}. The size can be equal or less than the number of given
-     * {@literal ids}.
-     * @throws NullPointerException in case the given {@link Iterable ids} or one of its items is {@literal null}.
+     * @param ids must not be {@code null} nor contain any {@code null} values.
+     * @return guaranteed to be not {@code null}. The size can be equal or less than the number of given
+     * ids.
+     * @throws NullPointerException in case the given {@link Iterable ids} or one of its items is {@code null}.
      */
     Stream<T> findByIdIn(Iterable<K> ids);
 
@@ -182,7 +182,7 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
      * <p>
      * If the entity is not found in the persistence store it is silently ignored.
      *
-     * @param id must not be {@literal null}.
+     * @param id must not be {@code null}.
      * @throws NullPointerException when the Id is {@code null}.
      */
     void deleteById(K id);
@@ -192,7 +192,7 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
      * versioned (for example, with {@code jakarta.persistence.Version}), then also the version.
      * Other properties of the entity do not need to match.
      *
-     * @param entity must not be {@literal null}.
+     * @param entity must not be {@code null}.
      * @throws OptimisticLockingFailureException if the entity is not found in the database for deletion
      *         or has a version for optimistic locking that is inconsistent with the version in the database.
      * @throws NullPointerException when the entity is null
@@ -205,7 +205,7 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
      * <p>
      * Entities that are not found in the persistent store are silently ignored.
      *
-     * @param ids must not be {@literal null}. Must not contain {@literal null} elements.
+     * @param ids must not be {@code null}. Must not contain {@code null} elements.
      * @throws NullPointerException when the iterable is {@code null} or contains {@code null} elements.
      */
     void deleteByIdIn(Iterable<K> ids);
@@ -215,7 +215,7 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
      * versioned (for example, with {@code jakarta.persistence.Version}), then also the version.
      * Other properties of the entity do not need to match.
      *
-     * @param entities Must not be {@literal null}. Must not contain {@literal null} elements.
+     * @param entities Must not be {@code null}. Must not contain {@code null} elements.
      * @throws OptimisticLockingFailureException If an entity is not found in the database for deletion
      *         or has a version for optimistic locking that is inconsistent with the version in the database.
      * @throws NullPointerException If the iterable is {@code null} or contains {@code null} elements.

--- a/api/src/main/java/jakarta/data/repository/BasicRepository.java
+++ b/api/src/main/java/jakarta/data/repository/BasicRepository.java
@@ -132,7 +132,7 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
      * Retrieves an entity by its Id.
      *
      * @param id must not be {@code null}.
-     * @return the entity with the given Id or {@code Optional#empty()} if none found.
+     * @return the entity with the given Id or {@link Optional#empty()} if none is found.
      * @throws NullPointerException when the Id is {@code null}.
      */
     Optional<T> findById(K id);

--- a/api/src/main/java/jakarta/data/repository/Delete.java
+++ b/api/src/main/java/jakarta/data/repository/Delete.java
@@ -47,9 +47,9 @@ import java.lang.annotation.Target;
  * </p>
  * <p>For example, consider an interface representing a garage:</p>
  * <pre>
- * {@literal @}Repository
+ * {@code @Repository}
  * interface Garage {
- *     {@literal @}Delete
+ *     {@code @Delete}
  *     Car unpark(Car car);
  * }
  * </pre>

--- a/api/src/main/java/jakarta/data/repository/Insert.java
+++ b/api/src/main/java/jakarta/data/repository/Insert.java
@@ -59,9 +59,9 @@ import java.lang.annotation.Target;
  * </p>
  * <p>For example, consider an interface representing a garage:</p>
  * <pre>
- * {@literal @}Repository
+ * {@code @Repository}
  * interface Garage {
- *     {@literal @}Insert
+ *     {@code @Insert}
  *     Car park(Car car);
  * }
  * </pre>

--- a/api/src/main/java/jakarta/data/repository/Save.java
+++ b/api/src/main/java/jakarta/data/repository/Save.java
@@ -56,9 +56,9 @@ import java.lang.annotation.Target;
  *
  * <p>For example, consider an interface representing a garage:</p>
  * <pre>
- * {@literal @}Repository
+ * {@code @Repository}
  * interface Garage {
- *     {@literal @}Save
+ *     {@code @Save}
  *     Car park(Car car);
  * }
  * </pre>

--- a/api/src/main/java/jakarta/data/repository/Update.java
+++ b/api/src/main/java/jakarta/data/repository/Update.java
@@ -71,9 +71,9 @@ import java.lang.annotation.Target;
  *  </p>
  * <p>For example, consider an interface representing a garage:</p>
  * <pre>
- * &#64;Repository
+ * {@code @Repository}
  * interface Garage {
- *     {@literal @}Update
+ *     {@code @Update}
  *     Car update(Car car);
  * }
  * </pre>

--- a/tck/src/main/java/ee/jakarta/tck/data/common/cdi/Person.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/common/cdi/Person.java
@@ -17,7 +17,7 @@ package ee.jakarta.tck.data.common.cdi;
 
 /**
  * A test entity that will be persisted to a repository.
- * Uses the custom {@literal @}PersonEntity annotation.
+ * Uses the custom {@code @PersonEntity} annotation.
  * 
  * @see ee.jakarta.tck.data.common.cdi.PersonEntity
  */


### PR DESCRIPTION
replaces the use of `@literal` with `@code`

There are also quite a few uses of `&#64;`, `&lt;`, `&gt;`, and just `<code>` that could be updated to use `@code` as well. I think this could improve readability in the javadocs, particularly cases like `module-info.java`, but it would be a large effort, so I would like to know what other people think before attempting it.