### PR TITLE
remove integration with Jakarta Persistence

### DIFF
--- a/spec/src/main/asciidoc/jakarta-ee.adoc
+++ b/spec/src/main/asciidoc/jakarta-ee.adoc
@@ -29,11 +29,7 @@ If the application developer fails to disambiguate the provider for every reposi
 A Jakarta Data provider typically supports one entity-defining annotation type, but it may support multiple entity-defining annotation types.
 A provider may even have no entity-defining annotation and feature a programming model for entity classes where the entity classes are unannotated.
 
-In particular:
-
-- The `jakarta.persistence.Entity` annotation from the Jakarta Persistence specification is an entity-defining annotation for Jakarta Data providers backed by a Jakarta Persistence provider. Other Jakarta Data providers must not support the use of `jakarta.persistence.Entity` as an entity-defining annotation.
-
-- The `jakarta.nosql.Entity` annotation from the Jakarta NoSQL specification is an entity-defining annotation for Jakarta Data providers backed by NoSQL databases. Other Jakarta Data providers must not support the use of `jakarta.nosql.Entity` as an entity-defining annotation.
+In particular, the `jakarta.nosql.Entity` annotation from the Jakarta NoSQL specification is an entity-defining annotation for Jakarta Data providers backed by NoSQL databases. Other Jakarta Data providers must not support the use of `jakarta.nosql.Entity` as an entity-defining annotation.
 
 A Jakarta Data provider might define a custom entity-defining annotation.
 The name of such a custom entity-defining annotation type must end with `Entity`. This convention allows any Jakarta Data provider to identify when a repository is associated with entity classes declared using an unrecognized entity-defining annotation.
@@ -120,14 +116,7 @@ When a repository method is annotated with an interceptor binding annotation, th
 
 === Jakarta Persistence
 
-When integrating Jakarta Data with Jakarta Persistence, a developer uses the annotations defined in `jakarta.persistence` to specify the object/relational mapping metadata for entity types stored in a relational database.
-
-According to the Jakarta Persistence specification, every entity class should be annotated `jakarta.persistence.Entity`. Jakarta Data places an additional interpretation on this annotation, treating it as an entity-defining annotation.
-
-Thus, a Jakarta Data provider which supports Jakarta Persistence is able to supply an implementation of any repository whose associated entity classes are marked with the `jakarta.persistence.Entity` annotation. Typically, such an implementation simply delegates operations declared by the repository interface to the Jakarta Persistence `EntityManager`. Management of persistence contexts and integration with Jakarta Transactions remains the responsibility of the Jakarta Persistence provider.
-
-By supporting Jakarta Persistence, a Jakarta Data provider enables Java developers to utilize familiar and standardized mapping techniques when defining entities associated with Jakarta Data repositories, ensuring compatibility and interoperability with the respective technologies.
-
+Integration with Jakarta Persistence is left undefined in this first release of Jakarta Data.
 
 === Jakarta NoSQL
 
@@ -180,7 +169,3 @@ public interface School extends DataRepository<Student, String> {
     List<Student> findByAgeLessThanEqual(@Min(18) int age);
 }
 ----
-
-==== Avoiding Overlap with Validation from Jakarta Persistence
-
-Jakarta Data providers that are built using Jakarta Persistence might require the user to define persistence units for repositories or might handle the details of defining the persistence units internally. A user that defines the persistence unit for a Jakarta Data repository must specify the `validation-mode` as `NONE` per the "Enabling Automatic Validation" section of the Jakarta Persistence specification to avoid duplicate validation of entities. Similarly, the Jakarta Data provider must specify either the `validation-mode` of `NONE` or the `jakarta.persistence.validation.mode` map key with value of `none` that is defined in the "Enabling Automatic Validation" section of the Jakarta Persistence specification to avoid duplicate validation of entities.

--- a/spec/src/main/asciidoc/jakarta-ee.adoc
+++ b/spec/src/main/asciidoc/jakarta-ee.adoc
@@ -29,7 +29,11 @@ If the application developer fails to disambiguate the provider for every reposi
 A Jakarta Data provider typically supports one entity-defining annotation type, but it may support multiple entity-defining annotation types.
 A provider may even have no entity-defining annotation and feature a programming model for entity classes where the entity classes are unannotated.
 
-In particular, the `jakarta.nosql.Entity` annotation from the Jakarta NoSQL specification is an entity-defining annotation for Jakarta Data providers backed by NoSQL databases. Other Jakarta Data providers must not support the use of `jakarta.nosql.Entity` as an entity-defining annotation.
+In particular:
+
+- The `jakarta.persistence.Entity` annotation from the Jakarta Persistence specification is an entity-defining annotation for Jakarta Data providers backed by a Jakarta Persistence provider. Other Jakarta Data providers must not support the use of `jakarta.persistence.Entity` as an entity-defining annotation.
+
+- The `jakarta.nosql.Entity` annotation from the Jakarta NoSQL specification is an entity-defining annotation for Jakarta Data providers backed by NoSQL databases. Other Jakarta Data providers must not support the use of `jakarta.nosql.Entity` as an entity-defining annotation.
 
 A Jakarta Data provider might define a custom entity-defining annotation.
 The name of such a custom entity-defining annotation type must end with `Entity`. This convention allows any Jakarta Data provider to identify when a repository is associated with entity classes declared using an unrecognized entity-defining annotation.

--- a/spec/src/main/asciidoc/portability.asciidoc
+++ b/spec/src/main/asciidoc/portability.asciidoc
@@ -7,47 +7,15 @@ The portability that is offered by Jakarta Data pertains to usage of the Jakarta
 
 === Portability for Relational Databases
 
-Jakarta Data is intended to be compatible with two very different approaches to relational data access:
+A Jakarta Data provider backed by access to relational data must support the built-in lifecycle annotations `@Insert`, `@Update`, and `@Delete`, along with the built-in repository types `BasicRepository` and `CrudRepository`. It must also fully support Jakarta Data query methods, including pagination, ordering, and limiting, subject to the caveat that follows.
 
-- In the approach typified by Jakarta Persistence, entities are _managed objects_ associated with a _persistence context_, and have a well-defined _persistence lifecycle_. Under this approach, an entity instance maintains its association with the Jakarta Data provider between repository method calls.
-
-- In the _persistence context free_ approach, entity instances are unmanaged objects, and their association with the Jakarta Data provider never outlasts a single call to a lifecycle method or query method of a repository.
-
-The two approaches feature very different patterns of interaction with the repository, and it is not a goal of Jakarta Data to abstract away the differences.
-
-Regardless of the approach, a Jakarta Data provider backed by access to relational data must fully support Jakarta Data query methods, including pagination, ordering, and limiting, subject to the caveats specified below.
-
-==== Jakarta Persistence
-
-In Jakarta Persistence, an instance of `EntityManager` reifies access to a given persistence context.
-Jakarta Persistence does not currently support the persistence context free approach.
-
-A Jakarta Data provider backed by Jakarta Persistence must:
-
-- allow the use of `jakarta.persistence.Entity` as an entity-defining annotation,
-- along with resource accessor methods of type `jakarta.persistence.EntityManager`.
-
-A Jakarta Data provider backed by Jakarta Persistence should define a query annotation accepting JPQL as the query language, along with an annotation accepting native SQL as the query language.
-
-[CAUTION]
+[NOTE]
 ====
-This release of Jakarta Data does not standardize lifecycle annotations or query annotations for use with Jakarta Data providers backed by Jakarta Persistence.
+The SQL dialect and the database set limits on what operations are implementable.
+A Jakarta Data provider is not required to supply an implementation of a repository which declares query methods mapping to operations which are not supported by the database itself.
 ====
-
-The Jakarta Persistence specification, the respective Jakarta Persistence provider, JPQL, SQL, and the database all set limitations on what is possible for a repository implementation backed by Jakarta Persistence. All such limitations apply when the entities associated with a Jakarta Data repository are declared using the annotation `jakarta.persistence.Entity`. In particular, repository query methods must correspond to operations which are legal JPQL and SQL queries.
-
-For example, although one can write a repository method that asks for sorting by a collection attribute or attempts to perform a Like operation on a numeric type rather than a String, there is no expectation that a Jakarta Data provider backed by Jakarta Persistence should be able to supply an implementation of such a repository.
-
-==== Other Relational Data Access Technologies
-
-A Jakarta Data provider for relational data does not need to be based on Jakarta Persistence, and is not required to feature persistence contexts.
-
-A Jakarta Data provider based on persistence context free access to relational data must support the built-in lifecycle annotations `@Insert`, `@Update`, and `@Delete`, along with the built-in repository types `BasicRepository` and `CrudRepository`.
 
 If the provider is backed by JDBC, it should support resource accessor methods of type `java.sql.Connection`.
-
-As above, the SQL dialect and the database set limits on what operations are implementable.
-The Jakarta Data provider is not required to supply an implementation of a repository which declares query methods mapping to operations which are not supported by the database itself.
 
 === Portability for NoSQL Databases
 


### PR DESCRIPTION
If we're unable to reach consensus on #477, then we should just go ahead and slip support for Jakarta Persistence until a future version of Jakarta Data, hopefully after Jakarta Persistence itself starts to support a stateless programming model (a feature I proposed a while ago, but which did not make it into JPA 3.2).

This PR demonstrates that we can leave JPA support undefined in this release without doing any real violence to the spec as it exists today.
