### PR TITLE
char[] -> Character[] in TCK query method return type

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
@@ -83,7 +83,7 @@ public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long>, I
            " and thisCharacter not in ('E', 'G')" +
            " and id not between 72 and 78" +
            " order by id asc")
-    char[] getABCDFO();
+    Character[] getABCDFO();
 
     @Query("SELECT hexadecimal WHERE hexadecimal IS NOT NULL AND thisCharacter = ?1")
     Optional<String> hex(char ch);
@@ -97,7 +97,7 @@ public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long>, I
     }
 
     @Query("SELECT thisCharacter ORDER BY id DESC")
-    char[] reverseAlphabetic(Limit limit);
+    Character[] reverseAlphabetic(Limit limit);
 
     @Save
     List<AsciiCharacter> saveAll(List<AsciiCharacter> characters);

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -1362,8 +1362,10 @@ public class EntityTests {
     @Assertion(id = "458", strategy = "Use a repository method with a JDQL query that consists of only the SELECT and ORDER BY clauses.")
     public void testPartialQuerySelectAndOrderBy() {
 
-        assertEquals("zyxwvuts",
-                     String.valueOf(characters.reverseAlphabetic(Limit.range(6, 13))));
+        Character[] chars = characters.reverseAlphabetic(Limit.range(6, 13));
+        for (int i=0; i<chars.length; i++) {
+            assertEquals("zyxwvuts".charAt(i), chars[i]);
+        }
     }
 
     @Assertion(id = "133", strategy = "Use count and exists methods where the primary entity class is inferred from the lifecycle methods.")

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -1381,7 +1381,11 @@ public class EntityTests {
         // 'NOT LIKE' excludes '@'
         // 'NOT IN' excludes 'E' and 'G'
         // 'NOT BETWEEN' excludes 'H' through 'N'.
-        assertEquals("ABCDFO", String.valueOf(characters.getABCDFO()));
+        Character[] abcdfo = characters.getABCDFO();
+        assertEquals(6, abcdfo.length);
+        for (int i = 0; i<abcdfo.length; i++) {
+            assertEquals("ABCDFO".charAt(i), abcdfo[i]);
+        }
     }
 
     @Assertion(id = "458", strategy = "Use a repository method with a JDQL query that uses the NULL keyword.")


### PR DESCRIPTION
The return type of these queries in JPQL is implicitly, by definitely, `List<Character>`, and Jakarta Data does not require conversion from `Character[]` to `char[]`.