### PR TITLE
TCK must use JDQL rather than JPQL for Query

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/Catalog.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/Catalog.java
@@ -71,13 +71,13 @@ public interface Catalog extends DataRepository<Product, String> {
 
     int countBySurgePriceGreaterThanEqual(Double price);
 
-    @Query("SELECT p FROM Product p WHERE (SIZE(p.departments) = ?1 AND p.price < ?2) ORDER BY p.name")
-    List<Product> findByDepartmentCountAndPriceBelow(int numDepartments, double maxPrice);
-
     @OrderBy("name")
     Product[] findByDepartmentsContains(Department department);
 
     Stream<Product> findByDepartmentsEmpty();
+
+    @Query("WHERE LENGTH(name) = ?1 AND price < ?2 ORDER BY name")
+    List<Product> findByNameLengthAndPriceBelow(int nameLength, double maxPrice);
 
     List<Product> findByNameLike(String name);
 
@@ -107,7 +107,7 @@ public interface Catalog extends DataRepository<Product, String> {
 //        return query.getSingleResult();
 //    }
 
-    @Query("SELECT o FROM Product o WHERE (:rate * o.price <= :max AND :rate * o.price >= :min) ORDER BY o.name")
+    @Query("FROM Product WHERE (:rate * price <= :max AND :rate * price >= :min) ORDER BY name")
     Stream<Product> withTaxBetween(@Param("min") double mininunTaxAmount,
                                    @Param("max") double maximumTaxAmount,
                                    @Param("rate") double taxRate);

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/PersistenceEntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/PersistenceEntityTests.java
@@ -313,17 +313,18 @@ public class PersistenceEntityTests {
         catalog.save(Product.of("basketball", 14.88, "TEST-PROD-76", Department.SPORTING_GOODS));
         catalog.save(Product.of("baseball cap", 12.99, "TEST-PROD-77", Department.SPORTING_GOODS, Department.CLOTHING));
 
-        List<Product> found = catalog.findByDepartmentCountAndPriceBelow(2, 100.0);
+        List<Product> found = catalog.findByNameLengthAndPriceBelow(10, 100.0);
 
-        assertEquals(List.of("baseball cap", "toothpaste"),
+        assertEquals(List.of("basketball", "toothpaste"),
                      found.stream().map(Product::getName).collect(Collectors.toList()));
 
-        found = catalog.findByDepartmentCountAndPriceBelow(3, 10000.0);
+        found = catalog.findByNameLengthAndPriceBelow(8, 1000.0);
 
         assertEquals(List.of("sunblock"),
                      found.stream().map(Product::getName).collect(Collectors.toList()));
 
         assertEquals(7L, catalog.deleteByProductNumLike("TEST-PROD-%"));
+
     }
 
     @Assertion(id = "133", strategy = "Insert, update, and delete an entity with a generated version.")


### PR DESCRIPTION
With the addition of JDQL, it became optional for Jakarta Data providers that are backed by Jakarta Persistence to support JPQL, so TCK tests of `@Query` need to be updated to switch over to JDQL.  This pull converts the two remaining occurrences.