### PR TITLE
TCK tests broken by removal of alias for id

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/Catalog.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/Catalog.java
@@ -15,11 +15,14 @@
  */
 package ee.jakarta.tck.data.standalone.persistence;
 
+import static jakarta.data.repository.By.ID;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 import jakarta.data.Order;
+import jakarta.data.repository.By;
 import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Find;
@@ -61,7 +64,8 @@ public interface Catalog extends DataRepository<Product, String> {
     @Save
     void save(Product product);
 
-    void deleteById(String productNum);
+    @Delete
+    void deleteById(@By(ID) String productNum);
 
     long deleteByProductNumLike(String pattern);
 
@@ -77,16 +81,16 @@ public interface Catalog extends DataRepository<Product, String> {
 
     Stream<Product> findByDepartmentsEmpty();
 
-    List<Product> findByIdBetween(String first, String last, Order<Product> sorts);
-
     List<Product> findByNameLike(String name);
-    
-    List<Product> findByProductNumLike(String productNum);
 
     @OrderBy(value = "price", descending = true)
     Stream<Product> findByPriceNotNullAndPriceLessThanEqual(double maxPrice);
 
     List<Product> findByPriceNull();
+
+    List<Product> findByProductNumBetween(String first, String last, Order<Product> sorts);
+
+    List<Product> findByProductNumLike(String productNum);
 
     EntityManager getEntityManager();
 

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/PersistenceEntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/PersistenceEntityTests.java
@@ -124,7 +124,7 @@ public class PersistenceEntityTests {
         catalog.save(Product.of("banana", 0.49, "TEST-PROD-17", Department.GROCERY));
         catalog.save(Product.of("plum", 0.89, "TEST-PROD-18", Department.GROCERY));
 
-        Iterable<Product> found = catalog.findByIdBetween("TEST-PROD-13", "TEST-PROD-17", Order.by(Sort.asc("name")));
+        Iterable<Product> found = catalog.findByProductNumBetween("TEST-PROD-13", "TEST-PROD-17", Order.by(Sort.asc("name")));
         Iterator<Product> it = found.iterator();
         assertEquals(true, it.hasNext());
         assertEquals("banana", it.next().getName());
@@ -256,7 +256,7 @@ public class PersistenceEntityTests {
         // Remove only the entities that actually exist in the database
         catalog.removeMultiple(strawberries, blueberries, raspberries);
 
-        Iterable<Product> remaining = catalog.findByIdBetween("TEST-PROD-95", "TEST-PROD-99", Order.by());
+        Iterable<Product> remaining = catalog.findByProductNumBetween("TEST-PROD-95", "TEST-PROD-99", Order.by());
         assertEquals(false, remaining.iterator().hasNext());
     }
 


### PR DESCRIPTION
TCK tests that were using the Id alias for methods like `findByIdBetween` and their own custom `deleteById` method were broken by the removal of the Id alias from the spec. This pull updates them.