### PR TITLE
Update the Javadoc of @Query after merge of JDQL

### DIFF
--- a/api/src/main/java/jakarta/data/page/CursoredPage.java
+++ b/api/src/main/java/jakarta/data/page/CursoredPage.java
@@ -120,7 +120,7 @@ import java.util.NoSuchElementException;
  * <p>For example:</p>
  *
  * <pre>
- * &#64;Query("SELECT o FROM Customer o WHERE (o.ordersPlaced &gt;= ?1 OR o.totalSpent &gt;= ?2)")
+ * &#64;Query("WHERE (ordersPlaced &gt;= ?1 OR totalSpent &gt;= ?2)")
  * &#64;OrderBy("zipcode")
  * &#64;OrderBy("birthYear")
  * &#64;OrderBy("id")

--- a/api/src/main/java/jakarta/data/page/CursoredPage.java
+++ b/api/src/main/java/jakarta/data/page/CursoredPage.java
@@ -120,8 +120,8 @@ import java.util.NoSuchElementException;
  * {@code @OrderBy("zipcode")}
  * {@code @OrderBy("birthYear")}
  * {@code @OrderBy("id")}
- * {@code CursoredPage<Customer> getTopBuyers(int minOrders, float minSpent,
- *                                     {@code PageRequest<Customer> pageRequest);}
+ * {@code CursoredPage<Customer>} getTopBuyers(int minOrders, float minSpent,
+ *                                     {@code PageRequest<Customer>} pageRequest);
  * </pre>
  *
  * <p>Only queries which return entities may be used with cursor-based pagination

--- a/api/src/main/java/jakarta/data/page/CursoredPage.java
+++ b/api/src/main/java/jakarta/data/page/CursoredPage.java
@@ -102,6 +102,28 @@ import java.util.NoSuchElementException;
  * existing entities are modified or if an entity is re-added with different
  * sort criteria after having previously been removed.</p>
  *
+ * <h2>Cursor-based Pagination with {@code @Query}</h2>
+ *
+ * <p>Cursor-based pagination involves generating and appending additional
+ * restrictions involving the key fields to the {@code WHERE} clause of the
+ * query. For this to be possible, a user-provided JDQL or JPQL query must
+ * end with a {@code WHERE} clause to which additional conditions may be
+ * appended.</p>
+ *
+ * <p>Sorting criteria must be specified independently of the user-provided
+ * query, either via the {@link OrderBy} annotation or, or by passing
+ * {@link Sort} criteria within the {@linkplain PageRequest#sorts() page
+ * request}. For example:</p>
+ *
+ * <pre>
+ * {@code @Query("WHERE ordersPlaced >= ?1 OR totalSpent >= ?2")}
+ * {@code @OrderBy("zipcode")}
+ * {@code @OrderBy("birthYear")}
+ * {@code @OrderBy("id")}
+ * {@code CursoredPage<Customer> getTopBuyers(int minOrders, float minSpent,
+ *                                     {@code PageRequest<Customer> pageRequest);}
+ * </pre>
+ *
  * <p>Only queries which return entities may be used with cursor-based pagination
  * because cursors are created from the entity attribute values that
  * form the unique key.</p>

--- a/api/src/main/java/jakarta/data/page/CursoredPage.java
+++ b/api/src/main/java/jakarta/data/page/CursoredPage.java
@@ -102,32 +102,6 @@ import java.util.NoSuchElementException;
  * existing entities are modified or if an entity is re-added with different
  * sort criteria after having previously been removed.</p>
  *
- * <h2>Cursor-based Pagination with {@code @Query}</h2>
- *
- * <p>Cursor-based pagination involves generating and appending additional
- * restrictions involving the key fields to the {@code WHERE} clause of the
- * query. For this to be possible, a user-provided JDQL or JPQL query must
- * end with a {@code WHERE} clause to which additional conditions may be
- * appended without otherwise changing the semantics of the query:</p>
- * <ul>
- * <li>The entire conditional expression of the {@code WHERE} clause must
- *     be enclosed in parentheses.
- * <li>Sorting criteria must be specified independently of the user-provided
- *     query, either via the {@link OrderBy} annotation or, or by passing
- *     {@link Sort} criteria within the {@linkplain PageRequest#sorts() page
- *     request}.
- * </ul>
- * <p>For example:</p>
- *
- * <pre>
- * &#64;Query("WHERE (ordersPlaced &gt;= ?1 OR totalSpent &gt;= ?2)")
- * &#64;OrderBy("zipcode")
- * &#64;OrderBy("birthYear")
- * &#64;OrderBy("id")
- * CursoredPage&lt;Customer&gt; getTopBuyers(int minOrders, float minSpent,
- *                                         {@code PageRequest<Customer>} pageRequest);
- * </pre>
- *
  * <p>Only queries which return entities may be used with cursor-based pagination
  * because cursors are created from the entity attribute values that
  * form the unique key.</p>

--- a/api/src/main/java/jakarta/data/repository/OrderBy.java
+++ b/api/src/main/java/jakarta/data/repository/OrderBy.java
@@ -57,7 +57,7 @@ import java.lang.annotation.Target;
  * numeric values means smaller numbers before larger numbers and for
  * string values means {@code A} before {@code Z}.</p>
  *
- * <p>A repository method with an {@code @OrderBy} annotation may not
+ * <p>A repository method with an {@code @OrderBy} annotation must not
  * have:</p>
  * <ul>
  * <li>the <em>Query by Method Name</em> {@code OrderBy} keyword in its

--- a/api/src/main/java/jakarta/data/repository/OrderBy.java
+++ b/api/src/main/java/jakarta/data/repository/OrderBy.java
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
  * <p>When multiple {@code OrderBy} annotations are specified on a
  * repository method, the precedence for sorting follows the order
  * in which the {@code OrderBy} annotations are specified,
- * and after that follows any sort criteria that is supplied
+ * and after that follows any sort criteria that are supplied
  * dynamically by {@link Sort} parameters, any {@link Order} parameter,
  * or by a {@link PageRequest} parameter with
  * {@linkplain PageRequest#sorts() sorting criteria}.</p>
@@ -57,12 +57,17 @@ import java.lang.annotation.Target;
  * numeric values means smaller numbers before larger numbers and for
  * string values means {@code A} before {@code Z}.</p>
  *
- * <p>A repository method will fail if an {@code OrderBy} annotation is
- * specified in combination with any of:</p>
+ * <p>A repository method with an {@code @OrderBy} annotation may not
+ * have:</p>
  * <ul>
- * <li>an {@code OrderBy} keyword</li>
- * <li>a {@link Query} annotation that contains an {@code ORDER BY} clause.</li>
+ * <li>the <em>Query by Method Name</em> {@code OrderBy} keyword in its
+ *     name, nor</li>
+ * <li>a {@link Query @Query} annotation specifying a JDQL or JPQL query
+ *     with an {@code ORDER BY} clause.</li>
  * </ul>
+ * <p>A Jakarta Data provider is permitted to reject such a repository
+ * method declaration at compile time or to implement the method to
+ * throw {@link UnsupportedOperationException}.</p>
  *
  * <p>A repository method will fail with a
  * {@link jakarta.data.exceptions.DataException DataException}

--- a/api/src/main/java/jakarta/data/repository/Param.java
+++ b/api/src/main/java/jakarta/data/repository/Param.java
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
  * {@code @Repository}
  * public interface Products extends BasicRepository{@code <Product, String>} {
  *
- *     {@code @Query("WHERE (p.length * p.width * p.height <= :maxVolume)")}
+ *     {@code @Query("WHERE length * width * height <= :maxVolume")}
  *     {@code Page<Product>} freeShippingEligible({@code @Param}("maxVolume") float volumeLimit,
  *                                        {@code PageRequest<?>} pageRequest);
  *

--- a/api/src/main/java/jakarta/data/repository/Param.java
+++ b/api/src/main/java/jakarta/data/repository/Param.java
@@ -40,10 +40,9 @@ import java.lang.annotation.Target;
  * }
  * </pre>
  *
- * <p>The {@code Param} annotation is unnecessary when the method parameter name
- * matches the query language named parameter name and the application is compiled with the
- * {@code -parameters} compiler option that makes parameter names available
- * at runtime.</p>
+ * <p>The {@code Param} annotation is unnecessary when the method parameter name matches the query language
+ * named parameter name and the application is compiled with the {@code -parameters} compiler option making
+ * parameter names available at runtime.</p>
  *
  * @see Query
  */

--- a/api/src/main/java/jakarta/data/repository/Param.java
+++ b/api/src/main/java/jakarta/data/repository/Param.java
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
  * {@code @Repository}
  * public interface Products extends BasicRepository{@code <Product, String>} {
  *
- *     {@code @Query("SELECT p from Products p WHERE (p.length * p.width * p.height <= :maxVolume)")}
+ *     {@code @Query("WHERE (p.length * p.width * p.height <= :maxVolume)")}
  *     {@code Page<Product>} freeShippingEligible({@code @Param}("maxVolume") float volumeLimit,
  *                                        {@code PageRequest<?>} pageRequest);
  *

--- a/api/src/main/java/jakarta/data/repository/Query.java
+++ b/api/src/main/java/jakarta/data/repository/Query.java
@@ -20,6 +20,7 @@ package jakarta.data.repository;
 import jakarta.data.Sort;
 import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
+import jakarta.data.page.PageRequest;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -27,29 +28,49 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * <p>Annotates a repository method to specify a query string such as SQL, JPQL, Cypher etc. to execute.</p>
+ * <p>Annotates a repository method as a query method, specifying a query written in Jakarta Data Query Language (JDQL)
+ * or in Jakarta Persistence Query Language (JPQL). A Jakarta Data provider is not required to support the complete JPQL
+ * language, which targets relational data stores.</p>
  *
- * <p>Jakarta Data providers for relational databases must support
- * JPQL queries if backed by a Jakarta Persistence provider,
- * and otherwise must support SQL queries.</p>
+ * <p>The required {@link #value} member specifies the JDQL or JPQL query as a string. When {@linkplain Page pagination}
+ * is used, the {@link #count} member optionally specifies a query which returns the total number of elements satisfying
+ * the query.</p>
  *
- * <h2>Parameters</h2>
+ * <p>For {@code select} statements, the return type of the query method must be consistent with the type returned by
+ * the query. For {@code update} or {@code delete} statements, it must be {@code void}, {@code int} or {@code long}.</p>
  *
- * <p>The query language can used named parameters or positional parameters.</p>
+ * <p>Compared to SQL, JDQL allows an abbreviated syntax for {@code select} statements:</p>
+ * <ul>
+ * <li>The {@code from} clause is optional in JDQL. When it is missing, the queried entity is determined by the return
+ *     type of the repository method, or, if the return type is not an entity type, by the primary entity type of the
+ *     repository.</li>
+ * <li>The {@code select} clause is optional in both JDQL and JPQL. When it is missing, the query returns the queried
+ *     entity.</li>
+ * </ul>
  *
- * <p><b>Named parameters</b> are referred to by name within the query language.
- * The {@link Param} annotation annotates method parameters to bind them to a named parameter name.
- * The {@code Param} annotation is unnecessary for named parameters when the method parameter name
- * matches the query language named parameter name and the application is compiled with the
- * {@code -parameters} compiler option that makes parameter names available
- * at runtime. When the {@code Param} annotation is not used, the Jakarta Data provider must
- * interpret the query by scanning for the delimiter that is used for positional parameters.
- * If the delimiter appears for another purpose in a query that requires named parameters,
- * it might be necessary for the application to explicitly define the {@code Param} in order to
- * disambiguate.</p>
+ * <p>A query might involve:</p>
+ * <ul>
+ * <li>named parameters of form {@code :name} where the labels {@code name} are legal Java identifiers, or </li>
+ * <li>ordinal parameters of form {@code ?n} where the labels {@code n} are sequential positive integers starting
+ *     from {@code 1}.</li>
+ * </ul>
+ * <p>A given query may not mix named and ordinal parameters.</p>
  *
- * <p><b>Positional parameters</b> are referred to by a number that corresponds to the
- * numerical position, starting with 1, of the repository method parameters.</p>
+ * <p>Each parameter of an annotated query method must either:</p>
+ * <ul>
+ * <li>have exactly the same name (the parameter name in the Java source, or a name assigned by {@link Param @Param})
+ *     and type as a named parameter of the query,</li>
+ * <li>have exactly the same type and position within the parameter list of the method as a positional parameter of the
+ *     query, or</li>
+ * <li>be of type {@code Limit}, {@code Order}, {@code PageRequest}, or {@code Sort}.</li>
+ * </ul>
+ *
+ * <p>The {@link Param} annotation associates a method parameter with a named parameter. The {@code Param} annotation is
+ * unnecessary when the method parameter name matches the name of a named parameter and the application is compiled with
+ * the {@code -parameters} compiler option making parameter names available at runtime.</p>
+ *
+ * <p>A method parameter is associated with an ordinal parameter by its position in the method parameter list. The first
+ * parameter of the method is associated with the ordinal parameter {@code ?1}.</p>
  *
  * <p>For example,</p>
  *
@@ -57,12 +78,20 @@ import java.lang.annotation.Target;
  * {@code @Repository}
  * public interface People extends CrudRepository{@code <Person, Long>} {
  *
- *     // JPQL using positional parameters
- *     {@code @Query("SELECT p from Person p WHERE (EXTRACT(YEAR FROM p.birthday) = ?1)")}
+ *     // JDQL with positional parameters
+ *     {@code @Query("where firstName = ?1 and lastName = ?2")}
+ *     {@code List<Person>} byName(String first, String last);
+ *
+ *     // JDQL with a named parameter
+ *     {@code @Query("where firstName || ' ' || lastName like :pattern")}
+ *     {@code List<Person>} byName(String pattern);
+ *
+ *     // JPQL using a positional parameter
+ *     {@code @Query("from Person where extract(year from birthdate) = ?1")}
  *     {@code List<Person>} bornIn(int year);
  *
  *     // JPQL using named parameters
- *     {@code @Query("SELECT DISTINCT p.name from Person p WHERE (LENGTH(p.name) >= :min AND LENGTH(p.name) <= :max)")}
+ *     {@code @Query("select distinct name from Person where length(name) >= :min and length(name) <= :max")}
  *     {@code Page<String>} namesOfLength({@code @Param}("min") int minLength,
  *                                {@code @Param}("max") int maxLength,
  *                                {@code PageRequest<Person>} pageRequest);
@@ -71,13 +100,12 @@ import java.lang.annotation.Target;
  * }
  * </pre>
  *
- * <h2>Return Types</h2>
- *
- * <p>Some query languages such as JPQL can be used to return a type other than the
- * entity class, as shown in the above example, resulting in a {@link Page} that is
- * parameterized with the query result type rather than the entity class.
- * to request a subsequent page, use the {@link Page#nextPageRequest(Class)} method
- * to specify the entity class. For example,</p>
+ * <p>A query with an explicit {@code select} clause may return a type other than the entity class, as shown in the
+ * example above, resulting in a {@link Page} parameterized with a query result type different to the queried entity
+ * type when pagination is used. This results in a mismatch between the {@link Page} type returned by the repository
+ * method and the {@link PageRequest} type accepted by the repository method. Therefore, a client must use the method
+ * {@link Page#nextPageRequest(Class)}, explicitly specifying the entity class, to obtain the next page of results. For
+ * example,</p>
  *
  * <pre>
  * {@code Page<String>} page2 = people.namesOfLength(5, 10, page1.nextPageRequest(Person.class));
@@ -94,30 +122,30 @@ import java.lang.annotation.Target;
 public @interface Query {
 
     /**
-     * <p>Defines the query to be executed when the annotated method is called.</p>
+     * <p>Specifies the query executed by the annotated repository method,
+     * in JDQL or JPQL.</p>
      *
-     * <p>If an application defines a repository method with {@code @Query}
-     * and supplies other forms of sorting (such as {@link Sort}) to that method,
-     * then it is the responsibility of the application to compose the query in
-     * such a way that an {@code ORDER BY} clause (or query language equivalent)
-     * can be validly appended. The Jakarta Data provider is not expected to
-     * parse query language that is provided by the application.</p>
+     * <p>If the annotated repository method accepts other forms of sorting
+     * (such as a parameter of type {@link Sort}), it is the responsibility
+     * of the application programmer to compose the query so that an
+     * {@code ORDER BY} clause can be validly appended to the text of the
+     * query.</p>
      *
      * @return the query to be executed when the annotated method is called.
      */
     String value();
 
     /**
-     * <p>Defines an additional query that counts the number of elements that are
-     * returned by the {@link #value() primary} query. This is used to compute
-     * the {@link Page#totalElements total elements} and {@link Page#totalPages
-     * total pages} for paginated repository queries which are annotated with
-     * {@code @Query} and return a {@link Page} or {@link CursoredPage}.</p>
+     * <p>Specifies an additional query that counts the number of elements
+     * returned by the {@linkplain #value() primary query} and is used
+     * to compute the {@linkplain Page#totalElements total elements} and
+     * {@linkplain Page#totalPages total pages} for paginated repository
+     * methods returning {@link Page} or {@link CursoredPage}.</p>
      *
-     * <p>The default value of empty string indicates that no counting query
-     * is provided. A counting query is unnecessary when pagination is
-     * performed with {@link jakarta.data.page.PageRequest#withoutTotal()} or
-     * when pagination is not used at all.</p>
+     * <p>The additional query is optional. It is not used when pagination
+     * is performed with {@link PageRequest#withoutTotal()} or when the
+     * repository method returns a type other than {@link Page} or
+     * {@link CursoredPage}.</p>
      *
      * @return a query for counting the number of elements across all pages.
      *         Empty string indicates that no counting query is provided.

--- a/api/src/main/java/jakarta/data/repository/Query.java
+++ b/api/src/main/java/jakarta/data/repository/Query.java
@@ -54,7 +54,7 @@ import java.lang.annotation.Target;
  * <li>ordinal parameters of form {@code ?n} where the labels {@code n} are sequential positive integers starting
  *     from {@code 1}.</li>
  * </ul>
- * <p>A given query may not mix named and ordinal parameters.</p>
+ * <p>A given query must not mix named and ordinal parameters.</p>
  *
  * <p>Each parameter of an annotated query method must either:</p>
  * <ul>

--- a/api/src/main/java/jakarta/data/repository/Query.java
+++ b/api/src/main/java/jakarta/data/repository/Query.java
@@ -18,7 +18,6 @@
 package jakarta.data.repository;
 
 import jakarta.data.Sort;
-import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 

--- a/api/src/main/java/jakarta/data/repository/Query.java
+++ b/api/src/main/java/jakarta/data/repository/Query.java
@@ -32,9 +32,7 @@ import java.lang.annotation.Target;
  * or in Jakarta Persistence Query Language (JPQL). A Jakarta Data provider is not required to support the complete JPQL
  * language, which targets relational data stores.</p>
  *
- * <p>The required {@link #value} member specifies the JDQL or JPQL query as a string. When {@linkplain Page pagination}
- * is used, the {@link #count} member optionally specifies a query which returns the total number of elements satisfying
- * the query.</p>
+ * <p>The required {@link #value} member specifies the JDQL or JPQL query as a string.</p>
  *
  * <p>For {@code select} statements, the return type of the query method must be consistent with the type returned by
  * the query. For {@code update} or {@code delete} statements, it must be {@code void}, {@code int} or {@code long}.</p>
@@ -147,22 +145,5 @@ public @interface Query {
      * @return the query to be executed when the annotated method is called.
      */
     String value();
-
-    /**
-     * <p>Specifies an additional query that counts the number of elements
-     * returned by the {@linkplain #value() primary query} and is used
-     * to compute the {@linkplain Page#totalElements total elements} and
-     * {@linkplain Page#totalPages total pages} for paginated repository
-     * methods returning {@link Page} or {@link CursoredPage}.</p>
-     *
-     * <p>The additional query is optional. It is not used when pagination
-     * is performed with {@link PageRequest#withoutTotal()} or when the
-     * repository method returns a type other than {@link Page} or
-     * {@link CursoredPage}.</p>
-     *
-     * @return a query for counting the number of elements across all pages.
-     *         Empty string indicates that no counting query is provided.
-     */
-    String count() default "";
 }
 

--- a/api/src/main/java/jakarta/data/repository/Query.java
+++ b/api/src/main/java/jakarta/data/repository/Query.java
@@ -29,7 +29,10 @@ import java.lang.annotation.Target;
 /**
  * <p>Annotates a repository method as a query method, specifying a query written in Jakarta Data Query Language (JDQL)
  * or in Jakarta Persistence Query Language (JPQL). A Jakarta Data provider is not required to support the complete JPQL
- * language, which targets relational data stores.</p>
+ * language, which targets relational data stores. However, a given provider might offer a subset of JPQL which goes
+ * beyond the subset required by JDQL, or might even offer vendor-specific extensions to JDQL which target particular
+ * capabilities of the target data store technology. Such extensions come with no guarantee of portability between
+ * providers, nor between databases.</p>
  *
  * <p>The required {@link #value} member specifies the JDQL or JPQL query as a string.</p>
  *

--- a/api/src/main/java/jakarta/data/repository/Query.java
+++ b/api/src/main/java/jakarta/data/repository/Query.java
@@ -100,6 +100,19 @@ import java.lang.annotation.Target;
  * }
  * </pre>
  *
+ * <p>A method annotated with {@code @Query} must return one of the following types:</p>
+ * <ul>
+ *     <li>the query result type {@code R}, when the query returns a single result,</li>
+ *     <li>{@code Optional<R>}, when the query returns at most a single result,</li>
+ *     <li>an array type {@code R[]},
+ *     <li>{@code List<R>},</li>
+ *     <li>{@code Stream<R>}, or</li>
+ *     <li>{@code Page<R>} or {@code CursoredPage<R>}.</li>
+ * </ul>
+ * <p>The method returns an object for every query result. If the return type of the annotated method is {@code R} or
+ * {@code Optional<R>}, and the query returns more than one element when executed, the method must throw
+ * {@link jakarta.data.exceptions.NonUniqueResultException}.</p>
+ *
  * <p>A query with an explicit {@code select} clause may return a type other than the entity class, as shown in the
  * example above, resulting in a {@link Page} parameterized with a query result type different to the queried entity
  * type when pagination is used. This results in a mismatch between the {@link Page} type returned by the repository

--- a/api/src/main/java/jakarta/data/repository/Query.java
+++ b/api/src/main/java/jakarta/data/repository/Query.java
@@ -18,6 +18,7 @@
 package jakarta.data.repository;
 
 import jakarta.data.Sort;
+import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 
@@ -123,10 +124,6 @@ import java.lang.annotation.Target;
  * <pre>
  * {@code Page<String>} page2 = people.namesOfLength(5, 10, page1.nextPageRequest(Person.class));
  * </pre>
- *
- * <p>A Jakarta Data provider is permitted to support features of JPQL which go beyond the subset required by JDQL, even
- * when the provider does not provide a complete implementation of JPQL. A provider which does support such extensions
- * to JDQL might place restrictions on whether or how they may be used together with cursor-based pagination.</p>
  *
  * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Insert}, {@code @Update}, {@code @Delete}, and
  * {@code @Save} are mutually-exclusive. A given method of a repository interface may have at most one {@code @Find}

--- a/api/src/main/java/jakarta/data/repository/Query.java
+++ b/api/src/main/java/jakarta/data/repository/Query.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
 /**
  * <p>Annotates a repository method as a query method, specifying a query written in Jakarta Data Query Language (JDQL)
  * or in Jakarta Persistence Query Language (JPQL). A Jakarta Data provider is not required to support the complete JPQL
- * language, which targets relational data stores. However, a given provider might offer a subset of JPQL which goes
+ * language, which targets relational data stores. However, a given provider might offer features of JPQL which go
  * beyond the subset required by JDQL, or might even offer vendor-specific extensions to JDQL which target particular
  * capabilities of the target data store technology. Such extensions come with no guarantee of portability between
  * providers, nor between databases.</p>

--- a/api/src/main/java/jakarta/data/repository/Query.java
+++ b/api/src/main/java/jakarta/data/repository/Query.java
@@ -18,7 +18,6 @@
 package jakarta.data.repository;
 
 import jakarta.data.Sort;
-import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 
@@ -121,6 +120,10 @@ import java.lang.annotation.Target;
  * <pre>
  * {@code Page<String>} page2 = people.namesOfLength(5, 10, page1.nextPageRequest(Person.class));
  * </pre>
+ *
+ * <p>A Jakarta Data provider is permitted to support features of JPQL which go beyond the subset required by JDQL, even
+ * when the provider does not provide a complete implementation of JPQL. A provider which does support such extensions
+ * to JDQL might place restrictions on whether or how they may be used together with cursor-based pagination.</p>
  *
  * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Insert}, {@code @Update}, {@code @Delete}, and
  * {@code @Save} are mutually-exclusive. A given method of a repository interface may have at most one {@code @Find}

--- a/api/src/main/java/jakarta/data/repository/Repository.java
+++ b/api/src/main/java/jakarta/data/repository/Repository.java
@@ -40,7 +40,7 @@ import java.lang.annotation.Target;
  *     &#64;OrderBy("price")
  *     List&lt;Product&gt; findByNameLike(String namePattern);
  *
- *     &#64;Query("UPDATE Product o SET o.price = o.price - (o.price * ?1) WHERE o.price * ?1 &lt;= ?2")
+ *     &#64;Query("UPDATE Product SET price = price - (price * ?1) WHERE price * ?1 &lt;= ?2")
  *     int putOnSale(float rateOfDiscount, float maxDiscount);
  *
  *     ...

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -69,7 +69,7 @@ import jakarta.data.repository.Update;
  *     &#64;OrderBy("price")
  *     List&lt;Product&gt; findByNameIgnoreCaseLikeAndPriceLessThan(String namePattern, float max);
  *
- *     &#64;Query("UPDATE Product o SET o.price = o.price * (1.0 - ?1) WHERE o.yearProduced &lt;= ?2")
+ *     &#64;Query("UPDATE Product SET price = price * (1.0 - ?1) WHERE yearProduced &lt;= ?2")
  *     int discountOldInventory(float rateOfDiscount, int maxYear);
  *
  *     ...
@@ -149,7 +149,7 @@ import jakarta.data.repository.Update;
  *     &#64;OrderBy("address.zipCode")
  *     List&lt;Purchase&gt; findByAddressZipCodeIn(List&lt;Integer&gt; zipCodes);
  *
- *     &#64;Query("SELECT o FROM Purchase o WHERE o.address.zipCode=?1")
+ *     &#64;Query("WHERE address.zipCode = ?1")
  *     List&lt;Purchase&gt; forZipCode(int zipCode);
  *
  *     &#64;Save
@@ -666,7 +666,7 @@ import jakarta.data.repository.Update;
  * The results may even be limited to a positioned range. For example,</p>
  *
  * <pre>
- * &#64;Query("SELECT o FROM Products o WHERE (o.fullPrice - o.salePrice) / o.fullPrice &gt;= ?1 ORDER BY o.salePrice DESC")
+ * &#64;Query("WHERE (fullPrice - salePrice) / fullPrice &gt;= ?1 ORDER BY salePrice DESC")
  * Product[] highlyDiscounted(float minPercentOff, Limit limit);
  *
  * ...

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -494,7 +494,7 @@ The rule for concatenating compound names depends on the context, and is specifi
 
 |`@Query` | Path expression within query
 |`.`
-|`@Query("SELECT o FROM Order o WHERE o.address.zipCode=?1")`
+|`@Query("FROM Order WHERE address.zipCode = ?1")`
 
 |_Query by Method Name_ | Method name
 |`_`
@@ -797,7 +797,7 @@ Page<Book> booksByTitle(String title, PageRequest<Book> pageRequest);
 
 [source,java]
 ----
-@Query("SELECT p FROM Product p WHERE p.name=:prodname")
+@Query("where p.name = :prodname")
 Optional<Product> findByName(@Param("prodname") String name);
 ----
 
@@ -1251,7 +1251,7 @@ Page<User> findByNameStartsWith(String namePrefix, PageRequest<User> pagination)
 List<User> findByNameStartsWith(String namePrefix, Sort<?>... sorts);
 
 // Sorts first by name. When name is the same, applies the PageRequest's sort criteria
-@Query("SELECT u FROM User u WHERE (u.age > ?1)")
+@Query("WHERE (u.age > ?1)")
 @OrderBy("name")
 CursoredPage<User> olderThan(int age, PageRequest<User> pagination);
 ----
@@ -1486,7 +1486,7 @@ Here is an example where an application uses `@Query` to provide a partial query
 ----
 @Repository
 public interface CustomerRepository extends BasicRepository<Customer, Long> {
-  @Query("SELECT o FROM Customer o WHERE (o.totalSpent / o.totalPurchases > ?1)")
+  @Query("WHERE (o.totalSpent / o.totalPurchases > ?1)")
   CursoredPage<Customer> withAveragePurchaseAbove(float minimum, PageRequest<Customer> pageRequest);
 }
 ----

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -1486,7 +1486,7 @@ Here is an example where an application uses `@Query` to provide a partial query
 ----
 @Repository
 public interface CustomerRepository extends BasicRepository<Customer, Long> {
-  @Query("WHERE (o.totalSpent / o.totalPurchases > ?1)")
+  @Query("WHERE totalSpent / totalPurchases > ?1")
   CursoredPage<Customer> withAveragePurchaseAbove(float minimum, PageRequest<Customer> pageRequest);
 }
 ----


### PR DESCRIPTION
This was now very out of date, and I forgot about it in #520.

Also caught some more instances of 'run time' -> 'runtime', 'life cycle' -> 'lifecycle'.