### PR TITLE
Fix release workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,10 +1,10 @@
 name: Bug Report
-description: Report a mistake or inconsistency in the specification code or documentation text. 
+description: Report a mistake or inconsistency in the specification code or documentation text.
 title: "[Bug]: "
 labels: ["bug"] #Verified - label exists
 body:
   - type: markdown
-    attributes: 
+    attributes:
       value: |
         > Report a mistake or inconsistency in the specification code, TCK tests, or documentation text.
         > If error is related to a TCK test after release, then use the TCK Challenge template instead.
@@ -12,10 +12,11 @@ body:
     id: version
     validations:
       required: true
-    attributes: 
+    attributes:
       label: Specification Version
-      description: What version of the Concurrency Spec are you running using? 
+      description: What version of the Concurrency Spec are you running using?
       options:
+        - 1.0.0-M3
         - 1.0.0-M2
         - 1.0.0-M1
         - SNAPSHOT (Locally built)
@@ -29,5 +30,4 @@ body:
   - type: textarea
     attributes:
       label: Additional information
-      placeholder: |
-        > Proposed solutions, code examples, ect. 
+      placeholder: "> Proposed solutions, code examples, ect. \n"

--- a/.github/ISSUE_TEMPLATE/tck-challenge.yml
+++ b/.github/ISSUE_TEMPLATE/tck-challenge.yml
@@ -4,24 +4,22 @@ title: "[TCK Challenge]: "
 labels: ["challenge"] #Verified - label exists
 body:
   - type: markdown
-    attributes: 
-      value: |
-        > Before submitting a TCK Challenge to the Jakarta Data community please read and be familiar with the 
-        > [TCK Process document](https://jakarta.ee/committees/specification/tckprocess) which may be updated occasionally.
+    attributes:
+      value: "> Before submitting a TCK Challenge to the Jakarta Data community please read and be familiar with the \n> [TCK Process document](https://jakarta.ee/committees/specification/tckprocess) which may be updated occasionally.\n"
   - type: input
     id: specification
     validations:
       required: true
-    attributes: 
+    attributes:
       label: Specification
-      description: What specification is the challenge related to? Provide a link to the specification class or document section. 
+      description: What specification is the challenge related to? Provide a link to the specification class or document section.
       placeholder: |
         ex. [Entity value](https://github.com/jakartaee/data/blob/main/api/src/main/java/jakarta/data/Entity.java#L33)
   - type: input
     id: assertion
     validations:
       required: true
-    attributes: 
+    attributes:
       label: Assertion
       description: What assertion is the challenge related to? Provide a link to the assertion description
       placeholder: |
@@ -30,18 +28,19 @@ body:
     id: version
     validations:
       required: true
-    attributes: 
+    attributes:
       label: TCK Version
-      description: What version of the TCK are you running against? 
+      description: What version of the TCK are you running against?
       options:
+        - 1.0.0-M3
         - 1.0.0-M2
         - 1.0.0-M1
-        - SNAPSHOT (Locally built)      
+        - SNAPSHOT (Locally built)
   - type: input
     id: implementation
     validations:
       required: true
-    attributes: 
+    attributes:
       label: Implementation being tested
       description: What implementation is being tested? Include name of company/organization
       placeholder: |
@@ -50,10 +49,10 @@ body:
     id: challengeType
     validations:
       required: true
-    attributes: 
+    attributes:
       label: Challenge Scenario
-      description: Which of the following scenarios best match this challenge? 
-      options: 
+      description: Which of the following scenarios best match this challenge?
+      options:
         - Claims that a test assertion conflicts with the specification.
         - Claims that a test asserts requirements over and above that of the specification.
         - Claims that an assertion of the specification is not sufficiently implementable.
@@ -82,5 +81,5 @@ body:
         Please search to see if a challenge already exists, or has been approved, that matches your challenge.
         https://github.com/jakartaee/data/issues?q=is%3Aissue+label%3Achallenge
       options:
-      - label: I have searched the existing issues
-        required: true
+        - label: I have searched the existing issues
+          required: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        ref: 'main' # Otherwise, this action will checkout the tag that was created during publishing
     - name: Create branch
       id: checkout
       run: .github/scripts/checkout.sh update-templates-${{ github.sha }}


### PR DESCRIPTION
The release workflow happens when a release is published and checks to make sure the tag for the release is added to the bug-report and tck-challenge templates.
I did not realize that when we preformed a checkout during this workflow that it would checkout using the context of the release.
Therefore, the bot would accidentally open a pull request to the main branch, including version updates to the latest release version. 

That should be fixed, but forcing the checkout action to use the main branch instead of the release branch.
Sorry for the confusion :) 