### PR TITLE
Remove commons-io Dependency

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -57,11 +57,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>${assertj.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,6 @@
         <jakarta.validation.version>3.1.0-M2</jakarta.validation.version>
 
         <apache.rat.version>0.16.1</apache.rat.version>
-        <commons.io.version>2.15.1</commons.io.version>
 
         <arquillian.version>1.8.0.Final</arquillian.version>
         <junit.version>5.10.2</junit.version>
@@ -114,11 +113,6 @@
                 <version>${mockito.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>commons-io</groupId>
-                <artifactId>commons-io</artifactId>
-                <version>${commons.io.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>


### PR DESCRIPTION
Looking at #608, I don't see any usage of commons io in the data github repo. From git blame, it looks like this was brought along in the initial version of the pom.xml, and either usage was removed at some point or never existed.

Unless anyone know of another reason this is included I think we should remove it.