### PR TITLE
TCK tests for BasicRepository built-in methods

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/Box.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/Box.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.standalone.entity;
+
+@jakarta.persistence.Entity
+@jakarta.nosql.Entity
+public class Box {
+    @jakarta.persistence.Id
+    @jakarta.nosql.Id
+    public String boxIdentifier;
+
+    @jakarta.nosql.Column
+    public int length;
+
+    @jakarta.nosql.Column
+    public int width;
+
+    @jakarta.nosql.Column
+    public int height;
+
+    public static Box of(String id, int length, int width, int height) {
+        Box box = new Box();
+        box.boxIdentifier = id;
+        box.length = length;
+        box.width = width;
+        box.height = height;
+        return box;
+    }
+
+    @Override
+    public String toString() {
+        return "Box@" + Integer.toHexString(hashCode()) + ":" + length + "x" + width + "x" + height + ":" + boxIdentifier;
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/Boxes.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/Boxes.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.standalone.entity;
+
+import jakarta.data.repository.BasicRepository;
+import jakarta.data.repository.Repository;
+
+/**
+ * A repository that inherits from the built-in BasicRepository and adds no methods.
+ */
+@Repository
+public interface Boxes extends BasicRepository<Box, String> {
+}


### PR DESCRIPTION
Cover this test scenario from #133 
Use a repository that inherits from BasicRepository and defines no additional methods of its own. Use all of the built-in methods.

Fixes #133 because this is the last scenario that is listed there to add.
