### PR TITLE
fix two typing errors in TCK

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
@@ -90,5 +90,5 @@ public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long>, I
     List<AsciiCharacter> saveAll(List<AsciiCharacter> characters);
 
     @Query("SELECT COUNT(THIS) WHERE numericValue <= 97 AND numericValue >= 74")
-    int twentyFour();
+    long twentyFour();
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/PositiveIntegers.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/PositiveIntegers.java
@@ -70,7 +70,7 @@ public interface PositiveIntegers extends BasicRepository<NaturalNumber, Long> {
 
     // Per the spec: The 'and' operator has higher precedence than 'or'.
     @Query("WHERE numBitsRequired = :bits OR numType = :type AND id < :xmax")
-    CursoredPage<NaturalNumber> withBitCountOrOfTypeAndBelow(@Param("bits") int bitsRequired,
+    CursoredPage<NaturalNumber> withBitCountOrOfTypeAndBelow(@Param("bits") short bitsRequired,
                                                              @Param("type") NumberType numberType,
                                                              @Param("xmax") long exclusiveMax,
                                                              PageRequest<?> pageRequest);

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -1365,7 +1365,7 @@ public class EntityTests {
         CursoredPage<NaturalNumber> page1;
 
         try {
-            page1 = positives.withBitCountOrOfTypeAndBelow(4,
+            page1 = positives.withBitCountOrOfTypeAndBelow((short) 4,
                                                            NumberType.COMPOSITE, 20L,
                                                            page1Request);
         } catch (UnsupportedOperationException x) {
@@ -1387,7 +1387,7 @@ public class EntityTests {
         CursoredPage<NaturalNumber> page2;
 
         try {
-            page2 = positives.withBitCountOrOfTypeAndBelow(4,
+            page2 = positives.withBitCountOrOfTypeAndBelow((short) 4,
                                                            NumberType.COMPOSITE, 20L,
                                                            page1.nextPageRequest());
         } catch (UnsupportedOperationException x) {
@@ -1403,7 +1403,7 @@ public class EntityTests {
 
         assertEquals(true, page2.hasNext());
 
-        CursoredPage<NaturalNumber> page3 = positives.withBitCountOrOfTypeAndBelow(4,
+        CursoredPage<NaturalNumber> page3 = positives.withBitCountOrOfTypeAndBelow((short) 4,
                                                                                    NumberType.COMPOSITE, 20L,
                                                                                    page2.nextPageRequest());
 
@@ -1413,7 +1413,7 @@ public class EntityTests {
                                      .collect(Collectors.toList()));
 
         if (page3.hasNext()) {
-            CursoredPage<NaturalNumber> page4 = positives.withBitCountOrOfTypeAndBelow(4,
+            CursoredPage<NaturalNumber> page4 = positives.withBitCountOrOfTypeAndBelow((short) 4,
                                                                                        NumberType.COMPOSITE, 20L,
                                                                                        page3.nextPageRequest());
             assertEquals(false, page4.hasContent());


### PR DESCRIPTION
1. the type of the count() function is Long in JPA (we should clarify this in JDQL b/c it is undefined)
2. we say that only things with the exact same type can be compared using =, <>, and friends