### PR TITLE
minor changes to chapter 4

### DIFF
--- a/api/src/main/java/jakarta/data/Order.java
+++ b/api/src/main/java/jakarta/data/Order.java
@@ -52,8 +52,8 @@ import jakarta.data.repository.Query;
  * <p>When combined on a method with static sort criteria
  * ({@code OrderBy} keyword or {@link OrderBy} annotation or
  * {@link Query} with an {@code ORDER BY} clause), the static
- * sort criteria is applied first, followed by the dynamic sort criteria
- * that is defined by {@link Sort} instances in the order listed.</p>
+ * sort criteria are applied first, followed by the dynamic sort criteria
+ * that are defined by {@link Sort} instances in the order listed.</p>
  *
  * <p>In the example above, the matching employees are sorted first by salary
  * from highest to lowest. Employees with the same salary are then sorted

--- a/spec/src/main/asciidoc/query-language.asciidoc
+++ b/spec/src/main/asciidoc/query-language.asciidoc
@@ -2,7 +2,7 @@
 
 The Jakarta Data Query Language (JDQL) is a simple language designed to be used inside the `@Query` annotation to specify the semantics of query methods of Jakarta Data repositories. The language is in essence a subset of the widely-used Jakarta Persistence Query Language (JPQL), and thus a dialect of SQL. But, consistent with the goals of Jakarta Data, it is sufficiently limited in functionality that it is easily implementable across a wide variety of data storage technologies. Thus, the language defined in this chapter excludes features of JPQL which, while useful when the target datasource is a relational database, cannot be easily implemented on all non-relational datastores. In particular, the `from` clause of a Jakarta Data query may contain only a single entity.
 
-NOTE: A Jakarta Data provider backed by access to a relational database might choose to allow the use of a much larger subset of JPQL&mdash;or even the whole language&mdash;via the `@Query` annotation. Such extensions are not required by this specification.
+NOTE: A Jakarta Data provider backed by access to a relational database might choose to allow the use of a much larger subset of JPQL--or even the whole language--via the `@Query` annotation. Such extensions are not required by this specification.
 
 === Type system
 

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -1439,22 +1439,25 @@ The values of the entity attributes of the combined sort criteria define the cur
 
 Without cursor-based pagination, a Jakarta Data provider that is based on Jakarta Persistence might compose the following JPQL for the `findByZipcodeOrderByLastNameAscFirstNameAscIdAsc` repository method from the prior example:
 
-[source,jpql]
+[source,jpaql]
 ----
-SELECT o FROM Customer o WHERE (o.zipCode = ?1)
-                         ORDER BY o.lastName ASC, o.firstName ASC, o.id ASC
+FROM Customer
+WHERE (zipCode = ?1)
+ORDER BY lastName ASC, firstName ASC, id ASC
 ----
 
 When cursor-based pagination is used, the keys values from the `Cursor` of the `PageRequest` are available as query parameters, allowing the Jakarta Data provider to append additional query conditions. For example,
 
-[source,jpql]
+[source,jpaql]
 ----
-SELECT o FROM Customer o WHERE (o.zipCode = ?1)
-                           AND (   (o.lastName > ?2)
-                                OR (o.lastName = ?2 AND o.firstName > ?3)
-                                OR (o.lastName = ?2 AND o.firstName = ?3 AND o.id > ?4)
-                               )
-                         ORDER BY o.lastName ASC, o.firstName ASC, o.id ASC
+FROM Customer
+WHERE (zipCode = ?1)
+  AND (
+         lastName > ?2
+      OR lastName = ?2 AND firstName > ?3
+      OR lastName = ?2 AND firstName = ?3 AND id > ?4
+  )
+ORDER BY lastName ASC, firstName ASC, id ASC
 ----
 
 ===== Avoiding Missed and Duplicate Results

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -1224,11 +1224,11 @@ A repository method that is annotated with `@Query` with a value that does not c
 
 ==== Static Mechanisms for Sort Criteria
 
-Sort criteria is provided statically for a repository method by using the `OrderBy` keyword or by annotating the method with one or more `@OrderBy` annotations. The `OrderBy` keyword cannot be intermixed with the `@OrderBy` annotation or the `@Query` annotation. Static sort criteria takes precedence over dynamic sort criteria in that static sort criteria is evaluated first. When static sort criteria sorts entities to the same position, dynamic sort criteria is applied to further order those entities.
+Sort criteria are provided statically for a repository method by using the `OrderBy` keyword or by annotating the method with one or more `@OrderBy` annotations. The `OrderBy` keyword cannot be intermixed with the `@OrderBy` annotation or the `@Query` annotation. Static sort criteria takes precedence over dynamic sort criteria in that static sort criteria are evaluated first. When static sort criteria sorts entities to the same position, dynamic sort criteria are applied to further order those entities.
 
 ==== Dynamic Mechanisms for Sort Criteria
 
-Sort criteria is provided dynamically to repository methods either via `Sort` parameters or via a `PageRequest` or `Order` parameter that has one or more `Sort` values. `Sort` and `PageRequest` containing `Sort` must not both be provided to the same method. Similarly, `Order` and `PageRequest` containing `Sort` must not both be provided to the same method.
+Sort criteria are provided dynamically to repository methods either via `Sort` parameters or via a `PageRequest` or `Order` parameter that has one or more `Sort` values. `Sort` and `PageRequest` containing `Sort` must not both be provided to the same method. Similarly, `Order` and `PageRequest` containing `Sort` must not both be provided to the same method.
 
 ==== Examples of Sort Criteria Precedence
 

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -675,10 +675,10 @@ A concrete method may call other methods of the repository, including abstract m
 
 Every abstract method of the interface is usually either:
 
-- an entity instance _lifecycle method_,
-- an _annotated query method_,
-- an _automatic query method_ (with parameter-based conditions or Query by Method Name), or
-- a _resource accessor method_.
+- an entity instance <<Lifecycle methods,_lifecycle method_>>,
+- an <<Annotated Query methods,_annotated query method_>>,
+- an _automatic query method_ with <<Parameter-based automatic query methods,parameter-based conditions>> or <<Query by Method Name>>, or
+- a <<Resource accessor methods,_resource accessor method_>>.
 
 A repository may declare lifecycle methods for a single entity type, or for multiple related entity types.
 Similarly, a repository might have query methods which return different entity types.
@@ -687,9 +687,9 @@ A repository interface may inherit methods from a superinterface.
 A Jakarta Data implementation must treat inherited abstract methods as if they were directly declared by the repository interface.
 For example, a repository interface may inherit the `CrudRepository` interface defined by this specification.
 
-Repositories perform operations on entities. For repository methods that are annotated with `@Insert`, `@Update`, `@Save`, or `@Delete`, the entity type is determined from the method parameter type.  For `find` and `delete` methods where the return type is an entity, array of entity, or parameterized type such as `List<MyEntity>` or `Page<MyEntity>`, the entity type is determined from the method return type.  For `count`, `exists`, and other `delete` methods that do not return the entity or accept the entity as a parameter, the entity type cannot be determined from the method signature and a primary entity type must be defined for the repository.
+Repositories perform operations on entities. For repository methods that are annotated with `@Insert`, `@Update`, `@Save`, or `@Delete`, the entity type is determined from the method parameter type.  For `find` and `delete` methods where the return type is an entity, array of entity, or parameterized type such as `List<MyEntity>` or `Page<MyEntity>`, the entity type is determined from the method return type.  For `count`, `exists`, and other `delete` methods that do not return the entity or accept the entity as a parameter, the entity type cannot be determined from the method signature and a _primary entity type_ must be defined for the repository.
 
-Users of Jakarta Data declare a primary entity type for a repository by inheriting from a built-in repository super interface, such as `BasicRepository`, and specifying the primary entity type as the first type variable. For repositories that do not inherit from a super interface with a type parameter to indicate the primary entity type, life cycle methods on the repository determine the primary entity type. To do so, all life cycle methods where the method parameter is a type, an array of type, or is parameterized with a type that is annotated as an entity, must correspond to the same entity type. The primary entity type is assumed for methods that do not otherwise specify an entity type, such as `countByPriceLessThan`. Methods that require a primary entity type raise `MappingException` if a primary entity type is not provided.
+Users of Jakarta Data declare a primary entity type for a repository by inheriting from a built-in repository super interface, such as `BasicRepository`, and specifying the primary entity type as the first type variable. For repositories that do not inherit from a super interface with a type parameter to indicate the primary entity type, lifecycle methods on the repository determine the primary entity type. To do so, all lifecycle methods where the method parameter is a type, an array of type, or is parameterized with a type that is annotated as an entity, must correspond to the same entity type. The primary entity type is assumed for methods that do not otherwise specify an entity type, such as `countByPriceLessThan`. Methods that require a primary entity type raise `MappingException` if a primary entity type is not provided.
 
 
 NOTE: A Jakarta Data provider might go beyond what is required by this specification and support abstract methods which do not fall into any of the above categories. Such functionality is not defined by this specification, and so applications with repositories which declare such methods are not portable between providers.
@@ -1668,11 +1668,11 @@ It should be noted, the above result is different than what would be retrieved w
 
 The following order, with the lower number having higher precedence, is used when interpreting the meaning of repository methods.
 
-1. If the method is a Java default method, then its provided implementation is used.
-2. If the method has a _Resource Accessor Method_ return type, then the method is implemented as a _Resource Accessor Method_.
-3. If the method is annotated with `@Query`, then the method is implemented to run the corresponding Query Language query.
-4. If the method is annotated with `@Find` or a _Life Cycle_ annotation that defines the type of operation (`@Insert`, `@Update`, `@Save`, `@Delete`), then the annotation determines how the method is implemented, along with any applicable data access related annotations that are present on method parameters, according to the _Automatic Query Method_ with _Parameter-based Conditions_ pattern.
-5. If the method is named according to the _Query by Method Name_ naming conventions, then the implementation follows the _Query by Method Name_ pattern.
+1. If the method is a Java `default` method, then its provided implementation is used.
+2. If the method has a <<Resource accessor methods,_resource accessor method_>> return type recognized by the Jakarta Data provider, then the method is implemented as a resource accessor method.
+3. If the method is annotated with a <<Annotated Query methods,query annotation>> recognized by the Jakarta Data provider, such as `@Query`, then the method is implemented to execute the query specified by the query annotation.
+4. If the method is annotated with an <<Parameter-based automatic query methods,automatic query annotation>>, such as `@Find`, or with a <<Lifecycle methods,lifecycle annotation>> declaring the type of operation, for example, with `@Insert`, `@Update`, `@Save`, or `@Delete`, and the provider recognizes the annotation, then the annotation determines how the method is implemented, possibly with the help of other annotations present on the method parameters, for example, any `@By` annotations of the parameters.
+5. If the method is named according to the conventions of _Query by Method Name_, then the implementation follows the <<Query by Method Name,_Query by Method Name_>> pattern.
 
 A repository method that does not fit any of the above patterns and is not handled as a vendor-specific extension to the specification must either result in an error at build time or raise `UnsupportedOperationException` at run time.
 


### PR DESCRIPTION
- add xrefs
- uniformity in capitalization and lifecycle vs life cycle
- clarify 4.10 to properly generalize precedence to cover provider-defined annotations
- clean up a code example that made JPQL look bad
- "criteria" is a plural noun