### PR TITLE
Update Delete annotation return

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Delete.java
+++ b/api/src/main/java/jakarta/data/repository/Delete.java
@@ -50,7 +50,7 @@ import java.lang.annotation.Target;
  * {@code @Repository}
  * interface Garage {
  *     {@code @Delete}
- *     Car unpark(Car car);
+ *     void unpark(Car car);
  * }
  * </pre>
  * <p>If this annotation is combined with other operation annotations (e.g., {@code @Insert}, {@code @Update},


### PR DESCRIPTION
# Changes

- Update Delete annotation using void instead of the same instance once once the documentation does not show support to return the same interface.