### PR TITLE
TCK tests for JDQL UPDATE and DELETE

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/Coordinate.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/Coordinate.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.standalone.entity;
+
+import java.util.UUID;
+
+/**
+ * This entity includes some field types that aren't covered elsewhere in the TCK.
+ */
+@jakarta.persistence.Entity
+@jakarta.nosql.Entity
+public class Coordinate {
+    @jakarta.persistence.Id
+    @jakarta.nosql.Id
+    public UUID id;
+
+    @jakarta.nosql.Column
+    public double x;
+
+    @jakarta.nosql.Column
+    public float y;
+
+    public static Coordinate of(String id, double x, float y) {
+        Coordinate c = new Coordinate();
+        c.id = UUID.nameUUIDFromBytes(id.getBytes());
+        c.x = x;
+        c.y = y;
+        return c;
+    }
+
+    @Override
+    public String toString() {
+        return "Coordinate@" + Integer.toHexString(hashCode()) + "(" + x + "," + y + ")" + ":" + id;
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/MultipleEntityRepo.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/MultipleEntityRepo.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.standalone.entity;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import jakarta.data.repository.Insert;
+import jakarta.data.repository.Query;
+import jakarta.data.repository.Repository;
+
+/**
+ * A repository that performs operations on different types of entities.
+ */
+@Repository
+public interface MultipleEntityRepo { // Do not add a primary entity type.
+
+    // Methods for Box entity:
+
+    @Insert
+    Box[] addAll(Box... boxes);
+
+    @Query("DELETE FROM Box")
+    long removeAll();
+
+    @Query("UPDATE Box SET length = length + ?1, width = width - ?1, height = height * ?2")
+    long resizeAll(int lengthIncrementWidthDecrement, int heightFactor);
+
+    // Methods for Coordinate entity:
+
+    @Insert
+    Coordinate create(Coordinate c);
+
+    @Query("DELETE FROM Coordinate WHERE x > 0.0d AND y > 0.0f")
+    long deleteIfPositive();
+
+    @Query("UPDATE Coordinate SET x = :newX, y = y / :yDivisor WHERE id = :id")
+    boolean move(UUID id, double newX, float yDivisor);
+
+    @Query("WHERE id = ?1")
+    Optional<Coordinate> withUUID(UUID id);
+}


### PR DESCRIPTION
Add TCK tests for JDQL UPDATE and DELETE with and without a WHERE clause.
One of the tests uses a repository that handles multiple entity types where there is no primary entity type, relying on the FROM clause to identify the desired entity.  This also adds an additional entity to the TCK so that we can have some coverage for float, double, and UUID.