### PR TITLE
Revert "Update templates to include release 1.0.0-M3"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,10 +1,10 @@
 name: Bug Report
-description: Report a mistake or inconsistency in the specification code or documentation text.
+description: Report a mistake or inconsistency in the specification code or documentation text. 
 title: "[Bug]: "
 labels: ["bug"] #Verified - label exists
 body:
   - type: markdown
-    attributes:
+    attributes: 
       value: |
         > Report a mistake or inconsistency in the specification code, TCK tests, or documentation text.
         > If error is related to a TCK test after release, then use the TCK Challenge template instead.
@@ -12,11 +12,10 @@ body:
     id: version
     validations:
       required: true
-    attributes:
+    attributes: 
       label: Specification Version
-      description: What version of the Concurrency Spec are you running using?
+      description: What version of the Concurrency Spec are you running using? 
       options:
-        - 1.0.0-M3
         - 1.0.0-M2
         - 1.0.0-M1
         - SNAPSHOT (Locally built)
@@ -30,4 +29,5 @@ body:
   - type: textarea
     attributes:
       label: Additional information
-      placeholder: "> Proposed solutions, code examples, ect. \n"
+      placeholder: |
+        > Proposed solutions, code examples, ect. 

--- a/.github/ISSUE_TEMPLATE/tck-challenge.yml
+++ b/.github/ISSUE_TEMPLATE/tck-challenge.yml
@@ -4,22 +4,24 @@ title: "[TCK Challenge]: "
 labels: ["challenge"] #Verified - label exists
 body:
   - type: markdown
-    attributes:
-      value: "> Before submitting a TCK Challenge to the Jakarta Data community please read and be familiar with the \n> [TCK Process document](https://jakarta.ee/committees/specification/tckprocess) which may be updated occasionally.\n"
+    attributes: 
+      value: |
+        > Before submitting a TCK Challenge to the Jakarta Data community please read and be familiar with the 
+        > [TCK Process document](https://jakarta.ee/committees/specification/tckprocess) which may be updated occasionally.
   - type: input
     id: specification
     validations:
       required: true
-    attributes:
+    attributes: 
       label: Specification
-      description: What specification is the challenge related to? Provide a link to the specification class or document section.
+      description: What specification is the challenge related to? Provide a link to the specification class or document section. 
       placeholder: |
         ex. [Entity value](https://github.com/jakartaee/data/blob/main/api/src/main/java/jakarta/data/Entity.java#L33)
   - type: input
     id: assertion
     validations:
       required: true
-    attributes:
+    attributes: 
       label: Assertion
       description: What assertion is the challenge related to? Provide a link to the assertion description
       placeholder: |
@@ -28,19 +30,18 @@ body:
     id: version
     validations:
       required: true
-    attributes:
+    attributes: 
       label: TCK Version
-      description: What version of the TCK are you running against?
+      description: What version of the TCK are you running against? 
       options:
-        - 1.0.0-M3
         - 1.0.0-M2
         - 1.0.0-M1
-        - SNAPSHOT (Locally built)
+        - SNAPSHOT (Locally built)      
   - type: input
     id: implementation
     validations:
       required: true
-    attributes:
+    attributes: 
       label: Implementation being tested
       description: What implementation is being tested? Include name of company/organization
       placeholder: |
@@ -49,10 +50,10 @@ body:
     id: challengeType
     validations:
       required: true
-    attributes:
+    attributes: 
       label: Challenge Scenario
-      description: Which of the following scenarios best match this challenge?
-      options:
+      description: Which of the following scenarios best match this challenge? 
+      options: 
         - Claims that a test assertion conflicts with the specification.
         - Claims that a test asserts requirements over and above that of the specification.
         - Claims that an assertion of the specification is not sufficiently implementable.
@@ -81,5 +82,5 @@ body:
         Please search to see if a challenge already exists, or has been approved, that matches your challenge.
         https://github.com/jakartaee/data/issues?q=is%3Aissue+label%3Achallenge
       options:
-        - label: I have searched the existing issues
-          required: true
+      - label: I have searched the existing issues
+        required: true

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>jakarta.data</groupId>
         <artifactId>jakarta.data-parent</artifactId>
-        <version>1.0.0-M3</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jakarta.data-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>jakarta.data</groupId>
     <artifactId>jakarta.data-parent</artifactId>
-    <version>1.0.0-M3</version>
+    <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Jakarta Data</name>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>jakarta.data</groupId>
         <artifactId>jakarta.data-parent</artifactId>
-        <version>1.0.0-M3</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jakarta.data-spec</artifactId>

--- a/tck-dist/pom.xml
+++ b/tck-dist/pom.xml
@@ -22,7 +22,7 @@
  <parent>
   <groupId>jakarta.data</groupId>
   <artifactId>jakarta.data-parent</artifactId>
-  <version>1.0.0-M3</version>
+  <version>1.0.0-SNAPSHOT</version>
  </parent>
 
  <artifactId>jakarta.data-tck-dist</artifactId>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>jakarta.data</groupId>
     <artifactId>jakarta.data-parent</artifactId>
-    <version>1.0.0-M3</version>
+    <version>1.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jakarta.data-tck</artifactId>


### PR DESCRIPTION
Reverts jakartaee/data#445

I'm going to disable that workflow for now until I can exclude the pom.xml updates.

see comment here: https://github.com/jakartaee/data/pull/445#issuecomment-1938850663