### PR TITLE
change Iterable<E> to List<E> in lifecycle method signatures

### DIFF
--- a/api/src/main/java/jakarta/data/exceptions/OptimisticLockingFailureException.java
+++ b/api/src/main/java/jakarta/data/exceptions/OptimisticLockingFailureException.java
@@ -22,7 +22,7 @@ import jakarta.data.repository.BasicRepository;
 /**
  * Indicates a failure that is due to inconsistent state between the entity and the database.
  * For example, {@link BasicRepository#delete(Object) delete(entity)}
- * or {@link BasicRepository#deleteAll(Iterable) deleteAll(entities)}
+ * or {@link BasicRepository#deleteAll(java.util.List) deleteAll(entities)}
  * where the entity Id no longer exists in the database or the entity is versioned and the
  * version no longer matches the version in the database.
  */

--- a/api/src/main/java/jakarta/data/repository/BasicRepository.java
+++ b/api/src/main/java/jakarta/data/repository/BasicRepository.java
@@ -21,6 +21,7 @@ import jakarta.data.exceptions.OptimisticLockingFailureException;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -131,7 +132,7 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
      * @throws NullPointerException If either the iterable is null or any element is null.
      */
     @Save
-    <S extends T> Iterable<S> saveAll(Iterable<S> entities);
+    <S extends T> List<S> saveAll(List<S> entities);
 
     /**
      * Retrieves an entity by its Id.
@@ -232,6 +233,6 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
      * @throws NullPointerException If the iterable is {@code null} or contains {@code null} elements.
      */
     @Delete
-    void deleteAll(Iterable<? extends T> entities);
+    void deleteAll(List<? extends T> entities);
 
 }

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -20,6 +20,8 @@ package jakarta.data.repository;
 import jakarta.data.exceptions.EntityExistsException;
 import jakarta.data.exceptions.OptimisticLockingFailureException;
 
+import java.util.List;
+
 /**
  * <p>A built-in repository supertype for performing Create, Read, Update, and Delete (CRUD) operations.</p>
  *
@@ -130,7 +132,7 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * @throws NullPointerException if the iterable is null or any element is null.
      */
     @Insert
-    <S extends T> Iterable<S> insertAll(Iterable<S> entities);
+    <S extends T> List<S> insertAll(List<S> entities);
 
     /**
      * <p>Modifies an entity that already exists in the database.</p>
@@ -177,6 +179,6 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * @throws NullPointerException if either the supplied {@code Iterable} is null or any element is null.
      */
     @Update
-    <S extends T> Iterable<S> updateAll(Iterable<S> entities);
+    <S extends T> List<S> updateAll(List<S> entities);
 
 }

--- a/api/src/main/java/jakarta/data/repository/Delete.java
+++ b/api/src/main/java/jakarta/data/repository/Delete.java
@@ -39,7 +39,7 @@ import java.lang.annotation.Target;
  * </p>
  * <ul>
  *     <li>the class of the entity to be deleted, or</li>
- *     <li>{@code Iterable<E>} or {@code E[]} where {@code E} is the class of the entities to be deleted.</li>
+ *     <li>{@code List<E>} or {@code E[]} where {@code E} is the class of the entities to be deleted.</li>
  * </ul>
  * <p>The annotated method must be declared {@code void}.
  * </p>

--- a/api/src/main/java/jakarta/data/repository/Insert.java
+++ b/api/src/main/java/jakarta/data/repository/Insert.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
  * </p>
  * <ul>
  *     <li>the class of the entity to be inserted, or</li>
- *     <li>{@code Iterable<E>} or {@code E[]} where {@code E} is the class of the entities to be inserted.</li>
+ *     <li>{@code List<E>} or {@code E[]} where {@code E} is the class of the entities to be inserted.</li>
  * </ul>
  * <p>The annotated method must either be declared {@code void}, or have a return type that is the same as the type of
  * its parameter.

--- a/api/src/main/java/jakarta/data/repository/Save.java
+++ b/api/src/main/java/jakarta/data/repository/Save.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
  * </p>
  * <ul>
  *     <li>the class of the entity to be inserted or updated, or</li>
- *     <li>{@code Iterable<E>} or {@code E[]} where {@code E} is the class of the entities to be inserted or updated.</li>
+ *     <li>{@code List<E>} or {@code E[]} where {@code E} is the class of the entities to be inserted or updated.</li>
  * </ul>
  * <p>The annotated method must either be declared {@code void}, or have a return type that is the same as the type of
  * its parameter.

--- a/api/src/main/java/jakarta/data/repository/Update.java
+++ b/api/src/main/java/jakarta/data/repository/Update.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
  * </p>
  * <ul>
  *     <li>the class of the entity to be updated, or</li>
- *     <li>{@code Iterable<E>} or {@code E[]} where {@code E} is the class of the entities to be updated.</li>
+ *     <li>{@code List<E>} or {@code E[]} where {@code E} is the class of the entities to be updated.</li>
  * </ul>
  * <p>The annotated method must either be declared {@code void}, or have a return type that is the same as the type of
  * its parameter.

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -200,7 +200,7 @@ import jakarta.data.repository.Update;
  *
  * <ul>
  * <li>the class of the entity, or</li>
- * <li>{@code Iterable<E>} or {@code E[]} where {@code E} is the class of the
+ * <li>{@code List<E>} or {@code E[]} where {@code E} is the class of the
  *     entities.</li>
  * </ul>
  *

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -725,7 +725,7 @@ void lifecycle(Entity e);
 Entity lifecycle(Entity e);
 ----
 
-where `Lifecycle` is a lifecycle annotation, `lifecycle` is the arbitrary name of the method, and `Entity` is either `E`, `Iterable<E>`, or `E[]`, where `E` is a concrete entity class.
+where `Lifecycle` is a lifecycle annotation, `lifecycle` is the arbitrary name of the method, and `Entity` is either `E`, `List<E>`, or `E[]`, where `E` is a concrete entity class.
 
 This specification defines four built-in lifecycle annotations: `@Insert`, `@Update`, `@Delete`, and `@Save`. The semantics of these annotations is defined in their Javadoc.
 

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -210,7 +210,7 @@ public class EntityTests {
         TestPropertyUtility.waitForEventualConsistency();
 
         // BasicRepository.deleteAll(Iterable)
-        boxes.deleteAll(Set.of(box1, box2));
+        boxes.deleteAll(List.of(box1, box2));
 
         TestPropertyUtility.waitForEventualConsistency();
 
@@ -338,7 +338,7 @@ public class EntityTests {
         TestPropertyUtility.waitForEventualConsistency();
 
         // BasicRepository.deleteAll(Iterable)
-        boxes.deleteAll(Set.of(box1, box2));
+        boxes.deleteAll(List.of(box1, box2));
 
         TestPropertyUtility.waitForEventualConsistency();
 

--- a/tck/src/main/java/ee/jakarta/tck/data/web/validation/Rectangles.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/web/validation/Rectangles.java
@@ -33,7 +33,7 @@ public interface Rectangles extends DataRepository<Rectangle, String> {
     Rectangle save(@Valid Rectangle entity);
 
     @Save
-    Iterable<Rectangle> saveAll(@Valid Iterable<Rectangle> entities);
+    List<Rectangle> saveAll(@Valid List<Rectangle> entities);
     
     @PositiveOrZero
     long countBy();


### PR DESCRIPTION
This is way more friendly to both users and implementors.

`Iterable` is an absolute PITA to work with, both for users, when a method returns `Iterable`, and for implementors, when a method accepts it. And there are no interesting types which implement `Iterable` but not `Collection`.

Now, I considered making the substitution `Iterable` -> `Collection`, but really all that allows is `Set`s. And here, in lifecycle methods, `Set` actually has the wrong semantics, because the returned values are correlated with input values by their order.

So `List` is really the right thing to use here!