### PR TITLE
remove a new test from TCK

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/IdOperations.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/IdOperations.java
@@ -15,6 +15,10 @@
  */
 package ee.jakarta.tck.data.framework.read.only;
 
+import java.util.List;
+
+import jakarta.data.Limit;
+import jakarta.data.repository.Query;
 /**
  * This interface contains common operations for the NaturalNumbers and AsciiCharacters repositories.
  */
@@ -22,4 +26,6 @@ public interface IdOperations {
     long countByIdBetween(long minimum, long maximum);
 
     boolean existsById(long id);
+    @Query("SELECT id WHERE id >= :inclusiveMin ORDER BY id ASC")
+    List<Long> withIdEqualOrAbove(long inclusiveMin, Limit limit);
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/IdOperations.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/IdOperations.java
@@ -15,12 +15,6 @@
  */
 package ee.jakarta.tck.data.framework.read.only;
 
-import java.util.List;
-
-import jakarta.data.Limit;
-import jakarta.data.Order;
-import jakarta.data.repository.Query;
-
 /**
  * This interface contains common operations for the NaturalNumbers and AsciiCharacters repositories.
  */
@@ -28,7 +22,4 @@ public interface IdOperations {
     long countByIdBetween(long minimum, long maximum);
 
     boolean existsById(long id);
-
-    @Query("SELECT id WHERE id >= :inclusiveMin")
-    List<Long> withIdEqualOrAbove(long inclusiveMin, Limit limit, Order<?> sorts);
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -405,16 +405,6 @@ public class EntityTests {
         assertEquals(false, numbers.existsById(-1L));
 
         assertEquals(false, characters.existsById(-2L));
-
-        assertEquals(List.of(68L, 69L, 70L, 71L, 72L),
-                     characters.withIdEqualOrAbove(68L, Limit.of(5), Order.by(Sort.asc("numericValue"), Sort.asc("id")))
-                                     .stream()
-                                     .collect(Collectors.toList()));
-
-        assertEquals(List.of(71L, 73L, 79L, 83L, 89L),
-                     numbers.withIdEqualOrAbove(68L, Limit.of(5), Order.by(Sort.asc("numType"), Sort.asc("id")))
-                                     .stream()
-                                     .collect(Collectors.toList()));
     }
 
     @Assertion(id = "133", strategy = "Use a repository method with Contains to query for a substring of a String attribute.")

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -405,6 +405,12 @@ public class EntityTests {
         assertEquals(false, numbers.existsById(-1L));
 
         assertEquals(false, characters.existsById(-2L));
+
+        assertEquals(List.of(68L, 69L, 70L, 71L, 72L),
+                     characters.withIdEqualOrAbove(68L, Limit.of(5)));
+
+        assertEquals(List.of(71L, 72L, 73L, 74L, 75L),
+                     numbers.withIdEqualOrAbove(71L, Limit.of(5)));
     }
 
     @Assertion(id = "133", strategy = "Use a repository method with Contains to query for a substring of a String attribute.")


### PR DESCRIPTION
This test, which was added yesterday, requires dynamically sorting by fields which are not `select`ed. As far as I know, the specification does not explicitly require this, and in traditional SQL, sorting by unselected fields is something that is not usually considered allowed, though it's true that many databases are quite forgiving here. 

Now, it's true that I didn't disallow this in JDQL, but there's a big difference between allowing it statically and allowing it for dynamically-added sorting. 

Actually I probably _should_ have disallowed it in JDQL, because in fact JPQL disallows it in section 4.10 of the latest Persistence spec. (Again, actually-existing JPQL implementations do allow it.) I will follow up with a PR that adds a caveat about this to section 5.5.5.

Folks, I think at this late stage we should try hard to avoid adding "weird" new corner-casey things like this to the TCK. Let's stick to bread-and-butter things which we know are supposed to work and leave stuff like this alone for now.

