### PR TITLE
Committer list is missing Kyle's name

### DIFF
--- a/spec/src/main/asciidoc/chapters/introduction/project_team.adoc
+++ b/spec/src/main/asciidoc/chapters/introduction/project_team.adoc
@@ -32,6 +32,7 @@ of the project committers and various contributors.
 * https://projects.eclipse.org/content/graeme-rocher-committer-jakarta-data[Graeme Rocher]
 * https://projects.eclipse.org/content/james-krueger-committer-jakarta-data[James Krueger]
 * https://projects.eclipse.org/content/james-stephens-committer-jakarta-data[James Stephens]
+* https://projects.eclipse.org/content/kyle-aure-committer-jakarta-data[Kyle Aure]
 * https://projects.eclipse.org/content/mark-swatosh-committer-jakarta-data[Mark Swatosh]
 * https://projects.eclipse.org/content/michael-redlich-committer-jakarta-data[Michael Redlich]
 * https://projects.eclipse.org/content/nathan-rauh-committer-jakarta-data[Nathan Rauh]


### PR DESCRIPTION
Kyle's name is missing from the committer list in the spec.  It looks like all other names shown on https://projects.eclipse.org/projects/ee4j.data/who are present there.  I'm not sure how he was missed, but let's update it to include him.