### PR TITLE
TCK tests for literals in query language

### DIFF
--- a/spec/src/antlr/JDQL.g4
+++ b/spec/src/antlr/JDQL.g4
@@ -85,7 +85,7 @@ state_field_path_expression : IDENTIFIER ('.' IDENTIFIER)*;
 
 entity_name : IDENTIFIER; // no ambiguity
 
-enum_literal : IDENTIFIER; // ambiguity with state_field_path_expression resolvable semantically
+enum_literal : IDENTIFIER ('.' IDENTIFIER)*; // ambiguity with state_field_path_expression resolvable semantically
 
 input_parameter : ':' IDENTIFIER | '?' INTEGER;
 

--- a/spec/src/main/asciidoc/query-language.asciidoc
+++ b/spec/src/main/asciidoc/query-language.asciidoc
@@ -120,7 +120,7 @@ When executed, a parameter expression evaluates to the argument supplied to the 
 
 ==== Enum literals
 
-An _enum literal expression_ is a Java identifier, with syntax specified by `enum_literal`, and may only occur as the right operand of a `set` assignment or `=`/`<>` equality comparison. It is assigned the type of the left operand of the assignment or comparison. The type must be a Java `enum` type, and the identifier must be the name of an enumerated value of the `enum` type. For example, `day <> MONDAY` is a legal comparison expression.
+An _enum literal expression_ is a Java identifier, with syntax specified by `enum_literal`, and may only occur as the right operand of a `set` assignment or `=`/`<>` equality comparison. It is assigned the type of the left operand of the assignment or comparison. The type must be a Java `enum` type, and the identifier must be the name of an enumerated value of the `enum` type including the fully qualified Java enum class name. For example, `day <> java.time.DayOfWeek.MONDAY` is a legal comparison expression.
 
 When executed, an enum expression evaluates to the named member of the Java `enum` type.
 

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
@@ -27,6 +27,7 @@ import jakarta.data.page.PageRequest;
 import jakarta.data.repository.By;
 import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Find;
+import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
 
@@ -70,6 +71,9 @@ public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long>, I
 
     Optional<AsciiCharacter> findFirstByHexadecimalStartsWithAndIsControlOrderByIdAsc(String firstHexDigit, boolean isControlChar);
 
+    @Query("WHERE hexadecimal <> ' ORDER BY isn''t a keyword when inside a literal' AND hexadecimal IN ('4a', '4b', '4c', ?1)")
+    Stream<AsciiCharacter> jklOr(String hex);
+
     default Stream<AsciiCharacter> retrieveAlphaNumericIn(long minId, long maxId) {
         return findByIdBetween(minId, maxId, Sort.asc("id"))
                         .filter(c -> Character.isLetterOrDigit(c.getThisCharacter()));
@@ -77,4 +81,7 @@ public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long>, I
 
     @Save
     Iterable<AsciiCharacter> saveAll(Iterable<AsciiCharacter> characters);
+
+    @Query("SELECT COUNT(THIS) WHERE numericValue <= 97 AND numericValue >= 74")
+    int twentyFour();
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers.java
@@ -15,6 +15,7 @@
  */
 package ee.jakarta.tck.data.framework.read.only;
 
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import jakarta.data.Limit;
@@ -23,6 +24,7 @@ import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import jakarta.data.repository.BasicRepository;
+import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 
 import ee.jakarta.tck.data.framework.read.only.NaturalNumber.NumberType;
@@ -58,4 +60,9 @@ public interface NaturalNumbers extends BasicRepository<NaturalNumber, Long>, Id
                                                                        long maxSqrtFloor,
                                                                        PageRequest<NaturalNumber> pagination);
 
+    @Query("SELECT id WHERE isOdd = true AND id BETWEEN 21 AND ?1 ORDER BY id ASC")
+    Page<Long> oddsFrom21To(long max, PageRequest<NaturalNumber> pageRequest);
+
+    @Query("WHERE isOdd = false AND numType = ee.jakarta.tck.data.framework.read.only.NaturalNumber.NumberType.PRIME")
+    Optional<NaturalNumber> two();
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -1159,6 +1159,54 @@ public class EntityTests {
         assertEquals(false, it.hasNext());
     }
 
+    @Assertion(id = "458", strategy = "Use a repository method with a JDQL Query that specifies an enum literal and a boolean false literal.")
+    public void testLiteralEnumAndLiteralFalse() {
+
+        NaturalNumber two = numbers.two().orElseThrow();
+
+        assertEquals(2L, two.getId());
+        assertEquals(NumberType.PRIME, two.getNumType());
+        assertEquals(Short.valueOf((short) 2), two.getNumBitsRequired());
+    }
+
+    @Assertion(id = "458", strategy = "Use a repository method with a JDQL Query that specifies literal Integer values.")
+    public void testLiteralInteger() {
+
+        assertEquals(24, characters.twentyFour());
+    }
+
+    @Assertion(id = "458", strategy = "Use a repository method with a JDQL Query that specifies literal String values.")
+    public void testLiteralString() {
+
+        assertEquals(List.of('J', 'K', 'L', 'M'),
+                     characters.jklOr("4d")
+                                     .map(AsciiCharacter::getThisCharacter)
+                                     .sorted()
+                                     .collect(Collectors.toList()));
+    }
+
+    @Assertion(id = "458", strategy = "Use a repository method with a JDQL Query that specifies a boolean true literal.")
+    public void testLiteralTrue() {
+        Page<Long> page1 = numbers.oddsFrom21To(40L, PageRequest.ofSize(5));
+
+        assertEquals(10L, page1.totalElements());
+        assertEquals(2L, page1.totalPages());
+
+        assertEquals(List.of(21L, 23L, 25L, 27L, 29L), page1.content());
+
+        assertEquals(true, page1.hasNext());
+
+        Page<Long> page2 = numbers.oddsFrom21To(40L, page1.nextPageRequest(NaturalNumber.class));
+
+        assertEquals(List.of(31L, 33L, 35L, 37L, 39L), page2.content());
+
+        if (page2.hasNext()) {
+            Page<Long> page3 = numbers.oddsFrom21To(40L, page2.nextPageRequest(NaturalNumber.class));
+            assertEquals(false, page3.hasContent());
+            assertEquals(false, page3.hasNext());
+        }
+    }
+
     @Assertion(id = "133",
                strategy = "Use a repository method with two Sort parameters specifying a mixture of ascending and descending order, " +
                           "and verify all results are returned and are ordered according to the sort criteria.")


### PR DESCRIPTION
Add TCK tests for literals defined by the Jakarta Data Query Language.

While testing this, I noticed that we did not comply with [Jakarta Persistence 3.2 M2 specification]( https://jakarta.ee/specifications/persistence/3.2/jakarta-persistence-spec-3.2-m2#literals) regarding how enum literals and so I fixed that as well.