### PR TITLE
Replace Sort<T> by Sort<? super T> where appropriate

### DIFF
--- a/api/src/main/java/jakarta/data/Order.java
+++ b/api/src/main/java/jakarta/data/Order.java
@@ -73,19 +73,19 @@ import jakarta.data.repository.Query;
  *
  * @param <T> entity class of the attributes that are used as sort criteria.
  */
-public class Order<T> implements Iterable<Sort<T>> {
+public class Order<T> implements Iterable<Sort<? super T>> {
 
     /**
      * Unmodifiable list of Sort instances, from highest precedence to lowest.
      */
-    private final List<Sort<T>> sorts;
+    private final List<Sort<? super T>> sorts;
 
     /**
      * Creates a new instance.
      *
      * @param sorts unmodifiable list of Sort instances, from highest precedence to lowest.
      */
-    private Order(List<Sort<T>> sorts) {
+    private Order(List<Sort<? super T>> sorts) {
         this.sorts = sorts;
     }
 
@@ -99,7 +99,7 @@ public class Order<T> implements Iterable<Sort<T>> {
      *         This method never returns <code>null</code>.
      */
     @SafeVarargs
-    public static final <T> Order<T> by(Sort<T>... sorts) {
+    public static <T> Order<T> by(Sort<? super T>... sorts) {
         return new Order<T>(List.of(sorts));
     }
 
@@ -108,7 +108,7 @@ public class Order<T> implements Iterable<Sort<T>> {
      *
      * @return the instances of {@link Sort}, from highest precedence to lowest precedence.
      */
-    public List<Sort<T>> sorts() {
+    public List<Sort<? super T>> sorts() {
         return sorts;
     }
 
@@ -142,7 +142,7 @@ public class Order<T> implements Iterable<Sort<T>> {
      * @return iterator over the sort criteria.
      */
     @Override
-    public Iterator<Sort<T>> iterator() {
+    public Iterator<Sort<? super T>> iterator() {
         return sorts.iterator();
     }
 

--- a/api/src/main/java/jakarta/data/page/PageRequest.java
+++ b/api/src/main/java/jakarta/data/page/PageRequest.java
@@ -282,7 +282,7 @@ public interface PageRequest<T> {
      *
      * @return the order collection; will never be {@code null}.
      */
-    List<Sort<T>> sorts();
+    List<Sort<? super T>> sorts();
 
     /**
      * <p>Returns the <code>PageRequest</code> requesting the next page
@@ -333,7 +333,7 @@ public interface PageRequest<T> {
      * @param sorts sort criteria to use.
      * @return a new instance of <code>PageRequest</code>. This method never returns <code>null</code>.
      */
-    PageRequest<T> sortBy(Iterable<Sort<T>> sorts);
+    PageRequest<T> sortBy(Iterable<Sort<? super T>> sorts);
 
     /**
      * <p>Creates a new page request with the same
@@ -347,7 +347,7 @@ public interface PageRequest<T> {
      * @param sort sort criteria to use.
      * @return a new instance of <code>PageRequest</code>. This method never returns <code>null</code>.
      */
-    PageRequest<T> sortBy(Sort<T> sort);
+    PageRequest<T> sortBy(Sort<? super T> sort);
 
     /**
      * <p>Creates a new page request with the same
@@ -362,7 +362,7 @@ public interface PageRequest<T> {
      * @param sort2 dynamic sort criteria to use second.
      * @return a new instance of <code>PageRequest</code>. This method never returns <code>null</code>.
      */
-    PageRequest<T> sortBy(Sort<T> sort1, Sort<T> sort2);
+    PageRequest<T> sortBy(Sort<? super T> sort1, Sort<? super T> sort2);
 
     /**
      * <p>Creates a new page request with the same
@@ -378,7 +378,7 @@ public interface PageRequest<T> {
      * @param sort3 dynamic sort criteria to use last.
      * @return a new instance of <code>PageRequest</code>. This method never returns <code>null</code>.
      */
-    PageRequest<T> sortBy(Sort<T> sort1, Sort<T> sort2, Sort<T> sort3);
+    PageRequest<T> sortBy(Sort<? super T> sort1, Sort<? super T> sort2, Sort<? super T> sort3);
 
     /**
      * <p>Creates a new page request with the same
@@ -395,7 +395,7 @@ public interface PageRequest<T> {
      * @param sort4 dynamic sort criteria to use last.
      * @return a new instance of <code>PageRequest</code>. This method never returns <code>null</code>.
      */
-    PageRequest<T> sortBy(Sort<T> sort1, Sort<T> sort2, Sort<T> sort3, Sort<T> sort4);
+    PageRequest<T> sortBy(Sort<? super T> sort1, Sort<? super T> sort2, Sort<? super T> sort3, Sort<? super T> sort4);
 
     /**
      * <p>Creates a new page request with the same
@@ -413,7 +413,7 @@ public interface PageRequest<T> {
      * @param sort5 dynamic sort criteria to use last.
      * @return a new instance of <code>PageRequest</code>. This method never returns <code>null</code>.
      */
-    PageRequest<T> sortBy(Sort<T> sort1, Sort<T> sort2, Sort<T> sort3, Sort<T> sort4, Sort<T> sort5);
+    PageRequest<T> sortBy(Sort<? super T> sort1, Sort<? super T> sort2, Sort<? super T> sort3, Sort<? super T> sort4, Sort<? super T> sort5);
 
     /**
      * The type of pagination: offset-based or

--- a/api/src/main/java/jakarta/data/page/Pagination.java
+++ b/api/src/main/java/jakarta/data/page/Pagination.java
@@ -29,7 +29,7 @@ import java.util.stream.StreamSupport;
 /**
  * Built-in implementation of PageRequest.
  */
-record Pagination<T>(long page, int size, List<Sort<T>> sorts, Mode mode, Cursor type) implements PageRequest<T> {
+record Pagination<T>(long page, int size, List<Sort<? super T>> sorts, Mode mode, Cursor type) implements PageRequest<T> {
 
     Pagination {
         if (page < 1) {
@@ -120,7 +120,7 @@ record Pagination<T>(long page, int size, List<Sort<T>> sorts, Mode mode, Cursor
             s.append(", mode=").append(mode)
             .append(", ").append(type.size()).append(" keys");
         }
-        for (Sort<T> sort : sorts) {
+        for (Sort<? super T> sort : sorts) {
             s.append(", ").append(sort.property());
             if (sort.ignoreCase()) {
                 s.append(" IGNORE CASE");
@@ -141,35 +141,35 @@ record Pagination<T>(long page, int size, List<Sort<T>> sorts, Mode mode, Cursor
     }
 
     @Override
-    public PageRequest<T> sortBy(Iterable<Sort<T>> sorts) {
-        List<Sort<T>> sortList = sorts instanceof List ? List.copyOf((List<Sort<T>>) sorts)
+    public PageRequest<T> sortBy(Iterable<Sort<? super T>> sorts) {
+        List<Sort<? super T>> sortList = sorts instanceof List ? List.copyOf((List<Sort<? super T>>) sorts)
                 : sorts == null ? Collections.emptyList()
                 : StreamSupport.stream(sorts.spliterator(), false).collect(Collectors.toUnmodifiableList());
         return new Pagination<T>(page, size, sortList, mode, type);
     }
 
     @Override
-    public PageRequest<T> sortBy(Sort<T> sort) {
+    public PageRequest<T> sortBy(Sort<? super T> sort) {
         return new Pagination<T>(page, size, List.of(sort), mode, type);
     }
 
     @Override
-    public PageRequest<T> sortBy(Sort<T> sort1, Sort<T> sort2) {
+    public PageRequest<T> sortBy(Sort<? super T> sort1, Sort<? super T> sort2) {
         return new Pagination<T>(page, size, List.of(sort1, sort2), mode, type);
     }
 
     @Override
-    public PageRequest<T> sortBy(Sort<T> sort1, Sort<T> sort2, Sort<T> sort3) {
+    public PageRequest<T> sortBy(Sort<? super T> sort1, Sort<? super T> sort2, Sort<? super T> sort3) {
         return new Pagination<T>(page, size, List.of(sort1, sort2, sort3), mode, type);
     }
 
     @Override
-    public PageRequest<T> sortBy(Sort<T> sort1, Sort<T> sort2, Sort<T> sort3, Sort<T> sort4) {
+    public PageRequest<T> sortBy(Sort<? super T> sort1, Sort<? super T> sort2, Sort<? super T> sort3, Sort<? super T> sort4) {
         return new Pagination<T>(page, size, List.of(sort1, sort2, sort3, sort4), mode, type);
     }
 
     @Override
-    public PageRequest<T> sortBy(Sort<T> sort1, Sort<T> sort2, Sort<T> sort3, Sort<T> sort4, Sort<T> sort5) {
+    public PageRequest<T> sortBy(Sort<? super T> sort1, Sort<? super T> sort2, Sort<? super T> sort3, Sort<? super T> sort4, Sort<? super T> sort5) {
         return new Pagination<T>(page, size, List.of(sort1, sort2, sort3, sort4, sort5), mode, type);
     }
 }


### PR DESCRIPTION
To allow to sorting by a member of a super-entity, most locations which accept `Sort<T>` should accept `Sort<? super T>`. This is important to do correctly now, since it would be a breaking change to fix it up later.