### PR TITLE
Remove BasicRepository.countBy

### DIFF
--- a/api/src/main/java/jakarta/data/repository/BasicRepository.java
+++ b/api/src/main/java/jakarta/data/repository/BasicRepository.java
@@ -190,14 +190,6 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
     Stream<T> findByIdIn(Iterable<K> ids);
 
     /**
-     * Retrieves the total number of persistent entities of the specified type in the database.
-     *
-     * @return the total number of entities.
-     * @throws UnsupportedOperationException for Key-Value and Wide-Column databases that are not capable of the {@code count} operation.
-     */
-    long countBy();
-
-    /**
      * Deletes the entity with the given Id.
      * <p>
      * If the entity is not found in the persistence store it is silently ignored.

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers.java
@@ -36,6 +36,8 @@ import ee.jakarta.tck.data.framework.read.only.NaturalNumber.NumberType;
 @Repository
 public interface NaturalNumbers extends BasicRepository<NaturalNumber, Long>, IdOperations<NaturalNumber> {
 
+    long countBy();
+
     KeysetAwareSlice<NaturalNumber> findByFloorOfSquareRootOrderByIdAsc(long sqrtFloor,
                                                                         PageRequest<NaturalNumber> pagination);
 

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -194,9 +194,6 @@ public class EntityTests {
         // BasicRepository.existsById
         assertEquals(true, boxes.existsById("TestBasicRepositoryMethods-04"));
 
-        // BasicRepository.count
-        assertEquals(4, boxes.countBy());
-
         // BasicRepository.save
         box2.length = 21;
         box2.width = 20;
@@ -220,7 +217,7 @@ public class EntityTests {
         TestPropertyUtility.waitForEventualConsistency();
 
         assertEquals(false, boxes.existsById("TestBasicRepositoryMethods-01"));
-        assertEquals(3, boxes.countBy());
+        assertEquals(3, boxes.findAll().count());
 
         // BasicRepository.findByIdIn
         Stream<Box> stream = boxes.findByIdIn(List.of("TestBasicRepositoryMethods-04", "TestBasicRepositoryMethods-05"));
@@ -274,7 +271,7 @@ public class EntityTests {
         boxes.deleteByIdIn(List.of("TestBasicRepositoryMethods-05"));
         TestPropertyUtility.waitForEventualConsistency();
 
-        assertEquals(0, boxes.countBy());
+        assertEquals(0, boxes.findAll().count());
     }
 
     @Assertion(id = "133", strategy = "Use a repository that inherits from BasicRepository and defines no additional methods of its own. Use all of the built-in methods.")
@@ -325,9 +322,6 @@ public class EntityTests {
         // BasicRepository.existsById
         assertEquals(true, boxes.existsById("TestBasicRepositoryMethods-04"));
 
-        // BasicRepository.count
-        assertEquals(4, boxes.countBy());
-
         // BasicRepository.save
         box2.length = 21;
         box2.width = 20;
@@ -351,7 +345,7 @@ public class EntityTests {
         TestPropertyUtility.waitForEventualConsistency();
 
         assertEquals(false, boxes.existsById("TestBasicRepositoryMethods-01"));
-        assertEquals(3, boxes.countBy());
+        assertEquals(3, boxes.findAll().count());
 
         // BasicRepository.findByIdIn
         Stream<Box> stream = boxes.findByIdIn(List.of("TestBasicRepositoryMethods-04", "TestBasicRepositoryMethods-05"));
@@ -406,7 +400,7 @@ public class EntityTests {
 
         TestPropertyUtility.waitForEventualConsistency();
 
-        assertEquals(0, boxes.countBy());
+        assertEquals(0, boxes.findAll().count());
     }
 
     @Assertion(id = "133", strategy = "Request a Page higher than the final Page, expecting an empty Page with 0 results.")

--- a/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/jakarta.data.sig_17
+++ b/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/jakarta.data.sig_17
@@ -217,7 +217,6 @@ meth public abstract java.util.Optional<{jakarta.data.repository.BasicRepository
 meth public abstract java.util.stream.Stream<{jakarta.data.repository.BasicRepository%0}> findAll()
  anno 0 jakarta.data.repository.Find()
 meth public abstract java.util.stream.Stream<{jakarta.data.repository.BasicRepository%0}> findByIdIn(java.lang.Iterable<{jakarta.data.repository.BasicRepository%1}>)
-meth public abstract long countBy()
 meth public abstract void delete({jakarta.data.repository.BasicRepository%0})
  anno 0 jakarta.data.repository.Delete()
 meth public abstract void deleteAll(java.lang.Iterable<? extends {jakarta.data.repository.BasicRepository%0}>)

--- a/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/jakarta.data.sig_21
+++ b/tck/src/main/resources/ee/jakarta/tck/data/framework/signature/jakarta.data.sig_21
@@ -217,7 +217,6 @@ meth public abstract java.util.Optional<{jakarta.data.repository.BasicRepository
 meth public abstract java.util.stream.Stream<{jakarta.data.repository.BasicRepository%0}> findAll()
  anno 0 jakarta.data.repository.Find()
 meth public abstract java.util.stream.Stream<{jakarta.data.repository.BasicRepository%0}> findByIdIn(java.lang.Iterable<{jakarta.data.repository.BasicRepository%1}>)
-meth public abstract long countBy()
 meth public abstract void delete({jakarta.data.repository.BasicRepository%0})
  anno 0 jakarta.data.repository.Delete()
 meth public abstract void deleteAll(java.lang.Iterable<? extends {jakarta.data.repository.BasicRepository%0}>)


### PR DESCRIPTION
This pull removes the awkward BasicRepository.countBy method as discussed here, and updates the TCK,

              > That brings up another, even simpler option. Just remove `countBy()` and don't replace it in version 1.0.

That would be great.

_Originally posted by @gavinking in https://github.com/jakartaee/data/issues/458#issuecomment-1964836766_
            