### PR TITLE
TCK tests for queries without all clauses

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import jakarta.data.Limit;
 import jakarta.data.Order;
 import jakarta.data.Sort;
 import jakarta.data.page.Page;
@@ -38,6 +39,12 @@ import jakarta.data.repository.Save;
  */
 @Repository
 public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long>, IdOperations<AsciiCharacter> {
+
+    @Query(" ") // it is valid to have a query with no clauses
+    Stream<AsciiCharacter> all(Limit limit, Sort<?>... sort);
+
+    @Query("ORDER BY id ASC")
+    Stream<AsciiCharacter> alphabetic(Limit limit);
 
     int countByHexadecimalNotNull();
 
@@ -85,6 +92,9 @@ public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long>, I
         return findByIdBetween(minId, maxId, Sort.asc("id"))
                         .filter(c -> Character.isLetterOrDigit(c.getThisCharacter()));
     }
+
+    @Query("SELECT thisCharacter ORDER BY id DESC")
+    char[] reverseAlphabetic(Limit limit);
 
     @Save
     List<AsciiCharacter> saveAll(List<AsciiCharacter> characters);

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
@@ -85,6 +85,9 @@ public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long>, I
            " order by id asc")
     char[] getABCDFO();
 
+    @Query("SELECT hexadecimal WHERE hexadecimal IS NOT NULL AND thisCharacter = ?1")
+    Optional<String> hex(char ch);
+
     @Query("WHERE hexadecimal <> ' ORDER BY isn''t a keyword when inside a literal' AND hexadecimal IN ('4a', '4b', '4c', ?1)")
     Stream<AsciiCharacter> jklOr(String hex);
 

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -463,6 +463,15 @@ public class EntityTests {
                      Arrays.toString(stream.map(number -> number.getId()).toArray()));
     }
 
+    @Assertion(id = "458", strategy = "Use a repository method with a JDQL query that has no clauses.")
+    public void testEmptyQuery() {
+
+        assertEquals(List.of('a', 'b', 'c', 'd', 'e', 'f'),
+                     characters.all(Limit.range(97, 102), Sort.asc("id"))
+                                     .map(AsciiCharacter::getThisCharacter)
+                                     .collect(Collectors.toList()));
+    }
+
     @Assertion(id = "133", strategy = "Use a repository method that returns a single entity value where no result is found. Expect EmptyResultException.")
     public void testEmptyResultException() {
         try {
@@ -1339,6 +1348,22 @@ public class EntityTests {
         assertEquals(false, page.iterator().hasNext());
         assertEquals(0L, page.totalElements());
         assertEquals(0L, page.totalPages());
+    }
+
+    @Assertion(id = "458", strategy = "Use a repository method with a JDQL query that consists of only an ORDER BY clause.")
+    public void testPartialQueryOrderBy() {
+
+        assertEquals(List.of('A', 'B', 'C', 'D', 'E', 'F'),
+                     characters.alphabetic(Limit.range(65, 70))
+                                     .map(AsciiCharacter::getThisCharacter)
+                                     .collect(Collectors.toList()));
+    }
+
+    @Assertion(id = "458", strategy = "Use a repository method with a JDQL query that consists of only the SELECT and ORDER BY clauses.")
+    public void testPartialQuerySelectAndOrderBy() {
+
+        assertEquals("zyxwvuts",
+                     String.valueOf(characters.reverseAlphabetic(Limit.range(6, 13))));
     }
 
     @Assertion(id = "133", strategy = "Use count and exists methods where the primary entity class is inferred from the lifecycle methods.")

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -1384,6 +1384,13 @@ public class EntityTests {
         assertEquals("ABCDFO", String.valueOf(characters.getABCDFO()));
     }
 
+    @Assertion(id = "458", strategy = "Use a repository method with a JDQL query that uses the NULL keyword.")
+    public void testQueryWithNull() {
+
+        assertEquals("4a", characters.hex('J').orElseThrow());
+        assertEquals("44", characters.hex('D').orElseThrow());
+    }
+
     @Assertion(id = "458", strategy = "Use a repository method with a JDQL query that relies on the OR operator.")
     public void testQueryWithOr() {
         PageRequest<?> page1Request = PageRequest.ofSize(4).sortBy(Sort.desc("numBitsRequired"), Sort.asc("id"));


### PR DESCRIPTION
TCK tests that have been have been added so far have a decent mixture of SELECT, FROM, and WHERE clauses in the absence of other clauses. This pull adds tests with ORDER BY on its own, and ORDER BY with SELECT, and a query without any clauses at all.  I also added a TCK test where the query includes the NULL keyword.