### PR TITLE
Fix tck and javadoc errors and mistake with future compatibilty

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Delete.java
+++ b/api/src/main/java/jakarta/data/repository/Delete.java
@@ -64,7 +64,7 @@ import java.lang.annotation.Target;
  * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Insert}, {@code @Update}, {@code @Delete}, and
  * {@code @Save} are mutually-exclusive. A given method of a repository interface may have at most one {@code @Find}
  * annotation, lifecycle annotation, or query annotation.
- * </p
+ * </p>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/jakarta/data/repository/Delete.java
+++ b/api/src/main/java/jakarta/data/repository/Delete.java
@@ -28,8 +28,9 @@ import java.lang.annotation.Target;
  * <p>Lifecycle annotation for repository methods which perform delete operations.</p>
  *
  * <p>The {@code Delete} annotation indicates that the annotated repository method deletes the state of one or more
- * entities from the database.
+ * entities from the database. The method must follow one of the following patterns.
  * </p>
+ * <h2>Parameter for Entity Instances</h2>
  * <p>A {@code Delete} method might accept an instance or instances of an entity class. In this case, the method must
  * have exactly one parameter whose type is either:
  * </p>
@@ -40,8 +41,6 @@ import java.lang.annotation.Target;
  * <p>The annotated method must be declared {@code void}.
  * </p>
  * <p>All Jakarta Data providers are required to accept a {@code Delete} method which conforms to this signature.
- * Application of the {@code Delete} annotation to a method with any other signature is not portable between Jakarta
- * Data providers, excepting the specific case of a repository method with no parameters, as described below.
  * </p>
  * <p>For example, consider an interface representing a garage:</p>
  * <pre>
@@ -57,6 +56,7 @@ import java.lang.annotation.Target;
  * if the entity with a matching identifier does not have a matching version, the annotated method must raise
  * {@link jakarta.data.exceptions.OptimisticLockingFailureException}.
  * </p>
+ * <h2>Without Parameters</h2>
  * <p>Alternatively, the {@code Delete} annotation may be applied to a repository method with no parameters, indicating
  * that the annotated method deletes all instances of the primary entity type. In this case, the annotated method must
  * either be declared {@code void}, or return {@code int} or {@code long}.

--- a/api/src/main/java/jakarta/data/repository/Insert.java
+++ b/api/src/main/java/jakarta/data/repository/Insert.java
@@ -69,7 +69,7 @@ import java.lang.annotation.Target;
  * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Insert}, {@code @Update}, {@code @Delete}, and
  * {@code @Save} are mutually-exclusive. A given method of a repository interface may have at most one {@code @Find}
  * annotation, lifecycle annotation, or query annotation.
- * </p
+ * </p>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/jakarta/data/repository/Save.java
+++ b/api/src/main/java/jakarta/data/repository/Save.java
@@ -64,7 +64,7 @@ import java.lang.annotation.Target;
  * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Insert}, {@code @Update}, {@code @Delete}, and
  * {@code @Save} are mutually-exclusive. A given method of a repository interface may have at most one {@code @Find}
  * annotation, lifecycle annotation, or query annotation.
- * </p
+ * </p>
  *
  * @see Insert
  * @see Update

--- a/api/src/main/java/jakarta/data/repository/Update.java
+++ b/api/src/main/java/jakarta/data/repository/Update.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  * <p>The {@code Update} annotation indicates that the annotated repository method updates the state of one or more
  * entities already held in the database.
  * </p>
- * <p>An {@code Update} method might accept an instance or instances of an entity class. In this case, the method must
+ * <p>An {@code Update} method accepts an instance or instances of an entity class. The method must
  * have exactly one parameter whose type is either:
  * </p>
  * <ul>
@@ -41,8 +41,6 @@ import java.lang.annotation.Target;
  * its parameter.
  * <p>
  * All Jakarta Data providers are required to accept an {@code Update} method which conforms to this signature.
- * Application of the {@code Update} annotation to a method with any other signature is not portable between Jakarta
- * Data providers.
  * </p>
  * <p>For example, consider an interface representing a garage:</p>
  * <pre>

--- a/api/src/main/java/jakarta/data/repository/Update.java
+++ b/api/src/main/java/jakarta/data/repository/Update.java
@@ -44,7 +44,6 @@ import java.lang.annotation.Target;
  * Application of the {@code Update} annotation to a method with any other signature is not portable between Jakarta
  * Data providers.
  * </p>
- * </p>
  * <p>For example, consider an interface representing a garage:</p>
  * <pre>
  * {@code @Repository}
@@ -73,7 +72,7 @@ import java.lang.annotation.Target;
  * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Insert}, {@code @Update}, {@code @Delete}, and
  * {@code @Save} are mutually-exclusive. A given method of a repository interface may have at most one {@code @Find}
  * annotation, lifecycle annotation, or query annotation.
- * </p
+ * </p>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/Catalog.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/Catalog.java
@@ -18,12 +18,14 @@ package ee.jakarta.tck.data.standalone.persistence;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import jakarta.data.Order;
 import jakarta.data.Streamable;
 import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Delete;
+import jakarta.data.repository.Find;
 import jakarta.data.repository.Insert;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Param;
@@ -43,6 +45,9 @@ public interface Catalog extends DataRepository<Product, String> {
 
     @Insert
     Product[] addMultiple(Product... products);
+
+    @Find
+    Optional<Product> get(String productNum);
 
     @Update
     Product modify(Product product);


### PR DESCRIPTION
[first commit] The TCK needs to line up with the API change where Delete methods cannot return boolean.

[second commit] Also, this fixes some minor JavaDoc errors in that area that were preventing the project from building.

[third commit] Also, I realize that I got things backwards in trying to arrange for future compatibility. The way to give ourselves the flexibility of additional usage patterns of Delete/Update in the future is to disallow other usage now. Then we will not be making a breaking change when we expand it to include the additional pattern. I added updates to get rid of a few of the statements I mistakenly asked for previously.