### PR TITLE
TCK tests using return types that no longer correspond to spec requirements

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
@@ -15,7 +15,6 @@
  */
 package ee.jakarta.tck.data.framework.read.only;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -50,7 +49,7 @@ public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long>, I
     Optional<AsciiCharacter> find(@By("thisCharacter") char ch,
                                   @By("hexadecimal") String hex);
 
-    Collection<AsciiCharacter> findByHexadecimalContainsAndIsControlNot(String substring, boolean isPrintable);
+    List<AsciiCharacter> findByHexadecimalContainsAndIsControlNot(String substring, boolean isPrintable);
 
     Stream<AsciiCharacter> findByHexadecimalIgnoreCaseBetweenAndHexadecimalNotIn(String minHex,
                                                                                  String maxHex,

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
@@ -16,6 +16,7 @@
 package ee.jakarta.tck.data.framework.read.only;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -64,7 +65,7 @@ public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long>, I
 
     Page<AsciiCharacter> findByNumericValueBetween(int min, int max, PageRequest<AsciiCharacter> pagination);
 
-//    Streamable<AsciiCharacter> findByNumericValueLessThanEqualAndNumericValueGreaterThanEqual(int max, int min);
+    List<AsciiCharacter> findByNumericValueLessThanEqualAndNumericValueGreaterThanEqual(int max, int min);
 
     AsciiCharacter[] findFirst3ByNumericValueGreaterThanEqualAndHexadecimalEndsWith(long minValue, String lastHexDigit, Sort<AsciiCharacter> sort);
 

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/IdOperations.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/IdOperations.java
@@ -15,8 +15,7 @@
  */
 package ee.jakarta.tck.data.framework.read.only;
 
-import java.util.ArrayList;
-import java.util.Collection;
+import java.util.List;
 import java.util.stream.Stream;
 
 import jakarta.data.Limit;
@@ -31,11 +30,11 @@ import jakarta.data.Sort;
 public interface IdOperations<T> {
     Stream<T> findByIdBetween(long minimum, long maximum, Sort<T> sort);
 
-    Collection<T> findByIdGreaterThanEqual(long minimum,
+    List<T> findByIdGreaterThanEqual(long minimum,
                                            Limit limit,
                                            Order<T> sorts);
 
     T[] findByIdLessThan(long exclusiveMax, Sort<T> primarySort, Sort<T> secondarySort);
 
-    ArrayList<T> findByIdLessThanEqual(long maximum, Order<T> sorts);
+    List<T> findByIdLessThanEqual(long maximum, Order<T> sorts);
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/PositiveIntegers.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/PositiveIntegers.java
@@ -45,7 +45,7 @@ public interface PositiveIntegers extends BasicRepository<NaturalNumber, Long> {
                                                                                                   long eclusiveMax,
                                                                                                   PageRequest<NaturalNumber> pagination);
 
-    Iterable<NaturalNumber> findByIsOddTrueAndIdLessThanEqualOrderByIdDesc(long max);
+    List<NaturalNumber> findByIsOddTrueAndIdLessThanEqualOrderByIdDesc(long max);
 
     List<NaturalNumber> findByIsOddFalseAndIdBetween(long min, long max);
 

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -812,7 +812,7 @@ public class EntityTests {
                strategy = "Request the first CursoredPage of 6 results, expecting to find all 6, " +
                           "then request the next CursoredPage and the CursoredPage after that, " +
                           "expecting to find all results.")
-    public void testFirstKeysetAwareSliceOf6AndNextSlices() {
+    public void testFirstCursoredPageWithoutTotalOf6AndNextPages() {
         PageRequest<NaturalNumber> first6 = PageRequest.of(NaturalNumber.class).size(6).withoutTotal();
         CursoredPage<NaturalNumber> slice;
 
@@ -969,8 +969,8 @@ public class EntityTests {
     }
 
     @Assertion(id = "133",
-               strategy = "Request a CursoredPage of 7 results after the keyset of the 20th result, expecting to find the next 7 results. " +
-                          "Then request the CursoredPage before the keyset of the first entry of the page, expecting to find the previous 7 results. " +
+               strategy = "Request a CursoredPage of 7 results after the cursor of the 20th result, expecting to find the next 7 results. " +
+                          "Then request the CursoredPage before the cursor of the first entry of the page, expecting to find the previous 7 results. " +
                           "Then request the CursoredPage after the last entry of the original slice, expecting to find the next 7.")
     public void testCursoredPageOf7FromCursor() {
         // The query for this test returns 1-35 and 49 in the following order:
@@ -1081,10 +1081,10 @@ public class EntityTests {
     }
 
     @Assertion(id = "133",
-            strategy = "Request a CursoredPage of 9 results after the keyset of the 20th result, expecting to find the next 9 results. " +
-                       "Then request the CursoredPage before the keyset of the first entry of the slice, expecting to find the previous 9 results. " +
+            strategy = "Request a CursoredPage of 9 results after the cursor of the 20th result, expecting to find the next 9 results. " +
+                       "Then request the CursoredPage before the cursor of the first entry of the slice, expecting to find the previous 9 results. " +
                        "Then request the CursoredPage after the last entry of the original slice, expecting to find the next 9.")
-    public void testKeysetAwareSliceOf9FromCursor() {
+    public void testCursoredPageWithoutTotalOf9FromCursor() {
         // The query for this test returns composite natural numbers under 64 in the following order:
         //
         // 49 50 51 52 54 55 56 57 58 60 62 63 36 38 39 40 42 44 45 46 48 25 26 27 28 30 32 33 34 35 16 18 20 21 22 24 09 10 12 14 15 04 06 08
@@ -1145,7 +1145,7 @@ public class EntityTests {
     }
 
     @Assertion(id = "133", strategy = "Request a CursoredPage of results where none match the query, expecting an empty CursoredPage with 0 results.")
-    public void testKeysetAwareSliceOfNothing() {
+    public void testCursoredPageWithoutTotalOfNothing() {
         // There are no numbers larger than 30 which have a square root that rounds down to 3.
         PageRequest<NaturalNumber> pagination = PageRequest.of(NaturalNumber.class).size(33).afterKeyset(30L).withoutTotal();
 
@@ -1454,34 +1454,34 @@ public class EntityTests {
         assertEquals('d', found[1].getThisCharacter());
         assertEquals('T', found[2].getThisCharacter());
     }
-//
-//    @Assertion(id = "133", strategy = "Use a repository method that returns Streamable and verify the results.")
-//    public void testStreamable() {
-//        Streamable<AsciiCharacter> chars = characters.findByNumericValueLessThanEqualAndNumericValueGreaterThanEqual(109, 101);
-//
-//        assertEquals(Arrays.toString(new Character[] { Character.valueOf('e'),
-//                                                       Character.valueOf('f'),
-//                                                       Character.valueOf('g'),
-//                                                       Character.valueOf('h'),
-//                                                       Character.valueOf('i'),
-//                                                       Character.valueOf('j'),
-//                                                       Character.valueOf('k'),
-//                                                       Character.valueOf('l'),
-//                                                       Character.valueOf('m') }),
-//                     Arrays.toString(chars.stream().map(ch -> ch.getThisCharacter()).sorted().toArray()));
-//
-//        assertEquals(101 + 102 + 103 + 104 + 105 + 106 + 107 + 108 + 109,
-//                     chars.stream().mapToInt(AsciiCharacter::getNumericValue).sum());
-//
-//        Set<String> sorted = new TreeSet<>();
-//        chars.forEach(ch -> sorted.add(ch.getHexadecimal()));
-//        assertEquals(new TreeSet<>(Set.of("65", "66", "67", "68", "69", "6a", "6b", "6c", "6d")),
-//                     sorted);
-//
-//        Streamable<AsciiCharacter> empty = characters.findByNumericValueLessThanEqualAndNumericValueGreaterThanEqual(115, 120);
-//        assertEquals(false, empty.iterator().hasNext());
-//        assertEquals(0L, empty.stream().count());
-//    }
+
+    @Assertion(id = "133", strategy = "Obtain multiple streams from the same List result of a repository method.")
+    public void testStreamsFromList() {
+        List<AsciiCharacter> chars = characters.findByNumericValueLessThanEqualAndNumericValueGreaterThanEqual(109, 101);
+
+        assertEquals(Arrays.toString(new Character[] { Character.valueOf('e'),
+                                                       Character.valueOf('f'),
+                                                       Character.valueOf('g'),
+                                                       Character.valueOf('h'),
+                                                       Character.valueOf('i'),
+                                                       Character.valueOf('j'),
+                                                       Character.valueOf('k'),
+                                                       Character.valueOf('l'),
+                                                       Character.valueOf('m') }),
+                     Arrays.toString(chars.stream().map(ch -> ch.getThisCharacter()).sorted().toArray()));
+
+        assertEquals(101 + 102 + 103 + 104 + 105 + 106 + 107 + 108 + 109,
+                     chars.stream().mapToInt(AsciiCharacter::getNumericValue).sum());
+
+        Set<String> sorted = new TreeSet<>();
+        chars.forEach(ch -> sorted.add(ch.getHexadecimal()));
+        assertEquals(new TreeSet<>(Set.of("65", "66", "67", "68", "69", "6a", "6b", "6c", "6d")),
+                     sorted);
+
+        List<AsciiCharacter> empty = characters.findByNumericValueLessThanEqualAndNumericValueGreaterThanEqual(115, 120);
+        assertEquals(false, empty.iterator().hasNext());
+        assertEquals(0L, empty.stream().count());
+    }
 
     @Assertion(id = "133",
                strategy = "Request the third Page of 10 results, expecting to find all 10. " +

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/Catalog.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/Catalog.java
@@ -77,9 +77,9 @@ public interface Catalog extends DataRepository<Product, String> {
     @OrderBy("name")
     Product[] findByDepartmentsContains(Department department);
 
-    LinkedList<Product> findByDepartmentsEmpty();
+    Stream<Product> findByDepartmentsEmpty();
 
-    Iterable<Product> findByIdBetween(String first, String last, Order<Product> sorts);
+    List<Product> findByIdBetween(String first, String last, Order<Product> sorts);
 
     List<Product> findByNameLike(String name);
     
@@ -88,7 +88,7 @@ public interface Catalog extends DataRepository<Product, String> {
     @OrderBy(value = "price", descending = true)
     Stream<Product> findByPriceNotNullAndPriceLessThanEqual(double maxPrice);
 
-    Collection<Product> findByPriceNull();
+    List<Product> findByPriceNull();
 
     EntityManager getEntityManager();
 

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/Catalog.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/Catalog.java
@@ -15,8 +15,6 @@
  */
 package ee.jakarta.tck.data.standalone.persistence;
 
-import java.util.Collection;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/PersistenceEntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/PersistenceEntityTests.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/PersistenceEntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/PersistenceEntityTests.java
@@ -92,10 +92,11 @@ public class PersistenceEntityTests {
         catalog.save(Product.of("book", 15.98, "TEST-PROD-42"));
         catalog.save(Product.of("baseball cap", 10.99, "TEST-PROD-43", Department.SPORTING_GOODS, Department.CLOTHING));
 
-        LinkedList<Product> found = catalog.findByDepartmentsEmpty();
+        Stream<Product> found = catalog.findByDepartmentsEmpty();
 
-        assertEquals(1, found.size());
-        assertEquals("book", found.getFirst().getName());
+        assertEquals(List.of("book"),
+                     found.map(Product::getName)
+                          .collect(Collectors.toList()));
 
         assertEquals(3L, catalog.deleteByProductNumLike("TEST-PROD-%"));
     }


### PR DESCRIPTION
TCK tests need to avoid using repository method return types like Iterable, LinkedList, ArrayList, and so forth which are no longer required by the Jakarta Data specification/JavaDoc.

This pull updates these TCK repository methods to switch to return types that the spec requires.

Also, there is a TCK test that was commented out due to having the Streamable return type, which was also removed. I switched this to use a return type of List, which is a return type that is required to be supported by the spec, and re-enabled that test after renaming it from testStreamable to something more appropriate.