### PR TITLE
add precedence to specification document

### DIFF
--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -700,8 +700,8 @@ import java.util.List;
  *
  * <h2>Precedence of Repository Methods</h2>
  *
- * <p>The following precedence, from highest to lowest, is used when interpreting the
- * meaning of repository methods.</p>
+ * <p>The following order, with the lower number having higher precedence,
+ * is used to interpret the meaning of repository methods.</p>
  *
  * <ol>
  * <li>If you define a method as a <b>Java default method</b> and provide implementation,

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+// Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -1411,4 +1411,16 @@ Resulting Page Content:
 ----
 
 It should be noted, the above result is different than what would be retrieved with offset-based pagination, where the removal of an entity from the first page shifts the offset for entries 5 through 8 to start from `{"id":9, "name":"Harlene Branigan"}`, skipping over `{"id":8, "name":"Danita Pilipyak"}` that becomes offset position 4 after the removal. Keyset cursor-based pagination does not skip the entity because it queries relative to a cursor position, starting from the next entity after `{"id":2, "name":"Corri Davidou"}`.
+
+=== Precedence of Repository Methods
+
+The following order, with the lower number having higher precedence, is used when interpreting the meaning of repository methods.
+
+1. If the method is a Java default method, then its provided implementation is used.
+2. If the method has a _Resource Accessor Method_ return type, then the method is implemented as a _Resource Accessor Method_.
+3. If the method is annotated with `@Query`, then the method is implemented to run the corresponding Query Language query.
+4. If the method is annotated with a _Life Cycle_ annotation that defines the type of operation (`@Insert`, `@Update`, `@Save`, or `@Delete`), then the annotation determines how the method is implemented.
+5. If any of the method parameters are annotated with a data access related annotation (such as `@By`), then the method is implemented as an _Automatic Query Method_ with _Parameter-based Conditions_.
+6. If the method is named according to the _Query by Method Name_ naming conventions, then the implementation follows the _Query by Method Name_ pattern.
+7. Otherwise, the method is implemented as an _Automatic Query Method_ with _Parameter-based Conditions_. The `-parameters` compiler option that makes parameter names available at run time must be used.
 


### PR DESCRIPTION
Fixes #405 by copying the list of precedence for interpreting repository methods from the JavaDoc to the specification document.