### PR TITLE
Fix TCK test errors

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -79,7 +79,8 @@ public class EntityTests {
 
     @Deployment
     public static JavaArchive createDeployment() {
-        return ShrinkWrap.create(JavaArchive.class).addClasses(EntityTests.class);
+        return ShrinkWrap.create(JavaArchive.class)
+            .addClasses(EntityTests.class, Box.class, Boxes.class);
     }
 
     @Inject

--- a/tck/src/main/java/ee/jakarta/tck/data/web/validation/Rectangles.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/web/validation/Rectangles.java
@@ -20,19 +20,27 @@ import java.util.stream.Stream;
 
 import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Repository;
+import jakarta.data.repository.Save;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
 
 @Repository
 public interface Rectangles extends DataRepository<Rectangle, String> {
     
-    Rectangle save(@Valid Rectangle rect);
-    Iterable<Rectangle> saveAll(@Valid Iterable<Rectangle> rects);
+    @Save
+    Rectangle save(@Valid Rectangle entity);
+
+    @Save
+    Iterable<Rectangle> saveAll(@Valid Iterable<Rectangle> entities);
     
-    long count();
-    void deleteAll();
+    @PositiveOrZero
+    long countBy();
+
     Stream<Rectangle> findAll();
     
+    void deleteAllBy();
+
     @Size(min = 0, max = 3)
     List<Rectangle> findAllByOrderByIdAsc();
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/web/validation/ValidationTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/web/validation/ValidationTests.java
@@ -51,7 +51,7 @@ public class ValidationTests {
     
     @BeforeEach
     public void cleanup() {
-        rectangles.deleteAll();
+        rectangles.deleteAllBy();
         TestPropertyUtility.waitForEventualConsistency();
     }
     
@@ -64,7 +64,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(1, rectangles.count());
+        assertEquals(1, rectangles.countBy());
         assertRectangleFields(validRect, getResults().get(0));
         
         // Save All
@@ -78,7 +78,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(4, rectangles.count(), "Number of results was incorrect");
+        assertEquals(4, rectangles.countBy(), "Number of results was incorrect");
         
         //validate
         List<Rectangle> resultRects = getResults();
@@ -100,7 +100,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(0, rectangles.count(), "No rectangles should have presisted to database while violating constraints.");
+        assertEquals(0, rectangles.countBy(), "No rectangles should have presisted to database while violating constraints.");
         assertEquals(4, resultingException.getConstraintViolations().size(), "Incorrect number of constraint violations.");
         
         // Save All
@@ -118,7 +118,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(0, rectangles.count(), "No rectangles should have presisted to database while violating constraints.");
+        assertEquals(0, rectangles.countBy(), "No rectangles should have presisted to database while violating constraints.");
         assertEquals(5, resultingException.getConstraintViolations().size(), "Incorrect number of constraint violations.");        
     }
     
@@ -131,7 +131,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(1, rectangles.count(), "Number of results was incorrect");
+        assertEquals(1, rectangles.countBy(), "Number of results was incorrect");
         assertRectangleFields(validRect, getResults().get(0));
         
         // Update
@@ -140,7 +140,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(1, rectangles.count(), "Number of results was incorrect");
+        assertEquals(1, rectangles.countBy(), "Number of results was incorrect");
         assertRectangleFields(updatedRect, getResults().get(0));     
     }
     
@@ -158,7 +158,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(4, rectangles.count(), "Number of results was incorrect");
+        assertEquals(4, rectangles.countBy(), "Number of results was incorrect");
         
         // Update All
         List<Rectangle> updatedRects = List.of(
@@ -171,7 +171,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(4, rectangles.count(), "Number of results was incorrect");
+        assertEquals(4, rectangles.countBy(), "Number of results was incorrect");
         
         // Verify All
         List<Rectangle> resultRects = getResults();
@@ -190,7 +190,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(1, rectangles.count(), "Number of results was incorrect");
+        assertEquals(1, rectangles.countBy(), "Number of results was incorrect");
         
         // Update
         Rectangle updatedInvalidRect = new Rectangle("RECT-040", -5L, -5L, -5, -5);
@@ -200,7 +200,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(1, rectangles.count(), "Number of results was incorrect");
+        assertEquals(1, rectangles.countBy(), "Number of results was incorrect");
         assertEquals(4, resultingException.getConstraintViolations().size());
         
         // Verify
@@ -223,7 +223,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(4, rectangles.count(), "Number of results was incorrect");
+        assertEquals(4, rectangles.countBy(), "Number of results was incorrect");
         
         // Update All
         List<Rectangle> invalidRects = List.of(
@@ -238,7 +238,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(4, rectangles.count(), "Number of results was incorrect");
+        assertEquals(4, rectangles.countBy(), "Number of results was incorrect");
         assertEquals(4, resultingException.getConstraintViolations().size());
         
         // Verify
@@ -261,7 +261,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(3, rectangles.count(), "Number of results was incorrect");
+        assertEquals(3, rectangles.countBy(), "Number of results was incorrect");
         
         // Get
         List<Rectangle> resultRects = rectangles.findAllByOrderByIdAsc();
@@ -288,7 +288,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(4, rectangles.count(), "Number of results was incorrect");
+        assertEquals(4, rectangles.countBy(), "Number of results was incorrect");
         
         // Get
         resultingException = assertThrows(ConstraintViolationException.class, () -> {


### PR DESCRIPTION
While running the TCK I found two errors that need to be fixed:

- The EntityTest application did not include the correct classes to run.
- The validation test repository used invalid query methods. 