### PR TITLE
Update copyright with real values

### DIFF
--- a/spec/src/main/asciidoc/chapters/license/license-efsl.adoc
+++ b/spec/src/main/asciidoc/chapters/license/license-efsl.adoc
@@ -11,7 +11,7 @@ Release: {revdate}
 
 == Copyright
 
-Copyright (c) {inceptionYear} , {currentYear} Eclipse Foundation.
+Copyright (c) {inceptionYear}, {docyear} Eclipse Foundation.
 
 === Eclipse Foundation Specification License
 
@@ -49,9 +49,9 @@ specification is expressly prohibited.
 
 The notice is:
 
-"Copyright (c) [$date-of-document] Eclipse Foundation. This software or
-document includes material copied from or derived from [title and URI
-of the Eclipse Foundation specification document]."
+"Copyright (c) {inceptionYear}, {docyear} Eclipse Foundation. This software or
+document includes material copied from or derived from Jakarta Data and 
+https://jakarta.ee/specifications/data/."
 
 === Disclaimers
 

--- a/spec/src/main/asciidoc/jakarta-data.adoc
+++ b/spec/src/main/asciidoc/jakarta-data.adoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Contributors to the Eclipse Foundation
+// Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -18,6 +18,7 @@
 :version-label!:
 :doctype: book
 :license: Apache License v2.0
+:inceptionYear: 2022
 :source-highlighter: coderay
 :toc: left
 :toclevels: 3


### PR DESCRIPTION
Fixes #381 

Note: `{docyear}` is a generated variable by asciidoc and is parsed from `revdate`