### PR TITLE
Experiment with Sort with type parameter [Solution 2]

### DIFF
--- a/api/src/main/java/jakarta/data/DefaultSort.java
+++ b/api/src/main/java/jakarta/data/DefaultSort.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data;
+
+import jakarta.data.page.Pageable;
+import jakarta.data.repository.OrderBy;
+import jakarta.data.repository.Query;
+import java.util.Objects;
+
+/**
+ * <p>Requests sorting on a given entity attribute.</p>
+ *
+ * <p><code>Sort</code> allows the application to dynamically provide
+ * sort criteria which includes a case sensitivity request,
+ * a {@link Direction} and a property.</p>
+ *
+ * <p>Dynamic <code>Sort</code> criteria can be specified when
+ * {@link Pageable#sortBy(Sort[]) requesting a page of results}
+ * or can be optionally specified as
+ * parameters to a repository method in any of the positions that are after
+ * the query parameters. You can use <code>Sort...</code> to allow a variable
+ * number of <code>Sort</code> criteria. For example,</p>
+ *
+ * <pre>
+ * Employee[] findByYearHired(int yearYired, Limit maxResults, Sort... sortBy);
+ * ...
+ * highestPaidNewHires = employees.findByYearHired(Year.now(),
+ *                                                 Limit.of(10),
+ *                                                 Sort.desc("salary"),
+ *                                                 Sort.asc("lastName"),
+ *                                                 Sort.asc("firstName"));
+ * </pre>
+ *
+ * <p>When combined on a method with static sort criteria
+ * (<code>OrderBy</code> keyword or {@link OrderBy} annotation or
+ * {@link Query} with an <code>ORDER BY</code> clause), the static
+ * sort criteria is applied first, followed by the dynamic sort criteria
+ * that is defined by <code>Sort</code> instances in the order listed.</p>
+ *
+ * <p>In the example above, the matching employees are sorted first by salary
+ * from highest to lowest. Employees with the same salary are then sorted
+ * alphabetically by last name. Employees with the same salary and last name
+ * are then sorted alphabetically by first name.</p>
+ *
+ * <p>A repository method will fail with a
+ * {@link jakarta.data.exceptions.DataException DataException}
+ * or a more specific subclass if</p>
+ * <ul>
+ * <li>a <code>Sort</code> parameter is
+ *     specified in combination with a {@link Pageable} parameter with
+ *     {@link Pageable#sorts()}.</li>
+ * <li>the database is incapable of ordering with the requested
+ *     sort criteria.</li>
+ * </ul>
+ *
+ * @param property    name of the property to order by.
+ * @param isAscending whether ordering for this property is ascending (true) or descending (false).
+ * @param ignoreCase  whether or not to request case insensitive ordering from a database with case sensitive collation.
+ */
+record DefaultSort(String property, boolean isAscending, boolean ignoreCase) implements Sort {
+
+    /**
+     * <p>Defines sort criteria for an entity property. For more descriptive code, use:</p>
+     * <ul>
+     * <li>{@link #asc(String) Sort.asc(propertyName)} for ascending sort on a property.</li>
+     * <li>{@link #ascIgnoreCase(String) Sort.ascIgnoreCase(propertyName)} for case insensitive ascending sort on a property.</li>
+     * <li>{@link #desc(String) Sort.desc(propertyName)} for descending sort on a property.</li>
+     * <li>{@link #descIgnoreCase(String) Sort.descIgnoreCase(propertyName)} for case insensitive descending sort on a property.</li>
+     * </ul>
+     *
+     * @param property    name of the property to order by.
+     * @param isAscending whether ordering for this property is ascending (true) or descending (false).
+     * @param ignoreCase  whether or not to request case insensitive ordering from a database with case sensitive collation.
+     */
+    public DefaultSort {
+        Objects.requireNonNull(property, "property is required");
+    }
+
+    @Override
+    public String property() {
+        return property;
+    }
+
+    @Override
+    public boolean ignoreCase() {
+        return ignoreCase;
+    }
+
+    @Override
+    public boolean isAscending() {
+        return isAscending;
+    }
+
+    @Override
+    public boolean isDescending() {
+        return !isAscending;
+    }
+
+}

--- a/api/src/main/java/jakarta/data/DefaultSort.java
+++ b/api/src/main/java/jakarta/data/DefaultSort.java
@@ -17,61 +17,9 @@
  */
 package jakarta.data;
 
-import jakarta.data.page.Pageable;
-import jakarta.data.repository.OrderBy;
-import jakarta.data.repository.Query;
 import java.util.Objects;
 
-/**
- * <p>Requests sorting on a given entity attribute.</p>
- *
- * <p><code>Sort</code> allows the application to dynamically provide
- * sort criteria which includes a case sensitivity request,
- * a {@link Direction} and a property.</p>
- *
- * <p>Dynamic <code>Sort</code> criteria can be specified when
- * {@link Pageable#sortBy(Sort[]) requesting a page of results}
- * or can be optionally specified as
- * parameters to a repository method in any of the positions that are after
- * the query parameters. You can use <code>Sort...</code> to allow a variable
- * number of <code>Sort</code> criteria. For example,</p>
- *
- * <pre>
- * Employee[] findByYearHired(int yearYired, Limit maxResults, Sort... sortBy);
- * ...
- * highestPaidNewHires = employees.findByYearHired(Year.now(),
- *                                                 Limit.of(10),
- *                                                 Sort.desc("salary"),
- *                                                 Sort.asc("lastName"),
- *                                                 Sort.asc("firstName"));
- * </pre>
- *
- * <p>When combined on a method with static sort criteria
- * (<code>OrderBy</code> keyword or {@link OrderBy} annotation or
- * {@link Query} with an <code>ORDER BY</code> clause), the static
- * sort criteria is applied first, followed by the dynamic sort criteria
- * that is defined by <code>Sort</code> instances in the order listed.</p>
- *
- * <p>In the example above, the matching employees are sorted first by salary
- * from highest to lowest. Employees with the same salary are then sorted
- * alphabetically by last name. Employees with the same salary and last name
- * are then sorted alphabetically by first name.</p>
- *
- * <p>A repository method will fail with a
- * {@link jakarta.data.exceptions.DataException DataException}
- * or a more specific subclass if</p>
- * <ul>
- * <li>a <code>Sort</code> parameter is
- *     specified in combination with a {@link Pageable} parameter with
- *     {@link Pageable#sorts()}.</li>
- * <li>the database is incapable of ordering with the requested
- *     sort criteria.</li>
- * </ul>
- *
- * @param property    name of the property to order by.
- * @param isAscending whether ordering for this property is ascending (true) or descending (false).
- * @param ignoreCase  whether or not to request case insensitive ordering from a database with case sensitive collation.
- */
+
 record DefaultSort(String property, boolean isAscending, boolean ignoreCase) implements Sort {
 
     /**

--- a/api/src/main/java/jakarta/data/ParameterizedSort.java
+++ b/api/src/main/java/jakarta/data/ParameterizedSort.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data;
+
+public interface ParameterizedSort<T> extends Sort {
+}

--- a/api/src/main/java/jakarta/data/Sort.java
+++ b/api/src/main/java/jakarta/data/Sort.java
@@ -17,91 +17,78 @@
  */
 package jakarta.data;
 
-import jakarta.data.page.Pageable;
-import jakarta.data.repository.OrderBy;
-import jakarta.data.repository.Query;
 import java.util.Objects;
 
-/**
- * <p>Requests sorting on a given entity attribute.</p>
- *
- * <p><code>Sort</code> allows the application to dynamically provide
- * sort criteria which includes a case sensitivity request,
- * a {@link Direction} and a property.</p>
- *
- * <p>Dynamic <code>Sort</code> criteria can be specified when
- * {@link Pageable#sortBy(Sort[]) requesting a page of results}
- * or can be optionally specified as
- * parameters to a repository method in any of the positions that are after
- * the query parameters. You can use <code>Sort...</code> to allow a variable
- * number of <code>Sort</code> criteria. For example,</p>
- *
- * <pre>
- * Employee[] findByYearHired(int yearYired, Limit maxResults, Sort... sortBy);
- * ...
- * highestPaidNewHires = employees.findByYearHired(Year.now(),
- *                                                 Limit.of(10),
- *                                                 Sort.desc("salary"),
- *                                                 Sort.asc("lastName"),
- *                                                 Sort.asc("firstName"));
- * </pre>
- *
- * <p>When combined on a method with static sort criteria
- * (<code>OrderBy</code> keyword or {@link OrderBy} annotation or
- * {@link Query} with an <code>ORDER BY</code> clause), the static
- * sort criteria is applied first, followed by the dynamic sort criteria
- * that is defined by <code>Sort</code> instances in the order listed.</p>
- *
- * <p>In the example above, the matching employees are sorted first by salary
- * from highest to lowest. Employees with the same salary are then sorted
- * alphabetically by last name. Employees with the same salary and last name
- * are then sorted alphabetically by first name.</p>
- *
- * <p>A repository method will fail with a
- * {@link jakarta.data.exceptions.DataException DataException}
- * or a more specific subclass if</p>
- * <ul>
- * <li>a <code>Sort</code> parameter is
- *     specified in combination with a {@link Pageable} parameter with
- *     {@link Pageable#sorts()}.</li>
- * <li>the database is incapable of ordering with the requested
- *     sort criteria.</li>
- * </ul>
- *
- * @param property    name of the property to order by.
- * @param isAscending whether ordering for this property is ascending (true) or descending (false).
- * @param ignoreCase  whether or not to request case insensitive ordering from a database with case sensitive collation.
- */
-public record Sort(String property, boolean isAscending, boolean ignoreCase) {
-
+public interface Sort {
     /**
-     * <p>Defines sort criteria for an entity property. For more descriptive code, use:</p>
-     * <ul>
-     * <li>{@link #asc(String) Sort.asc(propertyName)} for ascending sort on a property.</li>
-     * <li>{@link #ascIgnoreCase(String) Sort.ascIgnoreCase(propertyName)} for case insensitive ascending sort on a property.</li>
-     * <li>{@link #desc(String) Sort.desc(propertyName)} for descending sort on a property.</li>
-     * <li>{@link #descIgnoreCase(String) Sort.descIgnoreCase(propertyName)} for case insensitive descending sort on a property.</li>
-     * </ul>
+     * Create a {@link Sort} instance
      *
-     * @param property    name of the property to order by.
-     * @param isAscending whether ordering for this property is ascending (true) or descending (false).
-     * @param ignoreCase  whether or not to request case insensitive ordering from a database with case sensitive collation.
+     * @param property   the property name to order by
+     * @param direction  the direction in which to order.
+     * @param ignoreCase whether to request a case insensitive ordering.
+     * @return a {@link Sort} instance. Never {@code null}.
+     * @throws NullPointerException when there is a null parameter
      */
-    public Sort {
-        Objects.requireNonNull(property, "property is required");
+    static Sort of(String property, Direction direction, boolean ignoreCase) {
+        Objects.requireNonNull(direction, "direction is required");
+        return new DefaultSort(property, Direction.ASC.equals(direction), ignoreCase);
     }
 
-    // Override to provide method documentation:
+    /**
+     * Create a {@link Sort} instance with {@link Direction#ASC ascending direction}
+     * that does not request case insensitive ordering.
+     *
+     * @param property the property name to order by
+     * @return a {@link Sort} instance. Never {@code null}.
+     * @throws NullPointerException when the property is null
+     */
+    static Sort asc(String property) {
+        return new DefaultSort(property, true, false);
+    }
+
+    /**
+     * Create a {@link Sort} instance with {@link Direction#ASC ascending direction}
+     * and case insensitive ordering.
+     *
+     * @param property the property name to order by.
+     * @return a {@link Sort} instance. Never {@code null}.
+     * @throws NullPointerException when the property is null.
+     */
+    static Sort ascIgnoreCase(String property) {
+        return new DefaultSort(property, true, true);
+    }
+
+    /**
+     * Create a {@link Sort} instance with {@link Direction#DESC descending direction}
+     * that does not request case insensitive ordering.
+     *
+     * @param property the property name to order by
+     * @return a {@link Sort} instance. Never {@code null}.
+     * @throws NullPointerException when the property is null
+     */
+    static Sort desc(String property) {
+        return new DefaultSort(property, false, false);
+    }
+
+    /**
+     * Create a {@link Sort} instance with {@link Direction#DESC descending direction}
+     * and case insensitive ordering.
+     *
+     * @param property the property name to order by.
+     * @return a {@link Sort} instance. Never {@code null}.
+     * @throws NullPointerException when the property is null.
+     */
+    static Sort descIgnoreCase(String property) {
+        return new DefaultSort(property, false, true);
+    }
+
     /**
      * Name of the property to order by.
      *
      * @return The property name to order by; will never be {@code null}.
      */
-    public String property() {
-        return property;
-    }
+    String property();
 
-    // Override to provide method documentation:
     /**
      * <p>Indicates whether or not to request case insensitive ordering
      * from a database with case sensitive collation.
@@ -110,88 +97,19 @@ public record Sort(String property, boolean isAscending, boolean ignoreCase) {
      *
      * @return Returns whether or not to request case insensitive sorting for the property.
      */
-    public boolean ignoreCase() {
-        return ignoreCase;
-    }
+    boolean ignoreCase();
 
-    // Override to provide method documentation:
     /**
      * Indicates whether to sort the property in ascending order (true) or descending order (false).
      *
      * @return Returns whether sorting for this property shall be ascending.
      */
-    public boolean isAscending() {
-        return isAscending;
-    }
+    boolean isAscending();
 
     /**
      * Indicates whether to sort the property in descending order (true) or ascending order (false).
      *
      * @return Returns whether sorting for this property shall be descending.
      */
-    public boolean isDescending() {
-        return !isAscending;
-    }
-
-    /**
-     * Create a {@link Sort} instance
-     *
-     * @param property  the property name to order by
-     * @param direction the direction in which to order.
-     * @param ignoreCase whether to request a case insensitive ordering.
-     * @return a {@link Sort} instance. Never {@code null}.
-     * @throws NullPointerException when there is a null parameter
-     */
-    public static Sort of(String property, Direction direction, boolean ignoreCase) {
-        Objects.requireNonNull(direction, "direction is required");
-        return new Sort(property, Direction.ASC.equals(direction), ignoreCase);
-    }
-
-    /**
-     * Create a {@link Sort} instance with {@link Direction#ASC ascending direction}
-     * that does not request case insensitive ordering.
-     *
-     * @param property the property name to order by
-     * @return a {@link Sort} instance. Never {@code null}.
-     * @throws NullPointerException when the property is null
-     */
-    public static Sort asc(String property) {
-        return new Sort(property, true, false);
-    }
-
-    /**
-     * Create a {@link Sort} instance with {@link Direction#ASC ascending direction}
-     * and case insensitive ordering.
-     *
-     * @param property the property name to order by.
-     * @return a {@link Sort} instance. Never {@code null}.
-     * @throws NullPointerException when the property is null.
-     */
-    public static Sort ascIgnoreCase(String property) {
-        return new Sort(property, true, true);
-    }
-
-    /**
-     * Create a {@link Sort} instance with {@link Direction#DESC descending direction}
-     * that does not request case insensitive ordering.
-     *
-     * @param property the property name to order by
-     * @return a {@link Sort} instance. Never {@code null}.
-     * @throws NullPointerException when the property is null
-     */
-    public static Sort desc(String property) {
-        return new Sort(property, false, false);
-    }
-
-    /**
-     * Create a {@link Sort} instance with {@link Direction#DESC descending direction}
-     * and case insensitive ordering.
-     *
-     * @param property the property name to order by.
-     * @return a {@link Sort} instance. Never {@code null}.
-     * @throws NullPointerException when the property is null.
-     */
-    public static Sort descIgnoreCase(String property) {
-        return new Sort(property, false, true);
-    }
+    boolean isDescending();
 }

--- a/api/src/main/java/jakarta/data/Sort.java
+++ b/api/src/main/java/jakarta/data/Sort.java
@@ -17,8 +17,56 @@
  */
 package jakarta.data;
 
+
 import java.util.Objects;
 
+/**
+ * <p>Requests sorting on a given entity attribute.</p>
+ *
+ * <p><code>Sort</code> allows the application to dynamically provide
+ * sort criteria which includes a case sensitivity request,
+ * a {@link Direction} and a property.</p>
+ *
+ * <p>Dynamic <code>Sort</code> criteria can be specified when
+ * {@link jakarta.data.page.Pageable#sortBy(Sort[]) requesting a page of results}
+ * or can be optionally specified as
+ * parameters to a repository method in any of the positions that are after
+ * the query parameters. You can use <code>Sort...</code> to allow a variable
+ * number of <code>Sort</code> criteria. For example,</p>
+ *
+ * <pre>
+ * Employee[] findByYearHired(int yearYired, Limit maxResults, Sort... sortBy);
+ * ...
+ * highestPaidNewHires = employees.findByYearHired(Year.now(),
+ *                                                 Limit.of(10),
+ *                                                 Sort.desc("salary"),
+ *                                                 Sort.asc("lastName"),
+ *                                                 Sort.asc("firstName"));
+ * </pre>
+ *
+ * <p>When combined on a method with static sort criteria
+ * (<code>OrderBy</code> keyword or {@link jakarta.data.repository.OrderBy} annotation or
+ * {@link jakarta.data.repository.Query} with an <code>ORDER BY</code> clause), the static
+ * sort criteria is applied first, followed by the dynamic sort criteria
+ * that is defined by <code>Sort</code> instances in the order listed.</p>
+ *
+ * <p>In the example above, the matching employees are sorted first by salary
+ * from highest to lowest. Employees with the same salary are then sorted
+ * alphabetically by last name. Employees with the same salary and last name
+ * are then sorted alphabetically by first name.</p>
+ *
+ * <p>A repository method will fail with a
+ * {@link jakarta.data.exceptions.DataException DataException}
+ * or a more specific subclass if</p>
+ * <ul>
+ * <li>a <code>Sort</code> parameter is
+ *     specified in combination with a {@link jakarta.data.page.Pageable} parameter with
+ *     {@link jakarta.data.page.Pageable#sorts()}.</li>
+ * <li>the database is incapable of ordering with the requested
+ *     sort criteria.</li>
+ * </ul>
+ *
+ */
 public interface Sort {
     /**
      * Create a {@link Sort} instance

--- a/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java
@@ -17,6 +17,7 @@
  */
 package jakarta.data.metamodel;
 
+import jakarta.data.ParameterizedSort;
 import jakarta.data.Sort;
 
 /**
@@ -31,20 +32,20 @@ import jakarta.data.Sort;
  * <li>{@link TextAttribute textual attributes}</li>
  * </ul>
  */
-public interface SortableAttribute extends Attribute {
+public interface SortableAttribute<T> extends Attribute {
 
     /**
      * Obtain a request for an ascending {@link Sort} based on the entity attribute.
      *
      * @return a request for an ascending sort on the entity attribute.
      */
-    Sort asc();
+    ParameterizedSort<T> asc();
 
     /**
      * Obtain a request for a descending {@link Sort} based on the entity attribute.
      *
      * @return a request for a descending sort on the entity attribute.
      */
-    Sort desc();
+    ParameterizedSort<T> desc();
 
 }

--- a/api/src/main/java/jakarta/data/repository/OrderBy.java
+++ b/api/src/main/java/jakarta/data/repository/OrderBy.java
@@ -17,7 +17,6 @@
  */
 package jakarta.data.repository;
 
-import jakarta.data.Sort;
 import jakarta.data.page.Pageable;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Repeatable;
@@ -32,7 +31,7 @@ import java.lang.annotation.Target;
  * repository method, the precedence for sorting follows the order
  * in which the <code>OrderBy</code> annotations are specified,
  * and after that follows any sort criteria that is supplied
- * dynamically by {@link Sort} parameters or by a
+ * dynamically by {@link jakarta.data.Sort} parameters or by a
  * {@link Pageable} parameter with {@link Pageable#sorts()}.</p>
  *
  * <p>For example, the following sorts first by the

--- a/api/src/main/java/jakarta/data/repository/Query.java
+++ b/api/src/main/java/jakarta/data/repository/Query.java
@@ -17,7 +17,6 @@
  */
 package jakarta.data.repository;
 
-import jakarta.data.Sort;
 import jakarta.data.page.KeysetAwarePage;
 import jakarta.data.page.Page;
 import java.lang.annotation.ElementType;
@@ -76,7 +75,7 @@ public @interface Query {
      * <p>Defines the query to be executed when the annotated method is called.</p>
      *
      * <p>If an application defines a repository method with <code>&#64;Query</code>
-     * and supplies other forms of sorting (such as {@link Sort}) to that method,
+     * and supplies other forms of sorting (such as {@link jakarta.data.Sort}) to that method,
      * then it is the responsibility of the application to compose the query in
      * such a way that an <code>ORDER BY</code> clause (or query language equivalent)
      * can be validly appended. The Jakarta Data provider is not expected to


### PR DESCRIPTION
# Changes

The goal is to create a Parameterized Sort that keeps what we currently have. Thus, update sort as an interface and share it for both: 

- Sort
- ParamitizedSort

```mermaid
classDiagram
    Sort <|-- DefaultSort
    Sort <|-- ParameterizedSort
  
````


⚠️ I did not update the TCK; my point here is: We can create new capabilities without breaking the core API all the time.

Reference: https://github.com/jakartaee/data/pull/432

