### PR TITLE
make javadoc for Order and Sort consistent with spec

### DIFF
--- a/api/src/main/java/jakarta/data/Order.java
+++ b/api/src/main/java/jakarta/data/Order.java
@@ -23,7 +23,6 @@ import java.util.List;
 import jakarta.data.metamodel.StaticMetamodel;
 import jakarta.data.page.PageRequest;
 import jakarta.data.repository.OrderBy;
-import jakarta.data.repository.Query;
 
 /**
  * <p>Requests sorting on various entity attributes.</p>
@@ -49,11 +48,10 @@ import jakarta.data.repository.Query;
  *                                        .size(10));
  * </pre>
  *
- * <p>When combined on a method with static sort criteria
- * ({@code OrderBy} keyword or {@link OrderBy} annotation or
- * {@link Query} with an {@code ORDER BY} clause), the static
- * sort criteria are applied first, followed by the dynamic sort criteria
- * that are defined by {@link Sort} instances in the order listed.</p>
+ * <p>When combined on a method with static sort criteria ({@code OrderBy}
+ * keyword or {@link OrderBy @OrderBy} annotation, the static sort criteria
+ * are applied first, followed by the dynamic sort criteria that are defined
+ * by {@link Sort} instances in the order listed.</p>
  *
  * <p>In the example above, the matching employees are sorted first by salary
  * from highest to lowest. Employees with the same salary are then sorted

--- a/api/src/main/java/jakarta/data/Sort.java
+++ b/api/src/main/java/jakarta/data/Sort.java
@@ -20,7 +20,6 @@ package jakarta.data;
 import jakarta.data.metamodel.StaticMetamodel;
 import jakarta.data.page.PageRequest;
 import jakarta.data.repository.OrderBy;
-import jakarta.data.repository.Query;
 
 import java.util.Objects;
 
@@ -72,12 +71,11 @@ import java.util.Objects;
  * on its position with the list of criteria.</p>
  *
  * <p>A repository method may declare static sorting criteria using
- * the ({@code OrderBy} keyword or {@link OrderBy} annotation, or
- * using {@link Query} with an {@code ORDER BY} clause), and also
- * accept dynamic sorting criteria via its parameters. In this
- * situation, the static sorting criteria are applied first,
- * followed by any dynamic sorting criteria specified by instances
- * of {@code Sort} .</p>
+ * the ({@code OrderBy} keyword or {@link OrderBy @OrderBy} annotation,
+ * and also accept dynamic sorting criteria via its parameters. In this
+ * situation, the static sorting criteria are applied first, followed
+ * by any dynamic sorting criteria specified by instances of
+ * {@code Sort}.</p>
  *
  * <p>In the example above, the matching employees are sorted first by
  * salary from highest to lowest. Employees with the same salary are


### PR DESCRIPTION
(`Order` and `Sort` cannot be combined with a `@Query` with an `order by` clause.)