### PR TITLE
Downgrade the maven-gpg-plugin to 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,7 +282,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.1</version>
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>


### PR DESCRIPTION
We failed in the last deploys: https://ci.eclipse.org/data/job/jakarta-data-deploy/

I found out that it happens after upgrading the maven-gpg-plugin.

I will do the downgrade and rerun the build.