### PR TITLE
fix requirements in Javadoc for built-in lifecycle annotations

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Delete.java
+++ b/api/src/main/java/jakarta/data/repository/Delete.java
@@ -27,8 +27,8 @@ import java.lang.annotation.Target;
 /**
  * <p>Lifecycle annotation for repository methods which perform delete operations.</p>
  *
- * <p>The {@code Delete} annotation indicates that the annotated repository method deletes the state of one or more entities
- * from in the database. The annotated repository method usually has exactly one parameter whose type must be one of
+ * <p>The {@code Delete} annotation indicates that the annotated repository method deletes the state of one or more
+ * entities from in the database. The annotated repository method usually has exactly one parameter whose type is one of
  * the following:
  * </p>
  * <ul>
@@ -46,15 +46,18 @@ import java.lang.annotation.Target;
  *     void unpark(Car car);
  * }
  * </pre>
- * <p>Alternatively, the {@code Delete} annotation may be applied to a repository method with no parameters, indicating
- * that the annotated method deletes all instances of the primary entity type. In this case, the annotated method must
- * either be declared {@code void}, or return {@code int} or {@code long}.
- * </p>
  * <p>Deletes are performed by matching the unique identifier of the entity. If the entity is versioned, for example,
  * with {@code jakarta.persistence.Version}, the version is also checked for consistency. Attributes other than the
  * identifier and version do not need to match. If no entity with a matching identifier is found in the database, or
  * if the entity with a matching identifier does not have a matching version, the annotated method must raise
  * {@link jakarta.data.exceptions.OptimisticLockingFailureException}.
+ * </p>
+ * <p>Alternatively, the {@code Delete} annotation may be applied to a repository method with no parameters, indicating
+ * that the annotated method deletes all instances of the primary entity type. In this case, the annotated method must
+ * either be declared {@code void}, or return {@code int} or {@code long}.
+ * </p>
+ * <p> Application of the {@code Delete} annotation to a method with any other signature is not portable between Jakarta
+ * Data providers.
  * </p>
  * <p>If this annotation occurs alongside a different lifecycle annotation, the annotated repository method must raise
  * {@link UnsupportedOperationException} every time it is called. Alternatively, a Jakarta Data provider is permitted to

--- a/api/src/main/java/jakarta/data/repository/Delete.java
+++ b/api/src/main/java/jakarta/data/repository/Delete.java
@@ -25,27 +25,18 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * <p>Annotates a repository method to perform delete operations.</p>
+ * <p>Lifecycle annotation for repository methods which perform delete operations.</p>
  *
- * <p>The {@code Delete} annotation indicates that the annotated repository method requests one or more
- * entities to be removed from the database. To request deletion of specific entity instances, the annotated
- * repository method must have a single parameter whose type must be one of the following:
+ * <p>The {@code Delete} annotation indicates that the annotated repository method the state of one or more entities
+ * from in the database. The annotated repository method usually has exactly one parameter whose type must be one of
+ * the following:
  * </p>
  * <ul>
  *     <li>The entity to be deleted.</li>
  *     <li>An {@code Iterable} of entities to be deleted.</li>
  *     <li>An array of entities to be deleted.</li>
  * </ul>
- * <p>The {@code Delete} annotation can be used on a repository method that has no parameters
- * to request deletion of all entity instances of the primary entity type.</p>
- * <p>The return type of the annotated method must be {@code void}, {@code boolean}, {@code int}, {@code long},
- * or a corresponding primitive wrapper such as {@link Integer}.
- * A boolean return type indicates whether or not an entity was deleted from the database.
- * An {@code int} or {@code long} return type indicates how many entities were deleted from the database.
- * </p>
- * <p>Deletion of a given entity is performed by matching the entity's Id. If the entity is versioned (e.g.,
- * with {@code jakarta.persistence.Version}), the version is also checked for consistency during deletion.
- * Properties other than the Id and version do not need to match for deletion.
+ * <p>The annotated method must be declared {@code void}.
  * </p>
  * <p>For example, consider an interface representing a garage:</p>
  * <pre>
@@ -55,12 +46,19 @@ import java.lang.annotation.Target;
  *     void unpark(Car car);
  * }
  * </pre>
- * <p>If this annotation is combined with other operation annotations (e.g.,
- * {@code @Find}, {@code @Insert}, {@code @Query}, {@code @Update},
- * {@code @Save}), it will throw an {@link UnsupportedOperationException} as only one operation type can be specified.</p>
- * <p>If the unique identifier of a requested entity is not found in the database or its version does not match, and the return
- * type of the annotated method is {@code void} or {@code Void}, the method must
- * raise {@link jakarta.data.exceptions.OptimisticLockingFailureException}.
+ * <p>Alternatively, the {@code Delete} annotation may be applied to a repository method with no parameters, indicating
+ * that the annotated method deletes all instances of the primary entity type. In this case, the annotated method must
+ * either be declared {@code void}, or return {@code int} or {@code long}.
+ * </p>
+ * <p>Deletes are performed by matching the unique identifier of the entity. If the entity is versioned, for example,
+ * with {@code jakarta.persistence.Version}, the version is also checked for consistency. Attributes other than the
+ * identifier and version do not need to match. If no entity with a matching identifier is found in the database, or
+ * if the entity with a matching identifier does not have a matching version, the annotated method must raise
+ * {@link jakarta.data.exceptions.OptimisticLockingFailureException}.
+ * </p>
+ * <p>If this annotation occurs alongside a different lifecycle annotation, the annotated repository method must raise
+ * {@link UnsupportedOperationException} every time it is called. Alternatively, a Jakarta Data provider is permitted to
+ * reject such a method declaration at compile time.</p>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/jakarta/data/repository/Delete.java
+++ b/api/src/main/java/jakarta/data/repository/Delete.java
@@ -59,9 +59,10 @@ import java.lang.annotation.Target;
  * <p> Application of the {@code Delete} annotation to a method with any other signature is not portable between Jakarta
  * Data providers.
  * </p>
- * <p>If this annotation occurs alongside a different lifecycle annotation, the annotated repository method must raise
- * {@link UnsupportedOperationException} every time it is called. Alternatively, a Jakarta Data provider is permitted to
- * reject such a method declaration at compile time.</p>
+ * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Insert}, {@code @Update}, {@code @Delete}, and
+ * {@code @Save} are mutually-exclusive. A given method of a repository interface may have at most one {@code @Find}
+ * annotation, lifecycle annotation, or query annotation.
+ * </p
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/jakarta/data/repository/Delete.java
+++ b/api/src/main/java/jakarta/data/repository/Delete.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
 /**
  * <p>Lifecycle annotation for repository methods which perform delete operations.</p>
  *
- * <p>The {@code Delete} annotation indicates that the annotated repository method the state of one or more entities
+ * <p>The {@code Delete} annotation indicates that the annotated repository method deletes the state of one or more entities
  * from in the database. The annotated repository method usually has exactly one parameter whose type must be one of
  * the following:
  * </p>

--- a/api/src/main/java/jakarta/data/repository/Delete.java
+++ b/api/src/main/java/jakarta/data/repository/Delete.java
@@ -28,13 +28,12 @@ import java.lang.annotation.Target;
  * <p>Lifecycle annotation for repository methods which perform delete operations.</p>
  *
  * <p>The {@code Delete} annotation indicates that the annotated repository method deletes the state of one or more
- * entities from in the database. The annotated repository method usually has exactly one parameter whose type is one of
- * the following:
+ * entities from in the database. The annotated repository method usually has exactly one parameter whose type is
+ * either:
  * </p>
  * <ul>
- *     <li>The entity to be deleted.</li>
- *     <li>An {@code Iterable} of entities to be deleted.</li>
- *     <li>An array of entities to be deleted.</li>
+ *     <li>the class of the entity to be deleted, or</li>
+ *     <li>{@code Iterable<E>} where {@code E} is the class of the entities to be deleted.</li>
  * </ul>
  * <p>The annotated method must be declared {@code void}.
  * </p>

--- a/api/src/main/java/jakarta/data/repository/Delete.java
+++ b/api/src/main/java/jakarta/data/repository/Delete.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
  * <p>Lifecycle annotation for repository methods which perform delete operations.</p>
  *
  * <p>The {@code Delete} annotation indicates that the annotated repository method deletes the state of one or more
- * entities from in the database.
+ * entities from the database.
  * </p>
  * <p>A {@code Delete} method might accept an instance or instances of an entity class. In this case, the method must
  * have exactly one parameter whose type is either:

--- a/api/src/main/java/jakarta/data/repository/Delete.java
+++ b/api/src/main/java/jakarta/data/repository/Delete.java
@@ -28,14 +28,20 @@ import java.lang.annotation.Target;
  * <p>Lifecycle annotation for repository methods which perform delete operations.</p>
  *
  * <p>The {@code Delete} annotation indicates that the annotated repository method deletes the state of one or more
- * entities from in the database. The annotated repository method usually has exactly one parameter whose type is
- * either:
+ * entities from in the database.
+ * </p>
+ * <p>A {@code Delete} method might accept an instance or instances of an entity class. In this case, the method must
+ * have exactly one parameter whose type is either:
  * </p>
  * <ul>
  *     <li>the class of the entity to be deleted, or</li>
  *     <li>{@code Iterable<E>} where {@code E} is the class of the entities to be deleted.</li>
  * </ul>
  * <p>The annotated method must be declared {@code void}.
+ * </p>
+ * <p>All Jakarta Data providers are required to accept a {@code Delete} method which conforms to this signature.
+ * Application of the {@code Delete} annotation to a method with any other signature is not portable between Jakarta
+ * Data providers, excepting the specific case of a repository method with no parameters, as described below.
  * </p>
  * <p>For example, consider an interface representing a garage:</p>
  * <pre>
@@ -54,9 +60,6 @@ import java.lang.annotation.Target;
  * <p>Alternatively, the {@code Delete} annotation may be applied to a repository method with no parameters, indicating
  * that the annotated method deletes all instances of the primary entity type. In this case, the annotated method must
  * either be declared {@code void}, or return {@code int} or {@code long}.
- * </p>
- * <p> Application of the {@code Delete} annotation to a method with any other signature is not portable between Jakarta
- * Data providers.
  * </p>
  * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Insert}, {@code @Update}, {@code @Delete}, and
  * {@code @Save} are mutually-exclusive. A given method of a repository interface may have at most one {@code @Find}

--- a/api/src/main/java/jakarta/data/repository/Find.java
+++ b/api/src/main/java/jakarta/data/repository/Find.java
@@ -28,10 +28,10 @@ import java.lang.annotation.Target;
 /**
  * <p>Annotates a repository method that performs entity search operations as Parameter-based automatic query methods.</p>
  *
- * <p>The {@code Find} annotation indicates that the annotated repository method executes a query to retrieve entities based on specified parameters.
- * The method parameters must match the types and names of the corresponding fields of the entity being queried.
- * There is no specific naming convention for methods annotated with {@code @Find}; they may be named arbitrarily,
- * and their names do not carry any specific semantic meaning.
+ * <p>The {@code Find} annotation indicates that the annotated repository method executes a query to retrieve entities
+ * based on specified parameters. The method parameters must match the types and names of the corresponding fields of
+ * the entity being queried. There is no specific naming convention for methods annotated with {@code @Find}; they may
+ * be named arbitrarily, and their names do not carry any specific semantic meaning.
  * </p>
  * <p>For example, consider an interface representing a garage:</p>
  * <pre>
@@ -62,12 +62,12 @@ import java.lang.annotation.Target;
  *     <li>Array of the entity type</li>
  * </ul>
  *
- * <p>If the annotated method return type is a single instance (either through {@code Optional} or directly), but the query returns more than one element,
- * it will throw a {@link jakarta.data.exceptions.NonUniqueResultException}.</p>
- *
- * <p>If this annotation is combined with other operation annotations (e.g., {@code @Update}, {@code @Delete},
- *  {@code @Save}), it will result in an {@link UnsupportedOperationException} being thrown, as only one operation type can be specified.
- *  A Jakarta Data provider implementation must detect and report this error either at compile time or runtime.</p>
+ * <p>If the annotated method return type is a single instance (either through {@code Optional} or directly), but the
+ * query returns more than one element, it will throw a {@link jakarta.data.exceptions.NonUniqueResultException}.
+ * </p>
+ * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Insert}, {@code @Update}, {@code @Delete}, and
+ * {@code @Save} are mutually-exclusive. A given method of a repository interface may have at most one {@code @Find}
+ * annotation, lifecycle annotation, or query annotation.
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/jakarta/data/repository/Insert.java
+++ b/api/src/main/java/jakarta/data/repository/Insert.java
@@ -25,39 +25,23 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * <p>Annotates a repository method that inserts entities.</p>
+ * <p>Lifecycle annotation for repository methods which perform insert operations.</p>
  *
- * <p>The {@code Insert} annotation indicates that the annotated repository method requests that one or more entities
- * be inserted into the database. This method must have a single parameter whose type must be one of the following:
+ * <p>The {@code Insert} annotation indicates that the annotated repository method adds the state of one or more
+ * entities to the database. The annotated repository method must have exactly one parameter whose type must be one of
+ * the following:
  * </p>
  * <ul>
  *     <li>The entity to be inserted.</li>
  *     <li>An {@code Iterable} of entities to be inserted.</li>
  *     <li>An array of entities to be inserted.</li>
  * </ul>
- * <p>The return type of an annotated method that requires a single entity as the parameter must have a return type
- * that is {@code void}, {@code Void}, or the same type as the parameter.
- * The return type of an annotated method that accepts an {@code Iterable} or array of entities as the parameter must
- * have a return type that is {@code void}, {@code Void}, or an {@code Iterable} or array of the entity.
- * For example, if the method is annotated with {@code @Insert} and takes a parameter of type {@code Car car},
- * the return type can be {@code Car}.
- * Similarly, if the parameter is an {@code Iterable<Car>} or an array of {@code Car}, the return type can be
- * {@code Iterable<Car>}.
- * Entities that are returned by the annotated method must include all values that were
- * written to the database, including all automatically generated values and incremented values
- * that changed due to the insert. The position of entities within an {@code Iterable} or array return value
- * must correspond to the position of entities in the parameter based on the unique identifier of the entity.
+ * <p>The annotated method must either be declared {@code void}, or have a return type that is the same as the type of
+ * its parameter.
  * </p>
- * <p>After invoking this method, it is recommended not to use the entity value supplied as a parameter, as this method
- * makes no guarantees about the state of the entity value after insertion.
- * </p>
- * <p>If an entity of this type with the same unique identifier already exists in the database
- * and the databases performs ACID (atomic, consistent, isolated, durable) transactions,
- * then annotated method raises {@link jakarta.data.exceptions.EntityExistsException}.
- * In databases that follow the BASE model or use an append model to write data,
- * this exception is not thrown.
- * </p>
- * <p>For example, consider an interface representing a garage:</p>
+ * <p>For example, if the method is annotated with {@code @Insert} and takes a parameter of type {@code Car car}, the
+ * return type can be {@code Car}. Similarly, if the parameter is of type {@code Iterable<Car>}, the return type can be
+ * {@code Iterable<Car>}. Consider an interface representing a garage:</p>
  * <pre>
  * {@code @Repository}
  * interface Garage {
@@ -65,14 +49,21 @@ import java.lang.annotation.Target;
  *     Car park(Car car);
  * }
  * </pre>
- * <p>The {@code @Insert} annotation can be used to indicate that the {@code park(Car)} method is responsible for inserting
- * a {@code Car} entity into a database.
+ * <p>When the annotated method is non-{@code void}, it must return an inserted entity instance for each entity instance
+ * passed as an argument. Instances returned by the annotated method must include all values that were written to the
+ * database, including all automatically generated identifiers, initial versions, and other values which changed as a
+ * result of the insert. The order of entities within an {@code Iterable} or array return value must match the position
+ * of entities in the argument. After the annotated method returns, an original entity instance supplied as an argument
+ * might not accurately reflect the inserted state.
  * </p>
- *
- * <p>If this annotation is combined with other operation annotations (e.g., {@code @Update}, {@code @Delete},
- * {@code @Find}, {@code @Query}, {@code @Save}),
- * it will throw an {@link UnsupportedOperationException} because only one operation type can be specified.
- * A Jakarta Data provider implementation must detect (and report) this error at compile time or at runtime.</p>
+ * <p>If an entity of the given type, and with the same unique identifier already exists in the database with the
+ * annotated method is called, and if the databases uses ACID (atomic, consistent, isolated, durable) transactions,
+ * then annotated method must raises {@link jakarta.data.exceptions.EntityExistsException}.
+ * If the database follows the BASE model, or uses an append model to write data, this exception is not thrown.
+ * </p>
+ * <p>If this annotation occurs alongside a different lifecycle annotation, the annotated repository method must raise
+ * {@link UnsupportedOperationException} every time it is called. Alternatively, a Jakarta Data provider is permitted to
+ * reject such a method declaration at compile time.</p>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/jakarta/data/repository/Insert.java
+++ b/api/src/main/java/jakarta/data/repository/Insert.java
@@ -28,13 +28,11 @@ import java.lang.annotation.Target;
  * <p>Lifecycle annotation for repository methods which perform insert operations.</p>
  *
  * <p>The {@code Insert} annotation indicates that the annotated repository method adds the state of one or more
- * entities to the database. The annotated repository method usually has exactly one parameter whose type is one of
- * the following:
+ * entities to the database. The annotated repository method usually has exactly one parameter whose type is either:
  * </p>
  * <ul>
- *     <li>The entity to be inserted.</li>
- *     <li>An {@code Iterable} of entities to be inserted.</li>
- *     <li>An array of entities to be inserted.</li>
+ *     <li>the class of the entity to be inserted, or</li>
+ *     <li>{@code Iterable<E>} or {@code E[]} where {@code E} is the class of the entities to be inserted.</li>
  * </ul>
  * <p>The annotated method must either be declared {@code void}, or have a return type that is the same as the type of
  * its parameter.

--- a/api/src/main/java/jakarta/data/repository/Insert.java
+++ b/api/src/main/java/jakarta/data/repository/Insert.java
@@ -28,7 +28,10 @@ import java.lang.annotation.Target;
  * <p>Lifecycle annotation for repository methods which perform insert operations.</p>
  *
  * <p>The {@code Insert} annotation indicates that the annotated repository method adds the state of one or more
- * entities to the database. The annotated repository method must have exactly one parameter whose type is either:
+ * entities to the database.
+ * </p>
+ * <p>An {@code Insert} method accepts an instance or instances of an entity class. The method must have exactly one
+ * parameter whose type is either:
  * </p>
  * <ul>
  *     <li>the class of the entity to be inserted, or</li>
@@ -36,6 +39,10 @@ import java.lang.annotation.Target;
  * </ul>
  * <p>The annotated method must either be declared {@code void}, or have a return type that is the same as the type of
  * its parameter.
+ * </p>
+ * <p>All Jakarta Data providers are required to accept an {@code Insert} method which conforms to this signature.
+ * Application of the {@code Insert} annotation to a method with any other signature is not portable between Jakarta
+ * Data providers.
  * </p>
  * <p>For example, if the method is annotated with {@code @Insert} and takes a parameter of type {@code Car car}, the
  * return type can be {@code Car}. Similarly, if the parameter is of type {@code Iterable<Car>}, the return type can be
@@ -58,9 +65,6 @@ import java.lang.annotation.Target;
  * annotated method is called, and if the databases uses ACID (atomic, consistent, isolated, durable) transactions,
  * then annotated method must raises {@link jakarta.data.exceptions.EntityExistsException}.
  * If the database follows the BASE model, or uses an append model to write data, this exception is not thrown.
- * </p>
- * <p>Application of the {@code Insert} annotation to a method with any other signature is not portable between Jakarta
- * Data providers.
  * </p>
  * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Insert}, {@code @Update}, {@code @Delete}, and
  * {@code @Save} are mutually-exclusive. A given method of a repository interface may have at most one {@code @Find}

--- a/api/src/main/java/jakarta/data/repository/Insert.java
+++ b/api/src/main/java/jakarta/data/repository/Insert.java
@@ -64,9 +64,10 @@ import java.lang.annotation.Target;
  * <p>Application of the {@code Insert} annotation to a method with any other signature is not portable between Jakarta
  * Data providers.
  * </p>
- * <p>If this annotation occurs alongside a different lifecycle annotation, the annotated repository method must raise
- * {@link UnsupportedOperationException} every time it is called. Alternatively, a Jakarta Data provider is permitted to
- * reject such a method declaration at compile time.</p>
+ * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Insert}, {@code @Update}, {@code @Delete}, and
+ * {@code @Save} are mutually-exclusive. A given method of a repository interface may have at most one {@code @Find}
+ * annotation, lifecycle annotation, or query annotation.
+ * </p
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/jakarta/data/repository/Insert.java
+++ b/api/src/main/java/jakarta/data/repository/Insert.java
@@ -56,7 +56,7 @@ import java.lang.annotation.Target;
  * of entities in the argument. After the annotated method returns, an original entity instance supplied as an argument
  * might not accurately reflect the inserted state.
  * </p>
- * <p>If an entity of the given type, and with the same unique identifier already exists in the database with the
+ * <p>If an entity of the given type, and with the same unique identifier already exists in the database when the
  * annotated method is called, and if the databases uses ACID (atomic, consistent, isolated, durable) transactions,
  * then annotated method must raises {@link jakarta.data.exceptions.EntityExistsException}.
  * If the database follows the BASE model, or uses an append model to write data, this exception is not thrown.

--- a/api/src/main/java/jakarta/data/repository/Insert.java
+++ b/api/src/main/java/jakarta/data/repository/Insert.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
  * <p>Lifecycle annotation for repository methods which perform insert operations.</p>
  *
  * <p>The {@code Insert} annotation indicates that the annotated repository method adds the state of one or more
- * entities to the database. The annotated repository method must have exactly one parameter whose type must be one of
+ * entities to the database. The annotated repository method usually has exactly one parameter whose type is one of
  * the following:
  * </p>
  * <ul>
@@ -60,6 +60,9 @@ import java.lang.annotation.Target;
  * annotated method is called, and if the databases uses ACID (atomic, consistent, isolated, durable) transactions,
  * then annotated method must raises {@link jakarta.data.exceptions.EntityExistsException}.
  * If the database follows the BASE model, or uses an append model to write data, this exception is not thrown.
+ * </p>
+ * <p>Application of the {@code Insert} annotation to a method with any other signature is not portable between Jakarta
+ * Data providers.
  * </p>
  * <p>If this annotation occurs alongside a different lifecycle annotation, the annotated repository method must raise
  * {@link UnsupportedOperationException} every time it is called. Alternatively, a Jakarta Data provider is permitted to

--- a/api/src/main/java/jakarta/data/repository/Insert.java
+++ b/api/src/main/java/jakarta/data/repository/Insert.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
  * <p>Lifecycle annotation for repository methods which perform insert operations.</p>
  *
  * <p>The {@code Insert} annotation indicates that the annotated repository method adds the state of one or more
- * entities to the database. The annotated repository method usually has exactly one parameter whose type is either:
+ * entities to the database. The annotated repository method must have exactly one parameter whose type is either:
  * </p>
  * <ul>
  *     <li>the class of the entity to be inserted, or</li>

--- a/api/src/main/java/jakarta/data/repository/Insert.java
+++ b/api/src/main/java/jakarta/data/repository/Insert.java
@@ -63,7 +63,7 @@ import java.lang.annotation.Target;
  * </p>
  * <p>If an entity of the given type, and with the same unique identifier already exists in the database when the
  * annotated method is called, and if the databases uses ACID (atomic, consistent, isolated, durable) transactions,
- * then annotated method must raises {@link jakarta.data.exceptions.EntityExistsException}.
+ * then the annotated method must raise {@link jakarta.data.exceptions.EntityExistsException}.
  * If the database follows the BASE model, or uses an append model to write data, this exception is not thrown.
  * </p>
  * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Insert}, {@code @Update}, {@code @Delete}, and

--- a/api/src/main/java/jakarta/data/repository/Query.java
+++ b/api/src/main/java/jakarta/data/repository/Query.java
@@ -82,6 +82,10 @@ import java.lang.annotation.Target;
  * <pre>
  * {@code Page<String>} page2 = people.namesOfLength(5, 10, page1.nextPageRequest(Person.class));
  * </pre>
+ *
+ * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Insert}, {@code @Update}, {@code @Delete}, and
+ * {@code @Save} are mutually-exclusive. A given method of a repository interface may have at most one {@code @Find}
+ * annotation, lifecycle annotation, or query annotation.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/api/src/main/java/jakarta/data/repository/Save.java
+++ b/api/src/main/java/jakarta/data/repository/Save.java
@@ -28,8 +28,10 @@ import java.lang.annotation.Target;
  * <p>Lifecycle annotation for repository methods which conditionally perform insert or update operations.</p>
  *
  * <p>The {@code Save} annotation indicates that the annotated repository method accepts one or more entities and, for
- * each entity, either adds its state to the database, or updates state already held in the database. The annotated
- * repository method must have exactly one parameter whose type is either:
+ * each entity, either adds its state to the database, or updates state already held in the database.
+ * </p>
+ * <p>A {@code Save} method accepts an instance or instances of an entity class. The method must have exactly one
+ * parameter whose type is either:
  * </p>
  * <ul>
  *     <li>the class of the entity to be inserted or updated, or</li>
@@ -37,6 +39,10 @@ import java.lang.annotation.Target;
  * </ul>
  * <p>The annotated method must either be declared {@code void}, or have a return type that is the same as the type of
  * its parameter.
+ * </p>
+ * <p>All Jakarta Data providers are required to accept a {@code Save} method which conforms to this signature.
+ * Application of the {@code Save} annotation to a method with any other signature is not portable between Jakarta Data
+ * providers.
  * </p>
  * <p>For example, consider an interface representing a garage:</p>
  * <pre>

--- a/api/src/main/java/jakarta/data/repository/Save.java
+++ b/api/src/main/java/jakarta/data/repository/Save.java
@@ -29,12 +29,11 @@ import java.lang.annotation.Target;
  *
  * <p>The {@code Save} annotation indicates that the annotated repository method accepts one or more entities and, for
  * each entity, either adds its state to the database, or updates state already held in the database. The annotated
- * repository method must have exactly one parameter whose type must be one of the following:
+ * repository method must have exactly one parameter whose type is either:
  * </p>
  * <ul>
- *     <li>The entity to be saved.</li>
- *     <li>An {@code Iterable} of entities to be saved.</li>
- *     <li>An array of entities to be saved.</li>
+ *     <li>the class of the entity to be inserted or updated, or</li>
+ *     <li>{@code Iterable<E>} or {@code E[]} where {@code E} is the class of the entities to be inserted or updated.</li>
  * </ul>
  * <p>The annotated method must either be declared {@code void}, or have a return type that is the same as the type of
  * its parameter.
@@ -56,9 +55,10 @@ import java.lang.annotation.Target;
  * <li>Otherwise, if there is no such entity in the database, the annotated method must behave as if it were annotated
  *     {@link Insert @Insert}.
  * </ul>
- * <p>If this annotation occurs alongside a different lifecycle annotation, the annotated repository method must raise
- * {@link UnsupportedOperationException} every time it is called. Alternatively, a Jakarta Data provider is permitted to
- * reject such a method declaration at compile time.</p>
+ * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Insert}, {@code @Update}, {@code @Delete}, and
+ * {@code @Save} are mutually-exclusive. A given method of a repository interface may have at most one {@code @Find}
+ * annotation, lifecycle annotation, or query annotation.
+ * </p
  *
  * @see Insert
  * @see Update

--- a/api/src/main/java/jakarta/data/repository/Save.java
+++ b/api/src/main/java/jakarta/data/repository/Save.java
@@ -25,35 +25,20 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * <p>Annotates a repository method that updates entities if found in the database
- * and inserts entities into the database that are not found.
- * This method must have a single parameter whose type must be one of the following:
+ * <p>Lifecycle annotation for repository methods which conditionally perform insert or update operations.</p>
+ *
+ * <p>The {@code Save} annotation indicates that the annotated repository method accepts one or more entities and, for
+ * each entity, either adds its state to the database, or updates state already held in the database. The annotated
+ * repository method must have exactly one parameter whose type must be one of the following:
  * </p>
  * <ul>
  *     <li>The entity to be saved.</li>
  *     <li>An {@code Iterable} of entities to be saved.</li>
  *     <li>An array of entities to be saved.</li>
  * </ul>
- * <p>The return type of an annotated method that requires a single entity as the parameter
- * must have a return type that is {@code void}, {@code Void}, or the same type as the parameter.
- * The return type of an annotated method that accepts an {@code Iterable} or array of entities
-  * as the parameter must have a return type that is {@code void}, {@code Void},
-  * or an {@code Iterable} or array of the entity.
+ * <p>The annotated method must either be declared {@code void}, or have a return type that is the same as the type of
+ * its parameter.
  * </p>
- * <p>Saving an entity involves persisting it in the database. If the entity has an ID or key that already exists
- * in the database, the method will update the existing record. If the entity does not exist in the database or has a
- * null ID, this method will insert a new record. The entity instance returned by this method will be updated with
- * any automatically generated or incremented values that changed due to the save operation.
- * </p>
- * <p>Entities that are returned by the annotated method must include all values that were
- * written to the database, including all automatically generated values and incremented values
- * that changed due to the save. The position of entities within an {@code Iterable} or array return value
- * must correspond to the position of entities in the parameter based on the unique identifier of the entity.</p>
- * <p>After invoking this method, avoid using the entity value that was supplied as a parameter, because it might not accurately
- * reflect the changes made during the save process. If the entity uses optimistic locking and its version differs from
- * the version in the database, an {@link jakarta.data.exceptions.OptimisticLockingFailureException} will be thrown.
- * </p>
- *
  * <p>For example, consider an interface representing a garage:</p>
  * <pre>
  * {@code @Repository}
@@ -62,16 +47,21 @@ import java.lang.annotation.Target;
  *     Car park(Car car);
  * }
  * </pre>
- * <p>The {@code @Save} annotation can be used to indicate that the {@code park(Car)} method is responsible
- * for updating the entity in the database if it already exists there and otherwise inserting
- * a car entity into a database.
+ * <p>The operation performed by the annotated method depends on whether the database already holds an entity with the
+ * unique identifier of an entity passed as an argument:
  * </p>
+ * <ul>
+ * <li>If there is such an entity already held in the database, the annotated method must behave as if it were annotated
+ *     {@link Update @Update}.
+ * <li>Otherwise, if there is no such entity in the database, the annotated method must behave as if it were annotated
+ *     {@link Insert @Insert}.
+ * </ul>
+ * <p>If this annotation occurs alongside a different lifecycle annotation, the annotated repository method must raise
+ * {@link UnsupportedOperationException} every time it is called. Alternatively, a Jakarta Data provider is permitted to
+ * reject such a method declaration at compile time.</p>
  *
- * <p>If this annotation is combined with other operation annotations (e.g., {@code @Update}, {@code @Delete},
- * {@code @Find}, {@code @Insert}, {@code @Query}),
- * it will throw an {@link UnsupportedOperationException} because only one operation type can be specified.
- * A Jakarta Data provider implementation must detect (and report) this error at compile time or at runtime.</p>
- * @see jakarta.data.exceptions.OptimisticLockingFailureException
+ * @see Insert
+ * @see Update
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/jakarta/data/repository/Update.java
+++ b/api/src/main/java/jakarta/data/repository/Update.java
@@ -29,12 +29,11 @@ import java.lang.annotation.Target;
  *
  * <p>The {@code Update} annotation indicates that the annotated repository method updates the state of one or more
  * entities already held in the database. The annotated repository method usually has exactly one parameter whose type
- * is one of the following:
+ * is either:
  * </p>
  * <ul>
- *     <li>The entity to be updated.</li>
- *     <li>An {@code Iterable} of entities to be updated.</li>
- *     <li>An array of entities to be updated.</li>
+ *     <li>the class of the entity to be updated, or</li>
+ *     <li>{@code Iterable<E>} or {@code E[]} where {@code E} is the class of the entities to be updated.</li>
  * </ul>
  * <p>The annotated method must either be declared {@code void}, or have a return type that is the same as the type of
  * its parameter.

--- a/api/src/main/java/jakarta/data/repository/Update.java
+++ b/api/src/main/java/jakarta/data/repository/Update.java
@@ -24,51 +24,21 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-
 /**
- * <p>Annotates a repository method to perform update operations.</p>
+ * <p>Lifecycle annotation for repository methods which perform update operations.</p>
  *
- * <p>The {@code Update} annotation indicates that the annotated repository method requests that one or more entities
- * be updated if found in the database. To request updates to specific entity instances, the annotated
- * repository method must have a single parameter whose type must be one of the following:
+ * <p>The {@code Update} annotation indicates that the annotated repository method updates the state of one or more
+ * entities already held in the database. The annotated repository method must have a exactly one parameter whose type
+ * must be one of the following:
  * </p>
  * <ul>
  *     <li>The entity to be updated.</li>
  *     <li>An {@code Iterable} of entities to be updated.</li>
  *     <li>An array of entities to be updated.</li>
  * </ul>
- * <p>The return type of the annotated method must be {@code void}, {@code boolean}, {@code int}, {@code long}
- * a corresponding primitive wrapper type such as {@link Integer}, or the same type as the parameter.
+ * <p>The annotated method must either be declared {@code void}, or have a return type that is the same as the type of
+ * its parameter.
  * </p>
- * <p>
- * A boolean return type indicates whether a matching entity was found in the database to update.
- * An {@code int} or {@code long} return type indicates how many matching entities were found in the database to update.
- * An entity return type indicates the updated entity if found in the database. If the entity is not found
- * in the database or has a non-matching version, then {@code null} is returned.
- * An {@code Iterable} or array return type includes all matching entities that are found in the database,
- * skipping over entities that are not present in the database or have a non-matching version.
- * For example, if the method is annotated with {@code @Update} and takes a parameter of type {@code Car car},
- * the return type can be {@code Car}.
- * Similarly, if the parameter is an {@code Iterable<Car>} or an array of {@code Car}, the return type can be
- * {@code Iterable<Car>}.
- * Entities that are returned by the annotated method must include all values that were
- * written to the database, including all automatically generated values, updated versions and incremented values
- * that changed due to the update. The order of entities within an {@code Iterable} or array return value
- * must correspond to the position of entities in the parameter based on the unique identifier of the entity,
- * leaving out those that did not match the unique identifier and version that is in the database.
- * </p>
- * <p>Updating an entity involves modifying its existing data in the database. The method will search for the entity
- * in the database using its ID (and version, if versioned) and then update the corresponding record with the new data. After invoking
- * this method, do not continue to use the entity value that is supplied as a parameter, as it may not accurately
- * reflect the changes made during the update process.
- * </p>
- * <p>If the entity does not exist in the database or it is versioned and its version differs from the version in the database,
- * no update is made and no error is raised.
- * </p>
- *<p>
- * In databases that use an append model to write data or follow the BASE model, this method
- * behaves the same as the {@code @Insert} method.
- *  </p>
  * <p>For example, consider an interface representing a garage:</p>
  * <pre>
  * {@code @Repository}
@@ -77,10 +47,26 @@ import java.lang.annotation.Target;
  *     Car update(Car car);
  * }
  * </pre>
- * <p>If this annotation is combined with other operation annotations (e.g., {@code @Insert}, {@code @Delete},
- * {@code @Find}, {@code @Query},
- * {@code @Save}), it will throw an {@link UnsupportedOperationException} because only one operation type can be specified.
- * A Jakarta Data provider implementation must detect (and report) this error at compile time or at runtime.</p>
+ * <p>When the annotated method is non-{@code void}, it must return an updated entity instance for each entity instance
+ * passed as an argument. Instances returned by the annotated method must include all values that were written to the
+ * database, including all automatically generated values, updated versions, and incremented values which changed as a
+ * result of the update. The order of entities within an {@code Iterable} or array return value must match the position
+ * of entities in the argument, based on the unique identifier of the entity. After the annotated method returns, an
+ * original entity instance supplied as an argument might not accurately reflect the updated state.
+ * </p>
+ * <p>Updates are performed by matching the unique identifier of the entity. If the entity is versioned, for example,
+ * with {@code jakarta.persistence.Version}, the version is also checked for consistency. Attributes other than the
+ * identifier and version do not need to match. If no entity with a matching identifier is found in the database, or
+ * if the entity with a matching identifier does not have a matching version, the annotated method must raise
+ * {@link jakarta.data.exceptions.OptimisticLockingFailureException}.
+ * </p>
+ * <p>
+ * If the database follows the BASE model, or uses an append model to write data, the annotated method behaves the same
+ * as the {@code @Insert} method.
+ * </p>
+ * <p>If this annotation occurs alongside a different lifecycle annotation, the annotated repository method must raise
+ * {@link UnsupportedOperationException} every time it is called. Alternatively, a Jakarta Data provider is permitted to
+ * reject such a method declaration at compile time.</p>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/jakarta/data/repository/Update.java
+++ b/api/src/main/java/jakarta/data/repository/Update.java
@@ -67,9 +67,10 @@ import java.lang.annotation.Target;
  * <p>Application of the {@code Update} annotation to a method with any other signature is not portable between Jakarta
  * Data providers.
  * </p>
- * <p>If this annotation occurs alongside a different lifecycle annotation, the annotated repository method must raise
- * {@link UnsupportedOperationException} every time it is called. Alternatively, a Jakarta Data provider is permitted to
- * reject such a method declaration at compile time.</p>
+ * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Insert}, {@code @Update}, {@code @Delete}, and
+ * {@code @Save} are mutually-exclusive. A given method of a repository interface may have at most one {@code @Find}
+ * annotation, lifecycle annotation, or query annotation.
+ * </p
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/jakarta/data/repository/Update.java
+++ b/api/src/main/java/jakarta/data/repository/Update.java
@@ -28,8 +28,8 @@ import java.lang.annotation.Target;
  * <p>Lifecycle annotation for repository methods which perform update operations.</p>
  *
  * <p>The {@code Update} annotation indicates that the annotated repository method updates the state of one or more
- * entities already held in the database. The annotated repository method must have a exactly one parameter whose type
- * must be one of the following:
+ * entities already held in the database. The annotated repository method usually has exactly one parameter whose type
+ * is one of the following:
  * </p>
  * <ul>
  *     <li>The entity to be updated.</li>
@@ -63,6 +63,9 @@ import java.lang.annotation.Target;
  * <p>
  * If the database follows the BASE model, or uses an append model to write data, the annotated method behaves the same
  * as the {@code @Insert} method.
+ * </p>
+ * <p>Application of the {@code Update} annotation to a method with any other signature is not portable between Jakarta
+ * Data providers.
  * </p>
  * <p>If this annotation occurs alongside a different lifecycle annotation, the annotated repository method must raise
  * {@link UnsupportedOperationException} every time it is called. Alternatively, a Jakarta Data provider is permitted to

--- a/api/src/main/java/jakarta/data/repository/Update.java
+++ b/api/src/main/java/jakarta/data/repository/Update.java
@@ -28,8 +28,10 @@ import java.lang.annotation.Target;
  * <p>Lifecycle annotation for repository methods which perform update operations.</p>
  *
  * <p>The {@code Update} annotation indicates that the annotated repository method updates the state of one or more
- * entities already held in the database. The annotated repository method usually has exactly one parameter whose type
- * is either:
+ * entities already held in the database.
+ * </p>
+ * <p>An {@code Update} method might accept an instance or instances of an entity class. In this case, the method must
+ * have exactly one parameter whose type is either:
  * </p>
  * <ul>
  *     <li>the class of the entity to be updated, or</li>
@@ -37,6 +39,11 @@ import java.lang.annotation.Target;
  * </ul>
  * <p>The annotated method must either be declared {@code void}, or have a return type that is the same as the type of
  * its parameter.
+ * <p>
+ * All Jakarta Data providers are required to accept an {@code Update} method which conforms to this signature.
+ * Application of the {@code Update} annotation to a method with any other signature is not portable between Jakarta
+ * Data providers.
+ * </p>
  * </p>
  * <p>For example, consider an interface representing a garage:</p>
  * <pre>
@@ -62,9 +69,6 @@ import java.lang.annotation.Target;
  * <p>
  * If the database follows the BASE model, or uses an append model to write data, the annotated method behaves the same
  * as the {@code @Insert} method.
- * </p>
- * <p>Application of the {@code Update} annotation to a method with any other signature is not portable between Jakarta
- * Data providers.
  * </p>
  * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Insert}, {@code @Update}, {@code @Delete}, and
  * {@code @Save} are mutually-exclusive. A given method of a repository interface may have at most one {@code @Find}

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -737,10 +737,6 @@ Book mergeBook(Book book);
 Such lifecycle methods are not portable between Jakarta Data providers.
 ====
 
-A given method of a repository interface may have at most one lifecycle annotation. If a method of a repository interface has more than one lifecycle annotation, the annotated repository method must raise
- `UnsupportedOperationException` every time it is called. Alternatively, a Jakarta Data provider is permitted to
- reject such a method declaration at compile time.
-
 === Annotated Query methods
 
 An _annotated query method_ is an abstract method annotated by a _query annotation_ type.
@@ -867,6 +863,19 @@ default void cleanup() {
 ----
 
 A repository may have at most one resource accessor method.
+
+=== Conflicting Repository Method Annotations
+
+Annotations like `@Find`, `@Query`, `@Insert`, `@Update`, `@Delete`, and `@Save` are mutually-exclusive. A given method of a repository interface may have at most one:
+
+- `@Find` annotation,
+- lifecycle annotation, or
+- query annotation.
+
+If a method of a repository interface has more than one such annotation, the annotated repository method must raise
+`UnsupportedOperationException` every time it is called. Alternatively, a Jakarta Data provider is permitted to
+reject such a method declaration at compile time.
+
 
 === Query by Method Name
 

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -737,6 +737,10 @@ Book mergeBook(Book book);
 Such lifecycle methods are not portable between Jakarta Data providers.
 ====
 
+A given method of a repository interface may have at most one lifecycle annotation. If a method of a repository interface has more than one lifecycle annotation, the annotated repository method must raise
+ `UnsupportedOperationException` every time it is called. Alternatively, a Jakarta Data provider is permitted to
+ reject such a method declaration at compile time.
+
 === Annotated Query methods
 
 An _annotated query method_ is an abstract method annotated by a _query annotation_ type.


### PR DESCRIPTION
See #488.

This pull request absolutely _does_ change semantics, eliminating:

- dangerous "quiet failure" which can easily lead to data corruption in the case of minor errors of program logic
- the previous "explosion" of acceptable method signatures which makes Jakarta Data more difficult to implement, while offering little additional flexibility to users
- nails down the treatment of optimistic lock acquisition failures

These changes make Jakarta Data significantly easier to implement, and lead users down a path where they are much less likely to accidentally write broken code.