### PR TITLE
Attribute is missing type

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/Attribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/Attribute.java
@@ -21,8 +21,10 @@ import jakarta.data.Sort;
 
 /**
  * Represents an entity attribute in the {@link StaticMetamodel}.
+ *
+ * @param <T> entity class of the static metamodel.
  */
-public interface Attribute {
+public interface Attribute<T> {
     /**
      * Obtain the entity attribute name, suitable for use wherever the specification requires
      * an entity attribute name. For example, as the parameter to {@link Sort#asc(String)}.

--- a/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java
@@ -33,7 +33,7 @@ import jakarta.data.Sort;
  *
  * @param <T> entity class of the static metamodel.
  */
-public interface SortableAttribute<T> extends Attribute {
+public interface SortableAttribute<T> extends Attribute<T> {
 
     /**
      * Obtain a request for an ascending {@link Sort} based on the entity attribute.

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/_AsciiChar.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/_AsciiChar.java
@@ -32,7 +32,7 @@ public class _AsciiChar {
 
     public static volatile SortableAttribute<AsciiCharacter> id;
     public static volatile TextAttribute<AsciiCharacter> hexadecimal;
-    public static volatile Attribute isControl; // user decided it didn't care about sorting for this one
+    public static volatile Attribute<AsciiCharacter> isControl; // user decided it didn't care about sorting for this one
     public static volatile SortableAttribute<AsciiCharacter> numericValue;
     public static volatile TextAttribute<AsciiCharacter> thisCharacter;
 


### PR DESCRIPTION
It looks like I left off the the type parameter on `Attribute` like we have on `SortableAttribute`.  Although we currently got away with this because it doesn't create any `Sort<T>` instances, it is inconsistent and will be broken when the metamodel returns other typed things, such as if we want to enforce sending in only comparisons on a specific entity. 