### PR TITLE
clarify portability of @Query

### DIFF
--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -162,7 +162,8 @@ Or, using a positional parameter:
 void deleteBook(String isbn);
 ----
 
-Programs which make use of annotated query methods are not portable between providers.
+Programs which make use of annotated query methods are not in general portable between providers.
+However, when the `@Query` annotation specifies a query written in JDQL, the annotated query method is portable between providers to the extent to which its semantics can be implemented on the underlying data store.
 
 [NOTE]
 ====


### PR DESCRIPTION
Previously, `@Query` accepted any sort of query language. Now it is defined to accept JDQL, which is more portable.