### PR TITLE
TCK superinterface is no longer valid

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
@@ -38,7 +38,7 @@ import jakarta.data.repository.Save;
  * This interface is required to inherit only from DataRepository in order to satisfy a TCK scenario.
  */
 @Repository
-public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long>, IdOperations<AsciiCharacter> {
+public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long>, IdOperations {
 
     @Query(" ") // it is valid to have a query with no clauses
     Stream<AsciiCharacter> all(Limit limit, Sort<?>... sort);
@@ -65,6 +65,8 @@ public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long>, I
                                                                                  Order<AsciiCharacter> sorts);
 
     AsciiCharacter findByHexadecimalIgnoreCase(String hex);
+
+    Stream<AsciiCharacter> findByIdBetween(long minimum, long maximum, Sort<AsciiCharacter> sort);
 
     AsciiCharacter findByIsControlTrueAndNumericValueBetween(int min, int max);
 

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/IdOperations.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/IdOperations.java
@@ -16,25 +16,19 @@
 package ee.jakarta.tck.data.framework.read.only;
 
 import java.util.List;
-import java.util.stream.Stream;
 
 import jakarta.data.Limit;
 import jakarta.data.Order;
-import jakarta.data.Sort;
+import jakarta.data.repository.Query;
 
 /**
  * This interface contains common operations for the NaturalNumbers and AsciiCharacters repositories.
- *
- * @param <T> type of entity.
  */
-public interface IdOperations<T> {
-    Stream<T> findByIdBetween(long minimum, long maximum, Sort<T> sort);
+public interface IdOperations {
+    long countByIdBetween(long minimum, long maximum);
 
-    List<T> findByIdGreaterThanEqual(long minimum,
-                                           Limit limit,
-                                           Order<T> sorts);
+    boolean existsById(long id);
 
-    T[] findByIdLessThan(long exclusiveMax, Sort<T> primarySort, Sort<T> secondarySort);
-
-    List<T> findByIdLessThanEqual(long maximum, Order<T> sorts);
+    @Query("SELECT id WHERE id >= :inclusiveMin")
+    List<Long> withIdEqualOrAbove(long inclusiveMin, Limit limit, Order<?> sorts);
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers.java
@@ -15,11 +15,13 @@
  */
 package ee.jakarta.tck.data.framework.read.only;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 import jakarta.data.Limit;
 import jakarta.data.Order;
+import jakarta.data.Sort;
 import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
@@ -36,7 +38,7 @@ import ee.jakarta.tck.data.framework.read.only.NaturalNumber.NumberType;
  * TODO figure out a way to make this a ReadOnlyRepository instead.
  */
 @Repository
-public interface NaturalNumbers extends BasicRepository<NaturalNumber, Long>, IdOperations<NaturalNumber> {
+public interface NaturalNumbers extends BasicRepository<NaturalNumber, Long>, IdOperations {
 
     long countBy();
 
@@ -46,6 +48,14 @@ public interface NaturalNumbers extends BasicRepository<NaturalNumber, Long>, Id
     Stream<NaturalNumber> findByIdBetweenOrderByNumTypeAsc(long minimum,
                                                            long maximum,
                                                            Order<NaturalNumber> sorts);
+
+    List<NaturalNumber> findByIdGreaterThanEqual(long minimum,
+                                                 Limit limit,
+                                                 Order<NaturalNumber> sorts);
+
+    NaturalNumber[] findByIdLessThan(long exclusiveMax, Sort<NaturalNumber> primarySort, Sort<NaturalNumber> secondarySort);
+
+    List<NaturalNumber> findByIdLessThanEqual(long maximum, Sort<?>... sorts);
 
     Page<NaturalNumber> findByIdLessThanOrderByFloorOfSquareRootDesc(long exclusiveMax,
                                                                      PageRequest<NaturalNumber> pagination);


### PR DESCRIPTION
Recently, language was added to the spec which states:

> A superinterface of a repository interface must either:
>
> - be one of the built-in generic repository supertypes defined by this specification, `DataRepository`, `BasicRepository`, or `CrudRepository`, or
> - be a non-generic toplevel interface with no type parameters, whose abstract methods likewise declare no type parameters.

However, the TCK still has a test for a common superinterface that has a type parameter for the entity type.  I think this part of the TCK was written back when the primary entity type was the only possible entity that could be used by a repository.  In any case, it isn't valid anymore, and this pull updates the common superinterface into something that meets the above requirements.