### PR TITLE
add Cursor.elements()

### DIFF
--- a/api/src/main/java/jakarta/data/page/KeysetCursor.java
+++ b/api/src/main/java/jakarta/data/page/KeysetCursor.java
@@ -18,6 +18,7 @@
 package jakarta.data.page;
 
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Built-in implementation of Cursor for keyset pagination.
@@ -58,6 +59,11 @@ class KeysetCursor implements PageRequest.Cursor {
 
     public int size() {
         return keyset.length;
+    }
+
+    @Override
+    public List<?> elements() {
+        return List.of(keyset);
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/page/PageRequest.java
+++ b/api/src/main/java/jakarta/data/page/PageRequest.java
@@ -488,6 +488,14 @@ public interface PageRequest<T> {
         int size();
 
         /**
+         * An unmodifiable list of values in the keyset.
+         *
+         * @return an unmodifiable list containing the
+         *         ordered values
+         */
+        List<?> elements();
+
+        /**
          * String representation of the keyset cursor, including the number of
          * key values in the cursor but not the values themselves.
          *

--- a/api/src/test/java/jakarta/data/page/KeysetPageRequestTest.java
+++ b/api/src/test/java/jakarta/data/page/KeysetPageRequestTest.java
@@ -153,7 +153,7 @@ class KeysetPageRequestTest {
         PageRequest.Cursor cursor1 = new KeysetCursor("keyval1", '2', 3);
         PageRequest.Cursor cursor2 = new KeysetCursor("keyval2", '2', 3);
         PageRequest.Cursor cursor3 = new KeysetCursor("keyval1", '2');
-        PageRequest.Cursor cursor4 = new Pagination.Cursor() {
+        PageRequest.Cursor cursor4 = new PageRequest.Cursor() {
             private final Object[] keyset = new Object[] { "keyval1", '2', 3 };
 
             @Override
@@ -164,6 +164,11 @@ class KeysetPageRequestTest {
             @Override
             public int size() {
                 return keyset.length;
+            }
+
+            @Override
+            public List<?> elements() {
+                return List.of(keyset);
             }
         };
 


### PR DESCRIPTION
Currently, `PageRequest.Cursor` is not even `Iterable`, which means that any time you want to read its elements you have to use an archaic indexed `for` loop. If you want to actually pass the key values as a list, you have to repackage them manually.

This adds an `elements()` method which automatically packages the elements as an unmodifiable list.