### PR TITLE
add convenience implementations of metamodel types

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/impl/AttributeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/impl/AttributeRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/data/metamodel/impl/AttributeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/impl/AttributeRecord.java
@@ -23,9 +23,10 @@ import jakarta.data.metamodel.Attribute;
  * Record type implementing {@link jakarta.data.metamodel.TextAttribute}.
  * This may be used to simplify implementation of the static metamodel.
  *
+ * @param <T> entity class of the static metamodel.
  * @param name the name of the attribute
  */
-public record AttributeRecord(String name)
-        implements Attribute {
+public record AttributeRecord<T>(String name)
+        implements Attribute<T> {
 }
 

--- a/api/src/main/java/jakarta/data/metamodel/impl/AttributeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/impl/AttributeRecord.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data.metamodel.impl;
+
+import jakarta.data.metamodel.Attribute;
+
+/**
+ * Record type implementing {@link jakarta.data.metamodel.TextAttribute}.
+ * This may be used to simplify implementation of the static metamodel.
+ *
+ * @param name the name of the attribute
+ */
+public record AttributeRecord(String name)
+        implements Attribute {
+}
+

--- a/api/src/main/java/jakarta/data/metamodel/impl/SortableAttributeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/impl/SortableAttributeRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/data/metamodel/impl/SortableAttributeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/impl/SortableAttributeRecord.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data.metamodel.impl;
+
+import jakarta.data.Sort;
+import jakarta.data.metamodel.SortableAttribute;
+
+/**
+ * Record type implementing {@link jakarta.data.metamodel.SortableAttribute}.
+ * This may be used to simplify implementation of the static metamodel.
+ *
+ * @param name the name of the attribute
+ */
+public record SortableAttributeRecord<T>(String name)
+        implements SortableAttribute<T> {
+    @Override
+    public Sort<T> asc() {
+        return Sort.asc(name);
+    }
+
+    @Override
+    public Sort<T> desc() {
+        return Sort.desc(name);
+    }
+}
+

--- a/api/src/main/java/jakarta/data/metamodel/impl/TextAttributeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/impl/TextAttributeRecord.java
@@ -1,0 +1,33 @@
+package jakarta.data.metamodel.impl;
+
+import jakarta.data.Sort;
+import jakarta.data.metamodel.TextAttribute;
+
+/**
+ * Record type implementing {@link jakarta.data.metamodel.TextAttribute}.
+ * This may be used to simplify implementation of the static metamodel.
+ *
+ * @param name the name of the attribute
+ */
+public record TextAttributeRecord<T>(String name)
+        implements TextAttribute<T> {
+    @Override
+    public Sort<T> asc() {
+        return Sort.asc(name);
+    }
+
+    @Override
+    public Sort<T> desc() {
+        return Sort.desc(name);
+    }
+
+    @Override
+    public Sort<T> ascIgnoreCase() {
+        return Sort.ascIgnoreCase(name);
+    }
+
+    @Override
+    public Sort<T> descIgnoreCase() {
+        return Sort.descIgnoreCase(name);
+    }
+}

--- a/api/src/main/java/jakarta/data/metamodel/impl/TextAttributeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/impl/TextAttributeRecord.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
 package jakarta.data.metamodel.impl;
 
 import jakarta.data.Sort;

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -907,6 +907,7 @@ import java.util.List;
 module jakarta.data {
     exports jakarta.data;
     exports jakarta.data.metamodel;
+    exports jakarta.data.metamodel.impl;
     exports jakarta.data.page;
     exports jakarta.data.repository;
     exports jakarta.data.exceptions;


### PR DESCRIPTION
Rather than requiring that every implementation of Jakarta Data supply implementations of the metamodel interfaces (which are almost certainly going to be mutually isomorphic), I think it would be _really_ convenient if the Jakarta Data jar came with these three extremely trivial record types built in.

This is especially useful for those of us who have impls based 100% on code generation, and would prefer to avoid introducing a runtime support module.

WDYT?