### PR TITLE
Update after release 1.0.0-M3

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yml
+++ b/.github/ISSUE_TEMPLATE/release.yml
@@ -40,7 +40,7 @@ body:
             - [ ] [Build and stage artifacts to staging repository](https://ci.eclipse.org/data/view/Release%20Builds/job/jakarta-data-build-and-stage/)
             - [ ] [Build and stage the TCK distribution artifact to download.eclipse.org](https://ci.eclipse.org/data/view/Eclipse%20Builds/job/jakarta-data-tck-build-and-stage/)
             - [ ] Update this issue with a comment that links to the staged artifacts and the generated GitHub branch and tag
-            - [ ] [Create a `pre-release` on GitHub](https://github.com/jakartaee/data/releases/new)
+            - [ ] [Create a `draft` release on GitHub](https://github.com/jakartaee/data/releases/new)
           #### Verify and modify
             - [ ] Ask for feedback from the community to verify the staged artifact has all the expected changes.
             - [ ] If anything needs to be added before publishing do that now and repeat the `Stage Release` section
@@ -48,7 +48,7 @@ body:
             - [ ] [Publish staged artifacts to the public repository](https://ci.eclipse.org/data/view/Release%20Builds/job/jakarta-data-stage-to-release/)
             - [ ] [Publish staged TCK distribution artifact to download.eclipse.org](https://ci.eclipse.org/data/view/Eclipse%20Builds/job/jakarta-data-tck-staged-to-promoted/)
             - [ ] Update this issue with a comment that links to the published artifacts and the generated GitHub branch and tag
-            - [ ] [Modify the `pre-release` on GitHub to be `latest`](https://github.com/jakartaee/data/releases)
+            - [ ] [Modify the `draft` release on GitHub to be `pre-release` or `latest`](https://github.com/jakartaee/data/releases)
           #### Follow up
             - [ ] [Email a Jakarta steering committee member to promote the TCK Distribution publically](https://ci.eclipse.org/jakartaee-spec-committee/job/promote-release/)
             - [ ] Update versions in non-build files, such as:

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,22 +8,7 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 
 == [Unreleased]
 
-=== Changed
-
-- Define the Sort and Pageable as parameterized
-- Include the Find annotation
-- Rename Pageable to PageRequest
-
-=== Added
-
-- Include FindAll method with pagination at BasicRepository
-
-
-=== Removed
-
-- Remove the PageableRepository interface
-
-== [1.0.0-M3] - 2024-01-30
+== [1.0.0-M3] - 2024-02-2023
 
 === Changed
 
@@ -32,6 +17,17 @@ and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Version
 - Introduced @Delete annotation to the default deleteAll() method
 - Restricted @Update and @Delete return types for numeric types to only int and long
 - Re-introduced static metamodel
+- Include the Find annotation
+- Rename Pageable to PageRequest
+- Define the Sort and Pageable as parameterized
+
+=== Added
+
+- Include FindAll method with pagination at BasicRepository
+
+=== Removed
+
+- Remove the PageableRepository interface
 
 
 == [1.0.0-M2] - 2023-11-31

--- a/README.adoc
+++ b/README.adoc
@@ -85,7 +85,7 @@ To start to use Jakarta Data, add the API as a Maven dependency:
 <dependency>
     <groupId>jakarta.data</groupId>
     <artifactId>jakarta.data-api</artifactId>
-    <version>1.0.0-M2</version>
+    <version>1.0.0-M3</version>
 </dependency>
 ----
 


### PR DESCRIPTION
- Update release template to use `draft` instead of `pre-release` during staging - FYI @lprimak
  - I didn't realize pre-release signified "Non production ready" instead of "before release". 
  - Also using `pre-release` will notify users that are following the repository so we should avoid using it until releases are publically available.
- Updated documentation files now that 1.0.0-M3 is publicly available 

Fixes #415 