### PR TITLE
TCK coverage for hasNext and hasPrevious

### DIFF
--- a/api/src/main/java/jakarta/data/page/KeysetAwareSlice.java
+++ b/api/src/main/java/jakarta/data/page/KeysetAwareSlice.java
@@ -19,6 +19,7 @@ package jakarta.data.page;
 
 import jakarta.data.repository.OrderBy;
 import jakarta.data.Sort;
+import java.util.NoSuchElementException;
 
 /**
  * <p>A slice of data with the ability to create a cursor from the
@@ -163,9 +164,11 @@ public interface KeysetAwareSlice<T> extends Slice<T> {
      * obtain the next page in a forward direction according to the
      * sort criteria and relative to that entity.</p>
      *
-     * @return pagination information for requesting the next page, or
-     *         <code>null</code> if the current page is empty
-     *         or if it is known that there is not a next page.
+     * @return pagination information for requesting the next page.
+     * @throws NoSuchElementException if the current page is empty
+     *         or it is known that there is no next page.
+     *         To avoid this exception, check for a {@code true} result of
+     *         {@link Slice#hasNext()} before invoking this method.
      */
     PageRequest<T> nextPageRequest();
 
@@ -190,9 +193,11 @@ public interface KeysetAwareSlice<T> extends Slice<T> {
      * cannot be relied upon to return a page number that is equal to the
      * current page number.</p>
      *
-     * @return pagination information for requesting the previous page, or
-     *         <code>null</code> if the current page is empty
-     *         or if it is known that there is not a previous page.
+     * @return pagination information for requesting the previous page.
+     * @throws NoSuchElementException if the current page is empty
+     *         or it is known that there is no previous page.
+     *         To avoid this exception, check for a {@code true} result of
+     *         {@link #hasPrevious()} before invoking this method.
      */
     PageRequest<T> previousPageRequest();
 }

--- a/api/src/main/java/jakarta/data/page/Slice.java
+++ b/api/src/main/java/jakarta/data/page/Slice.java
@@ -20,6 +20,7 @@ package jakarta.data.page;
 import jakarta.data.Streamable;
 import jakarta.data.repository.Query;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 /**
  * <p>A slice contains the data that is retrieved for a page request.
@@ -106,15 +107,19 @@ public interface Slice<T> extends Streamable<T> {
     <E> PageRequest<E> pageRequest(Class<E> entityClass);
 
     /**
-     * Returns a request for the {@link PageRequest#next() next} page, or <code>null</code> if it is known that there is no next page.
+     * Returns a request for the {@link PageRequest#next() next} page if
+     * {@link Slice#hasNext()} indicates there might be a next page.
      *
      * @return a request for the next page.
+     * @throws NoSuchElementException if it is known that there is no next page.
+     *         To avoid this exception, check for a {@code true} result of
+     *         {@link #hasNext()} before invoking this method.
      */
     PageRequest<T> nextPageRequest();
 
     /**
-     * <p>Returns a request for the {@link PageRequest#next() next} page,
-     * or <code>null</code> if it is known that there is no next page.</p>
+     * <p>Returns a request for the {@link PageRequest#next() next} page if
+     * {@link Slice#hasNext()} indicates there might be a next page.</p>
      *
      * <p>This method is useful when {@link Query query language} is used to
      * return a result of different type than the entity that is being queried.
@@ -124,6 +129,9 @@ public interface Slice<T> extends Streamable<T> {
      * @param <E>         entity class of the attributes that are used as sort criteria.
      * @param entityClass entity class of the attributes that are used as sort criteria.
      * @return a request for the next page.
+     * @throws NoSuchElementException if it is known that there is no next page.
+     *         To avoid this exception, check for a {@code true} result of
+     *         {@link #hasNext()} before invoking this method.
      */
     <E> PageRequest<E> nextPageRequest(Class<E> entityClass);
 }

--- a/api/src/main/java/jakarta/data/page/impl/KeysetAwareSliceRecord.java
+++ b/api/src/main/java/jakarta/data/page/impl/KeysetAwareSliceRecord.java
@@ -23,6 +23,7 @@ import jakarta.data.page.PageRequest.Cursor;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 /**
  * Record type implementing {@link KeysetAwareSlice}.
@@ -72,7 +73,16 @@ public record KeysetAwareSliceRecord<T>
     @Override
     @SuppressWarnings("unchecked")
     public <E> PageRequest<E> nextPageRequest(Class<E> entityClass) {
+        if (nextPageRequest == null)
+            throw new NoSuchElementException();
         return (PageRequest<E>) nextPageRequest;
+    }
+
+    @Override
+    public PageRequest<T> previousPageRequest() {
+        if (previousPageRequest == null)
+            throw new NoSuchElementException();
+        return previousPageRequest;
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/page/impl/PageRecord.java
+++ b/api/src/main/java/jakarta/data/page/impl/PageRecord.java
@@ -23,6 +23,7 @@ import jakarta.data.page.Slice;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 /**
  * Record type implementing {@link Slice}.
@@ -68,7 +69,11 @@ public record PageRecord<T>(PageRequest<T> pageRequest, List<T> content, long to
 
     @Override
     public PageRequest<T> nextPageRequest() {
-        return moreResults ? pageRequest.next() : null;
+        if (moreResults) {
+            return pageRequest.next();
+        } else {
+            throw new NoSuchElementException();
+        }
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/page/impl/SliceRecord.java
+++ b/api/src/main/java/jakarta/data/page/impl/SliceRecord.java
@@ -22,6 +22,7 @@ import jakarta.data.page.Slice;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 /**
  * Record type implementing {@link Slice}.
@@ -62,7 +63,11 @@ public record SliceRecord<T>(PageRequest<T> pageRequest, List<T> content, boolea
 
     @Override
     public PageRequest<T> nextPageRequest() {
-        return moreResults ? pageRequest.next() : null;
+        if (moreResults) {
+            return pageRequest.next();
+        } else {
+            throw new NoSuchElementException();
+        }
     }
 
     @Override

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -1308,8 +1308,10 @@ Next Page Execution:
 
 [source,java]
 ----
-PageRequest<Person> nextPageRequest = page.nextPageRequest();
-Page<Person> page2 = people.findAll(nextPageRequest);
+if (page.hasNext()) {
+   PageRequest<Person> nextPageRequest = page.nextPageRequest();
+   Page<Person> page2 = people.findAll(nextPageRequest);
+}
 ----
 
 
@@ -1347,10 +1349,13 @@ You can obtain the initial page relative to an offset and subsequent pages relat
 
 [source,java]
 ----
-for (PageRequest<Customer> p = PageRequest.of(Customer.class).size(50); p != null; ) {
-  page = customers.findByZipcodeOrderByLastNameAscFirstNameAscIdAsc(55901, p);
+PageRequest<Customer> pageRequest = PageRequest.of(Customer.class).size(50);
+Page<Customer> page = customers.findByZipcodeOrderByLastNameAscFirstNameAscIdAsc(
+                                55901, pageRequest);
+if (page.hasNext()) {
+  pageRequest = page.nextPageRequest();
+  page = customers.findByZipcodeOrderByLastNameAscFirstNameAscIdAsc(55901, pageRequest);
   ...
-  p = page.nextPageRequest();
 }
 ----
 
@@ -1427,15 +1432,16 @@ Example traversal of pages:
 
 [source,java]
 ----
-for (PageRequest<Customer> p = Order.by(_Customer.yearBorn.desc(),
-                                        _Customer.name.asc(),
-                                        _Customer.id.asc())
-                                    .pageSize(25);
-     p != null; ) {
-  page = customers.withAveragePurchaseAbove(50.0f, p);
+PageRequest<Customer> pageRequest = Order.by(_Customer.yearBorn.desc(),
+                                             _Customer.name.asc(),
+                                             _Customer.id.asc())
+                                         .pageSize(25);
+do {
+  page = customers.withAveragePurchaseAbove(50.0f, pageRequest);
   ...
-  p = page.nextPageRequest();
-}
+  if (page.hasNext())
+    pageRequest = page.nextPageRequest();
+} while (page.hasNext());
 ----
 
 ===== Example with Before/After Cursor
@@ -1577,8 +1583,10 @@ Next Page Execution:
 
 [source,java]
 ----
-PageRequest<Person> nextPageRequest = page.nextPageRequest();
-KeysetAwarePage<Person> page2 = people.findAll(nextPageRequest);
+if (page.hasNext()) {
+   PageRequest<Person> nextPageRequest = page.nextPageRequest();
+   KeysetAwarePage<Person> page2 = people.findAll(nextPageRequest);
+}
 ----
 
 

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
@@ -1059,6 +1060,27 @@ public class EntityTests {
         assertEquals(false, page.hasPrevious());
         assertEquals(0, page.content().size());
         assertEquals(0, page.numberOfElements());
+
+        try {
+            page.nextPageRequest();
+            fail("nextPageRequest must raise NoSuchElementException when current page is empty.");
+        } catch (NoSuchElementException x) {
+            // expected
+        }
+
+        try {
+            page.nextPageRequest(NaturalNumber.class);
+            fail("nextPageRequest(entityClass) must raise NoSuchElementException when current page is empty.");
+        } catch (NoSuchElementException x) {
+            // expected
+        }
+
+        try {
+            page.previousPageRequest();
+            fail("previousPageRequest must raise NoSuchElementException when current page is empty.");
+        } catch (NoSuchElementException x) {
+            // expected
+        }
     }
 
     @Assertion(id = "133",

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -736,17 +736,23 @@ public class EntityTests {
         assertEquals(List.of(99L, 98L, 96L, 95L, 94L, 93L, 92L),
                      page1.stream().map(NaturalNumber::getId).collect(Collectors.toList()));
 
+        assertEquals(true, page1.hasNext());
+
         Page<NaturalNumber> page2 = positives.findMatching(9L, Short.valueOf((short) 7), NumberType.COMPOSITE,
                                                            page1.nextPageRequest());
 
         assertEquals(List.of(91L, 90L, 88L, 87L, 86L, 85L, 84L),
                      page2.stream().map(NaturalNumber::getId).collect(Collectors.toList()));
 
+        assertEquals(true, page2.hasNext());
+
         Page<NaturalNumber> page3 = positives.findMatching(9L, Short.valueOf((short) 7), NumberType.COMPOSITE,
                                                            page2.nextPageRequest());
 
         assertEquals(List.of(82L, 81L),
                      page3.stream().map(NaturalNumber::getId).collect(Collectors.toList()));
+
+        assertEquals(false, page3.hasNext());
     }
 
     @Assertion(id = "133",
@@ -997,6 +1003,8 @@ public class EntityTests {
 
         assertEquals(7, page.numberOfElements());
 
+        assertEquals(true, page.hasPrevious());
+
         KeysetAwarePage<NaturalNumber> previousPage;
         try {
             previousPage = positives.findByFloorOfSquareRootNotAndIdLessThanOrderByBitsRequiredDesc(6L, 50L,
@@ -1047,6 +1055,8 @@ public class EntityTests {
         }
 
         assertEquals(false, page.hasContent());
+        assertEquals(false, page.hasNext());
+        assertEquals(false, page.hasPrevious());
         assertEquals(0, page.content().size());
         assertEquals(0, page.numberOfElements());
     }
@@ -1080,6 +1090,8 @@ public class EntityTests {
                      Arrays.toString(slice.stream().map(number -> number.getId()).toArray()));
 
         assertEquals(9, slice.numberOfElements());
+
+        assertEquals(true, slice.hasPrevious());
 
         KeysetAwareSlice<NaturalNumber> previousSlice;
         try {
@@ -1253,6 +1265,7 @@ public class EntityTests {
                                                   24L, 22L, 21L, 20L, 18L }), // square root rounds down to 4; composite
                      Arrays.toString(slice.stream().map(number -> number.getId()).toArray()));
 
+        assertEquals(true, slice.hasNext());
         pagination = slice.nextPageRequest();
         slice = numbers.findByIdLessThanOrderByFloorOfSquareRootDesc(25L, pagination);
 
@@ -1261,6 +1274,7 @@ public class EntityTests {
                                                   15L, 14L, 12L, 10L, 9L }), // square root rounds down to 3; composite
                      Arrays.toString(slice.stream().map(number -> number.getId()).toArray()));
 
+        assertEquals(true, slice.hasNext());
         pagination = slice.nextPageRequest();
         slice = numbers.findByIdLessThanOrderByFloorOfSquareRootDesc(25L, pagination);
 
@@ -1270,8 +1284,8 @@ public class EntityTests {
                                                   3L, 2L }), // square root rounds down to 1; prime
                      Arrays.toString(slice.stream().map(number -> number.getId()).toArray()));
 
-        pagination = slice.nextPageRequest();
-        if (pagination != null) {
+        if (slice.hasNext()) {
+            pagination = slice.nextPageRequest();
             slice = numbers.findByIdLessThanOrderByFloorOfSquareRootDesc(25L, pagination);
             assertEquals(false, slice.hasContent());
         }
@@ -1476,7 +1490,8 @@ public class EntityTests {
                                      .map(c -> c.getHexadecimal() + ':' + c.getThisCharacter() + ';')
                                      .reduce("", String::concat));
 
-        PageRequest<AsciiCharacter> fourth10 = third10.next();
+        assertEquals(true, page.hasNext());
+        PageRequest<AsciiCharacter> fourth10 = page.nextPageRequest();
         page = characters.findByNumericValueBetween(48, 90, fourth10); // 'N' to 'W'
 
         assertEquals(4, page.pageRequest().page());
@@ -1505,7 +1520,8 @@ public class EntityTests {
         assertEquals(Arrays.toString(new Long[] { 37L, 31L, 29L, 23L, 19L }),
                 Arrays.toString(slice.stream().map(number -> number.getId()).toArray()));
 
-        PageRequest<NaturalNumber> fourth5 = third5.next();
+        assertEquals(true, slice.hasNext());
+        PageRequest<NaturalNumber> fourth5 = slice.nextPageRequest();
 
         slice = numbers.findByNumTypeAndFloorOfSquareRootLessThanEqual(NumberType.PRIME, 8L, fourth5);
 


### PR DESCRIPTION
This pull adds TCK coverage for hasNext and hasPrevious methods. (first commit)

And updates examples in the documentation to use hasNext before trying to obtain the next page request. (second commit)

Also, it eliminates the possibility of null page requests from nextPageable and previousPageable by raising NoSuchElementException (commit 3), which I think was intended to be part of the hasNext/hasPrevious solution and would allow us to cancel the pull that was going to wrap PageRequest with an Optional. If this part wasn't wanted, let me know and I can remove the third commit.