### PR TITLE
Update API returning Optional instead of Null

### DIFF
--- a/api/src/main/java/jakarta/data/page/KeysetAwareSlice.java
+++ b/api/src/main/java/jakarta/data/page/KeysetAwareSlice.java
@@ -20,6 +20,8 @@ package jakarta.data.page;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.Sort;
 
+import java.util.Optional;
+
 /**
  * <p>A slice of data with the ability to create a cursor from the
  * keyset of each entity in the slice.</p>
@@ -154,10 +156,10 @@ public interface KeysetAwareSlice<T> extends Slice<T> {
      * sort criteria and relative to that entity.</p>
      *
      * @return pagination information for requesting the next page, or
-     *         <code>null</code> if the current page is empty
+     *         {@link Optional#empty()} if the current page is empty
      *         or if it is known that there is not a next page.
      */
-    PageRequest<T> nextPageRequest();
+    Optional<PageRequest<T>> nextPageRequest();
 
     /**
      * <p>Creates a request for the previous page
@@ -181,8 +183,8 @@ public interface KeysetAwareSlice<T> extends Slice<T> {
      * current page number.</p>
      *
      * @return pagination information for requesting the previous page, or
-     *         <code>null</code> if the current page is empty
+     *         {@link Optional#empty()} if the current page is empty
      *         or if it is known that there is not a previous page.
      */
-    PageRequest<T> previousPageRequest();
+    Optional<PageRequest<T>> previousPageRequest();
 }

--- a/api/src/main/java/jakarta/data/page/Slice.java
+++ b/api/src/main/java/jakarta/data/page/Slice.java
@@ -20,6 +20,7 @@ package jakarta.data.page;
 import jakarta.data.Streamable;
 import jakarta.data.repository.Query;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * <p>A slice contains the data that is retrieved for a page request.
@@ -98,15 +99,15 @@ public interface Slice<T> extends Streamable<T> {
     <E> PageRequest<E> pageRequest(Class<E> entityClass);
 
     /**
-     * Returns a request for the {@link PageRequest#next() next} page, or <code>null</code> if it is known that there is no next page.
+     * Returns a request for the {@link PageRequest#next() next} page, or {@link Optional#empty()} if it is known that there is no next page.
      *
      * @return a request for the next page.
      */
-    PageRequest<T> nextPageRequest();
+    Optional<PageRequest<T>> nextPageRequest();
 
     /**
      * <p>Returns a request for the {@link PageRequest#next() next} page,
-     * or <code>null</code> if it is known that there is no next page.</p>
+     * or {@link Optional#empty()} if it is known that there is no next page.</p>
      *
      * <p>This method is useful when {@link Query query language} is used to
      * return a result of different type than the entity that is being queried.
@@ -117,5 +118,5 @@ public interface Slice<T> extends Streamable<T> {
      * @param entityClass entity class of the attributes that are used as sort criteria.
      * @return a request for the next page.
      */
-    <E> PageRequest<E> nextPageRequest(Class<E> entityClass);
+    <E> Optional<PageRequest<E>> nextPageRequest(Class<E> entityClass);
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -737,13 +737,13 @@ public class EntityTests {
                      page1.stream().map(NaturalNumber::getId).collect(Collectors.toList()));
 
         Page<NaturalNumber> page2 = positives.findMatching(9L, Short.valueOf((short) 7), NumberType.COMPOSITE,
-                                                           page1.nextPageRequest());
+                                                           page1.nextPageRequest().orElse(null));
 
         assertEquals(List.of(91L, 90L, 88L, 87L, 86L, 85L, 84L),
                      page2.stream().map(NaturalNumber::getId).collect(Collectors.toList()));
 
         Page<NaturalNumber> page3 = positives.findMatching(9L, Short.valueOf((short) 7), NumberType.COMPOSITE,
-                                                           page2.nextPageRequest());
+                                                           page2.nextPageRequest().orElse(null));
 
         assertEquals(List.of(82L, 81L),
                      page3.stream().map(NaturalNumber::getId).collect(Collectors.toList()));
@@ -778,7 +778,7 @@ public class EntityTests {
                      Arrays.toString(page.stream().map(number -> number.getId()).toArray()));
 
         try {
-            page = positives.findByFloorOfSquareRootNotAndIdLessThanOrderByBitsRequiredDesc(4L, 33L, page.nextPageRequest());
+            page = positives.findByFloorOfSquareRootNotAndIdLessThanOrderByBitsRequiredDesc(4L, 33L, page.nextPageRequest().orElse(null));
         } catch (MappingException x) {
             // Test passes: Jakarta Data providers must raise MappingException when the database
             // is not capable of keyset pagination.
@@ -791,7 +791,7 @@ public class EntityTests {
         assertEquals(8, page.numberOfElements());
 
         try {
-            page = positives.findByFloorOfSquareRootNotAndIdLessThanOrderByBitsRequiredDesc(4L, 33L, page.nextPageRequest());
+            page = positives.findByFloorOfSquareRootNotAndIdLessThanOrderByBitsRequiredDesc(4L, 33L, page.nextPageRequest().orElse(null));
         } catch (MappingException x) {
             // Test passes: Jakarta Data providers must raise MappingException when the database
             // is not capable of keyset pagination.
@@ -826,7 +826,7 @@ public class EntityTests {
         assertEquals(6, slice.numberOfElements());
 
         try {
-            slice = numbers.findByFloorOfSquareRootOrderByIdAsc(7L, slice.nextPageRequest());
+            slice = numbers.findByFloorOfSquareRootOrderByIdAsc(7L, slice.nextPageRequest().orElse(null));
         } catch (MappingException x) {
             // Test passes: Jakarta Data providers must raise MappingException when the database
             // is not capable of keyset pagination.
@@ -839,7 +839,7 @@ public class EntityTests {
                      Arrays.toString(slice.stream().map(number -> number.getId()).toArray()));
 
         try {
-            slice = numbers.findByFloorOfSquareRootOrderByIdAsc(7L, slice.nextPageRequest());
+            slice = numbers.findByFloorOfSquareRootOrderByIdAsc(7L, slice.nextPageRequest().orElse(null));
         } catch (MappingException x) {
             // Test passes: Jakarta Data providers must raise MappingException when the database
             // is not capable of keyset pagination.
@@ -1000,7 +1000,7 @@ public class EntityTests {
         KeysetAwarePage<NaturalNumber> previousPage;
         try {
             previousPage = positives.findByFloorOfSquareRootNotAndIdLessThanOrderByBitsRequiredDesc(6L, 50L,
-                                                                                                    page.previousPageRequest());
+                                                                                                    page.previousPageRequest().orElse(null));
         } catch (MappingException x) {
             // Test passes: Jakarta Data providers must raise MappingException when the database
             // is not capable of keyset pagination.
@@ -1017,7 +1017,7 @@ public class EntityTests {
         KeysetAwarePage<NaturalNumber> nextPage;
         try {
             nextPage = positives.findByFloorOfSquareRootNotAndIdLessThanOrderByBitsRequiredDesc(6L, 50L,
-                                                                                                page.nextPageRequest());
+                                                                                                page.nextPageRequest().orElse(null));
         } catch (MappingException x) {
             // Test passes: Jakarta Data providers must raise MappingException when the database
             // is not capable of keyset pagination.
@@ -1085,7 +1085,7 @@ public class EntityTests {
         try {
             previousSlice = numbers.findByNumTypeAndNumBitsRequiredLessThan(NumberType.COMPOSITE,
                                                                             (short) 7,
-                                                                            slice.previousPageRequest());
+                                                                            slice.previousPageRequest().orElse(null));
         } catch (MappingException x) {
             // Test passes: Jakarta Data providers must raise MappingException when the database
             // is not capable of keyset pagination.
@@ -1101,7 +1101,7 @@ public class EntityTests {
          try {
              nextSlice = numbers.findByNumTypeAndNumBitsRequiredLessThan(NumberType.COMPOSITE,
                                                                          (short) 7,
-                                                                         slice.nextPageRequest());
+                                                                         slice.nextPageRequest().orElse(null));
          } catch (MappingException x) {
              // Test passes: Jakarta Data providers must raise MappingException when the database
              // is not capable of keyset pagination.
@@ -1253,7 +1253,7 @@ public class EntityTests {
                                                   24L, 22L, 21L, 20L, 18L }), // square root rounds down to 4; composite
                      Arrays.toString(slice.stream().map(number -> number.getId()).toArray()));
 
-        pagination = slice.nextPageRequest();
+        pagination = slice.nextPageRequest().orElse(null);
         slice = numbers.findByIdLessThanOrderByFloorOfSquareRootDesc(25L, pagination);
 
         assertEquals(Arrays.toString(new Long[] { 16L, // square root rounds down to 4; composite
@@ -1261,7 +1261,7 @@ public class EntityTests {
                                                   15L, 14L, 12L, 10L, 9L }), // square root rounds down to 3; composite
                      Arrays.toString(slice.stream().map(number -> number.getId()).toArray()));
 
-        pagination = slice.nextPageRequest();
+        pagination = slice.nextPageRequest().orElse(null);
         slice = numbers.findByIdLessThanOrderByFloorOfSquareRootDesc(25L, pagination);
 
         assertEquals(Arrays.toString(new Long[] { 7L, 5L, // square root rounds down to 2; prime
@@ -1270,7 +1270,7 @@ public class EntityTests {
                                                   3L, 2L }), // square root rounds down to 1; prime
                      Arrays.toString(slice.stream().map(number -> number.getId()).toArray()));
 
-        pagination = slice.nextPageRequest();
+        pagination = slice.nextPageRequest().orElse(null);
         if (pagination != null) {
             slice = numbers.findByIdLessThanOrderByFloorOfSquareRootDesc(25L, pagination);
             assertEquals(false, slice.hasContent());


### PR DESCRIPTION
# Changes

- For consistency, I've updated the return to be Optional instead of **null**.

Once we are using optional when the return might be null, such as, it would be great to keep the consistency here as well.