### PR TITLE
Remove BasicRepository.deleteAll()

### DIFF
--- a/api/src/main/java/jakarta/data/repository/BasicRepository.java
+++ b/api/src/main/java/jakarta/data/repository/BasicRepository.java
@@ -243,12 +243,4 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
     @Delete
     void deleteAll(Iterable<? extends T> entities);
 
-    /**
-     * Deletes all persistent entities of the primary entity type that are managed by the repository.
-     *
-     * @throws UnsupportedOperationException for Key-Value and Wide-Column databases that are not capable of the {@code deleteAll} operation.
-     */
-    @Delete
-    void deleteAll();
-
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -148,7 +148,12 @@ public class EntityTests {
             strategy = "Use a repository that inherits from BasicRepository and defines no additional methods of its own. " +
                        "Use all of the built-in methods.")
     public void testBasicRepositoryBuiltInMethods() {
-        boxes.deleteAll();
+        boxes.deleteByIdIn(List.of(
+                "TestBasicRepositoryMethods-01",
+                "TestBasicRepositoryMethods-02",
+                "TestBasicRepositoryMethods-03",
+                "TestBasicRepositoryMethods-04",
+                "TestBasicRepositoryMethods-05"));
 
         TestPropertyUtility.waitForEventualConsistency();
 
@@ -265,9 +270,8 @@ public class EntityTests {
         assertEquals(104, box5.width);
         assertEquals(185, box5.height);
 
-        // BasicRepository.deleteAll
-        boxes.deleteAll();
-
+        // BasicRepository.deleteByIdIn
+        boxes.deleteByIdIn(List.of("TestBasicRepositoryMethods-05"));
         TestPropertyUtility.waitForEventualConsistency();
 
         assertEquals(0, boxes.countBy());
@@ -275,7 +279,12 @@ public class EntityTests {
 
     @Assertion(id = "133", strategy = "Use a repository that inherits from BasicRepository and defines no additional methods of its own. Use all of the built-in methods.")
     public void testBasicRepositoryMethods() {
-        boxes.deleteAll();
+        boxes.deleteByIdIn(List.of(
+                "TestBasicRepositoryMethods-01",
+                "TestBasicRepositoryMethods-02",
+                "TestBasicRepositoryMethods-03",
+                "TestBasicRepositoryMethods-04",
+                "TestBasicRepositoryMethods-05"));
 
         TestPropertyUtility.waitForEventualConsistency();
 
@@ -392,8 +401,8 @@ public class EntityTests {
         assertEquals(104, box5.width);
         assertEquals(185, box5.height);
 
-        // BasicRepository.deleteAll
-        boxes.deleteAll();
+        // BasicRepository.deleteByIdIn
+        boxes.deleteByIdIn(List.of("TestBasicRepositoryMethods-05"));
 
         TestPropertyUtility.waitForEventualConsistency();
 

--- a/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/jakarta.data.sig_17
+++ b/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/jakarta.data.sig_17
@@ -218,8 +218,6 @@ meth public abstract java.util.stream.Stream<{jakarta.data.repository.BasicRepos
 meth public abstract long countBy()
 meth public abstract void delete({jakarta.data.repository.BasicRepository%0})
  anno 0 jakarta.data.repository.Delete()
-meth public abstract void deleteAll()
- anno 0 jakarta.data.repository.Delete()
 meth public abstract void deleteAll(java.lang.Iterable<? extends {jakarta.data.repository.BasicRepository%0}>)
  anno 0 jakarta.data.repository.Delete()
 meth public abstract void deleteById({jakarta.data.repository.BasicRepository%1})

--- a/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/jakarta.data.sig_21
+++ b/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/jakarta.data.sig_21
@@ -218,8 +218,6 @@ meth public abstract java.util.stream.Stream<{jakarta.data.repository.BasicRepos
 meth public abstract long countBy()
 meth public abstract void delete({jakarta.data.repository.BasicRepository%0})
  anno 0 jakarta.data.repository.Delete()
-meth public abstract void deleteAll()
- anno 0 jakarta.data.repository.Delete()
 meth public abstract void deleteAll(java.lang.Iterable<? extends {jakarta.data.repository.BasicRepository%0}>)
  anno 0 jakarta.data.repository.Delete()
 meth public abstract void deleteById({jakarta.data.repository.BasicRepository%1})


### PR DESCRIPTION
It was discussed on today's Jakarta Data call to remove the built-in deleteAll method from BasicRepository.  Users could still write their own deleteAll if they wish, but this operation is seen as something that is not likely to be typically wanted.