### PR TITLE
add boolean Page.hasNextPage()

### DIFF
--- a/api/src/main/java/jakarta/data/page/KeysetAwareSlice.java
+++ b/api/src/main/java/jakarta/data/page/KeysetAwareSlice.java
@@ -147,7 +147,8 @@ public interface KeysetAwareSlice<T> extends Slice<T> {
 
     /**
      * Returns {@code true} when it is possible to navigate to a previous
-     * page of results.
+     * page of results or if it is necessary to request a previous page in order to
+     * determine whether there are more previous results.
      * @return {@code false} if the current page is empty or if it is known
      *         that there is not a previous page.
      */

--- a/api/src/main/java/jakarta/data/page/KeysetAwareSlice.java
+++ b/api/src/main/java/jakarta/data/page/KeysetAwareSlice.java
@@ -146,6 +146,14 @@ public interface KeysetAwareSlice<T> extends Slice<T> {
     PageRequest.Cursor getKeysetCursor(int index);
 
     /**
+     * Returns {@code true} when it is possible to navigate to a previous
+     * page of results.
+     * @return {@code false} if the current page is empty or if it is known
+     *         that there is not a previous page.
+     */
+    boolean hasPrevious();
+
+    /**
      * <p>Creates a request for the next page
      * in a forward direction from the current page. This method computes a
      * keyset cursor from the last entity of the current page and includes the

--- a/api/src/main/java/jakarta/data/page/Page.java
+++ b/api/src/main/java/jakarta/data/page/Page.java
@@ -42,14 +42,6 @@ package jakarta.data.page;
 public interface Page<T> extends Slice<T> {
 
     /**
-     * Returns {@code true} if it is known that there are more results or that it is
-     * necessary to request a next page to determine whether there are more results, so that
-     * {@link #nextPageRequest()} will definitely not return {@code null}.
-     * @return {@code false} if this is the last page of results.
-     */
-    boolean hasNext();
-
-    /**
      * Returns the total number of elements across all pages that can be requested for the query.
      * @return the total number of elements across all pages.
      */

--- a/api/src/main/java/jakarta/data/page/Page.java
+++ b/api/src/main/java/jakarta/data/page/Page.java
@@ -42,6 +42,13 @@ package jakarta.data.page;
 public interface Page<T> extends Slice<T> {
 
     /**
+     * Returns {@code true} if it is known that there are more results, so that
+     * {@link #nextPageRequest()} will definitely not return {@code null}.
+     * @return {@code false} if this the last page of results
+     */
+    boolean hasNextPage();
+
+    /**
      * Returns the total number of elements across all pages that can be requested for the query.
      * @return the total number of elements across all pages.
      */

--- a/api/src/main/java/jakarta/data/page/Page.java
+++ b/api/src/main/java/jakarta/data/page/Page.java
@@ -46,7 +46,7 @@ public interface Page<T> extends Slice<T> {
      * {@link #nextPageRequest()} will definitely not return {@code null}.
      * @return {@code false} if this the last page of results
      */
-    boolean hasNextPage();
+    boolean hasNext();
 
     /**
      * Returns the total number of elements across all pages that can be requested for the query.

--- a/api/src/main/java/jakarta/data/page/Page.java
+++ b/api/src/main/java/jakarta/data/page/Page.java
@@ -42,9 +42,10 @@ package jakarta.data.page;
 public interface Page<T> extends Slice<T> {
 
     /**
-     * Returns {@code true} if it is known that there are more results, so that
+     * Returns {@code true} if it is known that there are more results or that it is
+     * necessary to request a next page to determine whether there are more results, so that
      * {@link #nextPageRequest()} will definitely not return {@code null}.
-     * @return {@code false} if this the last page of results
+     * @return {@code false} if this is the last page of results.
      */
     boolean hasNext();
 

--- a/api/src/main/java/jakarta/data/page/Slice.java
+++ b/api/src/main/java/jakarta/data/page/Slice.java
@@ -75,6 +75,14 @@ public interface Slice<T> extends Streamable<T> {
     int numberOfElements();
 
     /**
+     * Returns {@code true} if it is known that there are more results or that it is
+     * necessary to request a next page to determine whether there are more results, so that
+     * {@link #nextPageRequest()} will definitely not return {@code null}.
+     * @return {@code false} if this is the last page of results.
+     */
+    boolean hasNext();
+
+    /**
      * Returns the {@link PageRequest page request} for which this
      * slice was obtained.
      *

--- a/api/src/main/java/jakarta/data/page/impl/KeysetAwarePageRecord.java
+++ b/api/src/main/java/jakarta/data/page/impl/KeysetAwarePageRecord.java
@@ -56,6 +56,16 @@ public record KeysetAwarePageRecord<T>
     }
 
     @Override
+    public boolean hasNext() {
+        return nextPageRequest != null;
+    }
+
+    @Override
+    public boolean hasPrevious() {
+        return previousPageRequest != null;
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public <E> PageRequest<E> pageRequest(Class<E> entityClass) {
         return (PageRequest<E>) pageRequest;

--- a/api/src/main/java/jakarta/data/page/impl/KeysetAwareSliceRecord.java
+++ b/api/src/main/java/jakarta/data/page/impl/KeysetAwareSliceRecord.java
@@ -54,6 +54,16 @@ public record KeysetAwareSliceRecord<T>
     }
 
     @Override
+    public boolean hasNext() {
+        return nextPageRequest != null;
+    }
+
+    @Override
+    public boolean hasPrevious() {
+        return previousPageRequest != null;
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public <E> PageRequest<E> pageRequest(Class<E> entityClass) {
         return (PageRequest<E>) pageRequest;

--- a/api/src/main/java/jakarta/data/page/impl/PageRecord.java
+++ b/api/src/main/java/jakarta/data/page/impl/PageRecord.java
@@ -56,7 +56,7 @@ public record PageRecord<T>(PageRequest<T> pageRequest, List<T> content, long to
     }
 
     @Override
-    public boolean hasNextPage() {
+    public boolean hasNext() {
         return moreResults;
     }
 

--- a/api/src/main/java/jakarta/data/page/impl/PageRecord.java
+++ b/api/src/main/java/jakarta/data/page/impl/PageRecord.java
@@ -56,6 +56,11 @@ public record PageRecord<T>(PageRequest<T> pageRequest, List<T> content, long to
     }
 
     @Override
+    public boolean hasNextPage() {
+        return moreResults;
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public <E> PageRequest<E> pageRequest(Class<E> entityClass) {
         return (PageRequest<E>) pageRequest;

--- a/api/src/main/java/jakarta/data/page/impl/SliceRecord.java
+++ b/api/src/main/java/jakarta/data/page/impl/SliceRecord.java
@@ -50,6 +50,11 @@ public record SliceRecord<T>(PageRequest<T> pageRequest, List<T> content, boolea
     }
 
     @Override
+    public boolean hasNext() {
+        return moreResults;
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public <E> PageRequest<E> pageRequest(Class<E> entityClass) {
         return (PageRequest<E>) pageRequest;


### PR DESCRIPTION
A `Page` always knows if there are more results. But the only way to really get that information is to call `page.nextPageRequest()`. Thus, the idiom for iteration is:

```java
Page<Book> page = library.books("%", pageRequest);
...
while (page.nextPageRequest() != null) {
    page = library.books("%", slice.nextPageRequest());
    ...
}
```

which is quite nonbeautiful.

This proposal adds a `last()` method to `Page`, so that the idiom becomes:

```java
Page<Book> page = library.books("%", pageRequest);
...
while (!page.last()) {
    page = library.books("%", slice.nextPageRequest());
    ...
}
```

Now, if it were my call I would also add:

- `last()` to `Slice`, not just `Page`, and
- `first()` to `KeysetAwareSlice`

but I wanted to see how you guys really react to just this.