### PR TITLE
TCK tests for boolean operators and parenthesis

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
@@ -71,6 +71,13 @@ public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long>, I
 
     Optional<AsciiCharacter> findFirstByHexadecimalStartsWithAndIsControlOrderByIdAsc(String firstHexDigit, boolean isControlChar);
 
+    @Query("select thisCharacter where hexadecimal like '4_'" +
+           " and hexadecimal not like '%0'" +
+           " and thisCharacter not in ('E', 'G')" +
+           " and id not between 72 and 78" +
+           " order by id asc")
+    char[] getABCDFO();
+
     @Query("WHERE hexadecimal <> ' ORDER BY isn''t a keyword when inside a literal' AND hexadecimal IN ('4a', '4b', '4c', ?1)")
     Stream<AsciiCharacter> jklOr(String hex);
 

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/PositiveIntegers.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/PositiveIntegers.java
@@ -27,6 +27,8 @@ import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import jakarta.data.repository.Find;
+import jakarta.data.repository.Param;
+import jakarta.data.repository.Query;
 import jakarta.data.repository.BasicRepository;
 import jakarta.data.repository.Repository;
 
@@ -62,4 +64,14 @@ public interface PositiveIntegers extends BasicRepository<NaturalNumber, Long> {
 
     @Find
     List<NaturalNumber> findOdd(boolean isOdd, NumberType numType, Limit limit, Order<NaturalNumber> sorts);
+
+    @Query("Select id Where isOdd = true and (id = :id or id < :exclusiveMax) Order by id Desc")
+    List<Long> oddAndEqualToOrBelow(long id, long exclusiveMax);
+
+    // Per the spec: The 'and' operator has higher precedence than 'or'.
+    @Query("WHERE numBitsRequired = :bits OR numType = :type AND id < :xmax")
+    CursoredPage<NaturalNumber> withBitCountOrOfTypeAndBelow(@Param("bits") int bitsRequired,
+                                                             @Param("type") NumberType numberType,
+                                                             @Param("xmax") long exclusiveMax,
+                                                             PageRequest<?> pageRequest);
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -1349,6 +1349,83 @@ public class EntityTests {
         assertEquals(false, customRepo.existsByIdIn(Set.of(-10L, -12L, -14L)));
     }
 
+    @Assertion(id = "458", strategy = "Use a repository method with a JDQL query that uses the NOT operator with LIKE, IN, and BETWEEN.")
+    public void testQueryWithNot() {
+
+        // 'NOT LIKE' excludes '@'
+        // 'NOT IN' excludes 'E' and 'G'
+        // 'NOT BETWEEN' excludes 'H' through 'N'.
+        assertEquals("ABCDFO", String.valueOf(characters.getABCDFO()));
+    }
+
+    @Assertion(id = "458", strategy = "Use a repository method with a JDQL query that relies on the OR operator.")
+    public void testQueryWithOr() {
+        PageRequest<?> page1Request = PageRequest.ofSize(4).sortBy(Sort.desc("numBitsRequired"), Sort.asc("id"));
+        CursoredPage<NaturalNumber> page1;
+
+        try {
+            page1 = positives.withBitCountOrOfTypeAndBelow(4,
+                                                           NumberType.COMPOSITE, 20L,
+                                                           page1Request);
+        } catch (UnsupportedOperationException x) {
+            // Test passes: Jakarta Data providers must raise UnsupportedOperationException when the database
+            // is not capable of cursor-based pagination.
+            return;
+        }
+
+        assertEquals(List.of(16L, 18L, 8L, 9L),
+                     page1.stream()
+                                     .map(NaturalNumber::getId)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(true, page1.hasTotals());
+        assertEquals(3L, page1.totalPages());
+        assertEquals(12L, page1.totalElements());
+        assertEquals(true, page1.hasNext());
+
+        CursoredPage<NaturalNumber> page2;
+
+        try {
+            page2 = positives.withBitCountOrOfTypeAndBelow(4,
+                                                           NumberType.COMPOSITE, 20L,
+                                                           page1.nextPageRequest());
+        } catch (UnsupportedOperationException x) {
+            // Test passes: Jakarta Data providers must raise UnsupportedOperationException when the database
+            // is not capable of cursor-based pagination.
+            return;
+        }
+
+        assertEquals(List.of(10L, 11L, 12L, 13L),
+                     page2.stream()
+                                     .map(NaturalNumber::getId)
+                                     .collect(Collectors.toList()));
+
+        assertEquals(true, page2.hasNext());
+
+        CursoredPage<NaturalNumber> page3 = positives.withBitCountOrOfTypeAndBelow(4,
+                                                                                   NumberType.COMPOSITE, 20L,
+                                                                                   page2.nextPageRequest());
+
+        assertEquals(List.of(14L, 15L, 4L, 6L),
+                     page3.stream()
+                                     .map(NaturalNumber::getId)
+                                     .collect(Collectors.toList()));
+
+        if (page3.hasNext()) {
+            CursoredPage<NaturalNumber> page4 = positives.withBitCountOrOfTypeAndBelow(4,
+                                                                                       NumberType.COMPOSITE, 20L,
+                                                                                       page3.nextPageRequest());
+            assertEquals(false, page4.hasContent());
+        }
+    }
+
+    @Assertion(id = "458", strategy = "Use a repository method with a JDQL query that uses parenthesis to make OR be evaluated before AND.")
+    public void testQueryWithParenthesis() {
+
+        assertEquals(List.of(15L, 7L, 5L, 3L, 1L),
+                     positives.oddAndEqualToOrBelow(15L, 9L));
+    }
+
     @Assertion(id = "133", strategy = "Use a repository method that returns a single entity value where a single result is found.")
     public void testSingleEntity() {
         AsciiCharacter ch = characters.findByHexadecimalIgnoreCase("2B");


### PR DESCRIPTION
Add TCK tests for the `OR` operator, `NOT` operator, precedence for evaluating the `AND` operator ahead of the `OR` operator, and the use of parenthesis to control the order of evaluation.