### PR TITLE
CrudRepository update contradicts new lifecycle  method javadoc and TCK broken

### DIFF
--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 package jakarta.data.repository;
 
 import jakarta.data.exceptions.EntityExistsException;
+import jakarta.data.exceptions.OptimisticLockingFailureException;
 
 /**
  * <p>A built-in repository supertype for performing Create, Read, Update, and Delete (CRUD) operations on entities.</p>
@@ -130,6 +131,7 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      */
     @Insert
     <S extends T> Iterable<S> insertAll(Iterable<S> entities);
+
     /**
      * <p>Modifies an entity that already exists in the database.</p>
      *
@@ -142,14 +144,15 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * then the version must also match. The version is automatically incremented when making
      * the update.</p>
      *
-     * <p>Non-matching entities are ignored and do not cause an error to be raised.</p>
-     *
      * @param entity the entity to update. Must not be {@code null}.
-     * @return true if a matching entity was found in the database to update, otherwise false.
+     * @return an updated entity instance including all automatically generated values,
+     *         updated versions, and incremented values which changed as a result of the update.
+     * @throws OptimisticLockingFailureException the entity is not found in the database
+     *         or has a version that differs from the version in the database.
      * @throws NullPointerException if the entity is null.
      */
     @Update
-    boolean update(T entity);
+    T update(T entity);
 
     /**
      * <p>Modifies entities that already exist in the database.</p>
@@ -163,13 +166,15 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * then the version must also match. The version is automatically incremented when making
      * the update.</p>
      *
-     * <p>Non-matching entities are ignored and do not cause an error to be raised.</p>
-     *
      * @param entities entities to update.
-     * @return the number of matching entities that were found in the database to update.
-     * @throws NullPointerException if either the iterable is null or any element is null.
+     * @return updated entity instances, in the same order as the supplied entities,
+     *         and including all automatically generated values, updated versions, and
+     *         incremented values which changed as a result of the update.
+     * @throws OptimisticLockingFailureException If any of the supplied entities is not found in the database
+     *         or has a version that differs from the version in the database.
+     * @throws NullPointerException if either the supplied {@code Iterable} is null or any element is null.
      */
     @Update
-    int updateAll(Iterable<T> entities);
+    Iterable<T> updateAll(Iterable<T> entities);
 
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/PersistenceEntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/PersistenceEntityTests.java
@@ -358,7 +358,12 @@ public class PersistenceEntityTests {
         // Update must not be made when the version does not match:
         prod2.setVersionNum(prod2InitialVersion);
         prod2.setPrice(1.34);
-        assertEquals(null, catalog.modify(prod2));
+        try {
+            catalog.modify(prod2);
+            fail("Must raise OptimisticLockingFailureException for entity instance with old version.");
+        } catch (OptimisticLockingFailureException x) {
+            // expected
+        }
 
         catalog.remove(prod1);
 


### PR DESCRIPTION
The requirements of the `Update` annotation are now in conflict with the requirements of the `CrudRepository` update methods, which are annotated with that annotation.  The `Update` annotation disallows the return types that these methods currently have and it has an opposite requirement for raising `OptimisticLockingFailureException` rather than indicating the non-matching condition in the method return value.  We will need to make `CrudRepository` align its own requirements to that of the `Update` annotation so that the spec doesn't contradict itself.  Also, I found another spot where the TCK is broken by the `Update` annotation changes.