### PR TITLE
roll back commit 63686513

### DIFF
--- a/api/src/main/java/jakarta/data/Limit.java
+++ b/api/src/main/java/jakarta/data/Limit.java
@@ -27,7 +27,8 @@ import jakarta.data.page.PageRequest;
  * in terms of an offset and maximum number of results.</p>
  *
  * <p>A query method of a repository may have a parameter of type
- * {@code Limit}. The parameter of type {@code Limit} must occur after the
+ * {@code Limit} if its return type indicates that it may return multiple
+ * entities. The parameter of type {@code Limit} must occur after the
  * method parameters representing regular parameters of the query itself.
  * For example,</p>
  *

--- a/api/src/main/java/jakarta/data/Order.java
+++ b/api/src/main/java/jakarta/data/Order.java
@@ -29,7 +29,8 @@ import jakarta.data.repository.Query;
  * <p>Requests sorting on various entity attributes.</p>
  *
  * <p>A query method of a repository may have a parameter of type
- * {@code Order}. The parameter of type {@code Order} must occur
+ * {@code Order} if its return type indicates that it may return
+ * multiple entities. The parameter of type {@code Order} must occur
  * after the method parameters representing regular parameters of
  * the query itself.</p>
  *

--- a/api/src/main/java/jakarta/data/Sort.java
+++ b/api/src/main/java/jakarta/data/Sort.java
@@ -32,7 +32,8 @@ import java.util.Objects;
  * and well-defined case sensitivity.</p>
  *
  * <p>A query method of a repository may have a parameter or parameters
- * of type {@code Sort}. Parameters of type {@code Sort} must occur after
+ * of type {@code Sort} if its return type indicates that it may return
+ * multiple entities. Parameters of type {@code Sort} must occur after
  * the method parameters representing regular parameters of the query
  * itself.</p>
  *

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -1121,7 +1121,12 @@ Refer to the Jakarta Data module JavaDoc section on "Return Types for Repository
 
 === Special Parameters for Limits, Sorting, and Pagination
 
-An <<Annotated Query methods,annotated>>, <<Parameter-based automatic query methods,parameter-based>>, or <<Query by Method Name,method name>> query method may have _special parameters_ of type `Limit`, `Order`, `Sort`, or `PageRequest`.
+An <<Annotated Query methods,annotated>>, <<Parameter-based automatic query methods,parameter-based>>, or <<Query by Method Name,method name>> query method may have _special parameters_ of type `Limit`, `Order`, `Sort`, or `PageRequest` if the method return type indicates that the method may return multiple entities, that is, if the return type is:
+
+- an array type,
+- `List` or `Stream`, or
+- `Page` or `CursoredPage`.
+
 A special parameter controls which query results are returned to the caller of a repository method, or in what order the results are returned:
 
 - a `Limit` allows the query results to be limited to a given range defined in terms of an offset and maximum number of results,


### PR DESCRIPTION
and re-dis-allow special parameters for repository methods returning a single entity.

This undoes the effect of 63686513.