### PR TITLE
fix broken emdashes in PDF output

### DIFF
--- a/spec/src/main/asciidoc/jakarta-ee.adoc
+++ b/spec/src/main/asciidoc/jakarta-ee.adoc
@@ -116,7 +116,7 @@ This integration between CDI and Jakarta Data allows for seamless management of 
 
 ==== CDI Extensions for Jakarta Data providers
 
-In environments where CDI Full or CDI Lite is available, Jakarta Data providers can make use of a CDI extension&mdash;an implementation of `jakarta.enterprise.inject.spi.Extension` or `jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension`&mdash;to discover interfaces annotated with `@Repository` and make their implementations available for injection.
+In environments where CDI Full or CDI Lite is available, Jakarta Data providers can make use of a CDI extension--an implementation of `jakarta.enterprise.inject.spi.Extension` or `jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension`--to discover interfaces annotated with `@Repository` and make their implementations available for injection.
 
 NOTE: Jakarta Data does not mandate the use of a specific kind of CDI extension but places the general requirement on the Jakarta Data provider to arrange for injection of the provided repository implementation into injection points typed to the repository interface and having no qualifiers (other than `Default` or `Any`), as described above.
 


### PR DESCRIPTION
I messed up my asciidoc syntax: `&mdash;` doesn't work in the PDF.