### PR TITLE
Revert "chore(deps): Bump org.apache.maven.plugins:maven-gpg-plugin from 3.1.0 to 3.2.1"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,7 +282,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.1</version>
+                        <version>3.1.0</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>


### PR DESCRIPTION
Reverts jakartaee/data#581

This is preventing the M4 release.