### PR TITLE
compile with -parameters

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -70,4 +70,19 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>


### PR DESCRIPTION
We should compile the library with `-parameters`, to avoid seeing things like `arg0` in code generated from the built-in repository supertypes.

I don't use Maven, and so I don't know how to make this work, but we should do something like it.