### PR TITLE
Missing Sort in TCK test

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -972,7 +972,7 @@ public class EntityTests {
         //                                                                                  ^^^^^ next page ^^^^
 
         Pageable middle7 = Pageable.ofSize(7)
-                        .sortBy(Sort.asc("floorOfSquareRoot"), Sort.desc("id"))
+                        .sortBy(Sort.desc("numBitsRequired"), Sort.asc("floorOfSquareRoot"), Sort.desc("id"))
                         .afterKeyset((short) 5, 5L, 26L); // 20th result is 26; it requires 5 bits and its square root rounds down to 5.
 
         KeysetAwarePage<NaturalNumber> page;


### PR DESCRIPTION
While investigating other changes in the spec, I happened to notice that the TCK test testKeysetAwarePageOf7FromCursor is missing one of the Sorts.  The number of Sorts is supposed to exactly match the number of keyset values, but this test is providing 2 Sorts and 3 keyset values.  The 3 keyset values and their explanation in comments indicate that the test is intended to also sort on the numBitsRequired (in descending direction).  The test logic happens to otherwise be correct because this sort aligns with the descending sort on id that is also there.  In any case, we need to include the third sort so that the test matches up with spec requirements.