### PR TITLE
improve Query by Method Name doc

### DIFF
--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -35,6 +35,8 @@ import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
 import jakarta.data.repository.Update;
 
+import java.util.Set;
+
 /**
  * <p>Jakarta Data standardizes a programming model where data is represented by
  * simple Java classes and where operations on data are represented by interface
@@ -270,7 +272,8 @@ import jakarta.data.repository.Update;
  *
  * </table>
  *
- * <p>A Jakarta Data provider might allow additional entity attribute types.</p>
+ * <p>All of the basic types are sortable except for {@code byte[]}.
+ * A Jakarta Data provider might allow additional entity attribute types.</p>
  *
  * <h2>Lifecycle methods</h2>
  *
@@ -356,8 +359,8 @@ import jakarta.data.repository.Update;
  * <h2>Query by Method Name</h2>
  *
  * <p>Repository methods following the <em>Query by Method Name</em> pattern
- * must include the {@code By} keyword in the method name and must not include
- * the {@code @Find} annotation, {@code @Query} annotation, or
+ * must have a method name that begins with one of the following prefixes and
+ * must not include the {@code @Find} annotation, {@code @Query} annotation, or
  * any lifecycle annotations on the method or any data access related annotations
  * on the method parameters. Query conditions
  * are determined by the portion of the method name following the {@code By} keyword.</p>
@@ -395,8 +398,9 @@ import jakarta.data.repository.Update;
  * (referred to as the Predicate) that follows the {@code By} keyword,
  * in the same order specified.
  * Most conditions, such as {@code Like} or {@code LessThan},
- * correspond to a single method parameter. The exception to this rule is
- * {@code Between}, which corresponds to two method parameters.
+ * correspond to a single method parameter. The exceptions to this rule are
+ * {@code Between}, which corresponds to two method parameters, and {@code Null},
+ * {@code True}, and {@code False}, which require no method parameters.
  * Multiple conditions are delimited by the keywords {@code And}
  * and {@code Or}. The equality condition is implied when no
  * condition operator keyword is present.</p>
@@ -423,7 +427,7 @@ import jakarta.data.repository.Update;
  * <td style="font-family:sans-serif; font-size:0.8em">Key-value<br>Wide-Column</td></tr>
  *
  * <tr style="vertical-align: top"><td>{@code Between}</td>
- * <td>numeric, strings, time</td>
+ * <td>sortable basic types</td>
  * <td>Requires that the entity's attribute value be within the range specified by two parameters,
  * inclusive of the parameters. The minimum is listed first, then the maximum.</td>
  * <td>{@code findByAgeBetween(minAge, maxAge)}</td>
@@ -450,13 +454,13 @@ import jakarta.data.repository.Update;
  * <td style="font-family:sans-serif; font-size:0.8em">Key-value<br>Wide-Column</td></tr>
  *
  * <tr style="vertical-align: top"><td>{@code GreaterThan}</td>
- * <td>numeric, strings, time</td>
+ * <td>sortable basic types</td>
  * <td>Requires that the entity's attribute value be larger than the parameter value.</td>
  * <td>{@code findByStartTimeGreaterThan(startedAfter)}</td>
  * <td style="font-family:sans-serif; font-size:0.8em">Key-value<br>Wide-Column</td></tr>
  *
  * <tr style="vertical-align: top; background-color:#eee"><td>{@code GreaterThanEqual}</td>
- * <td>numeric, strings, time</td>
+ * <td>sortable basic types</td>
  * <td>Requires that the entity's attribute value be at least as big as the parameter value.</td>
  * <td>{@code findByAgeGreaterThanEqual(minimumAge)}</td>
  * <td style="font-family:sans-serif; font-size:0.8em">Key-value<br>Wide-Column</td></tr>
@@ -471,19 +475,20 @@ import jakarta.data.repository.Update;
  * <td style="font-family:sans-serif; font-size:0.8em">Key-value<br>Wide-Column<br>Document<br>Graph</td></tr>
  *
  * <tr style="vertical-align: top; background-color:#eee"><td>{@code In}</td>
- * <td>all attribute types</td>
- * <td>Requires that the entity's attribute value be within the list that is the parameter value.</td>
- * <td>{@code findByNameIn(names)}</td>
+ * <td>sortable basic types</td>
+ * <td>Requires that the entity's attribute value be within the {@link Set} that is
+ * the parameter value.</td>
+ * <td>{@code findByMonthIn(Set.of(Month.MAY, Month.JUNE))}</td>
  * <td style="font-family:sans-serif; font-size:0.8em">Key-value<br>Wide-Column<br>Document<br>Graph</td></tr>
  *
  * <tr style="vertical-align: top"><td>{@code LessThan}</td>
- * <td>numeric, strings, time</td>
+ * <td>sortable basic types</td>
  * <td>Requires that the entity's attribute value be less than the parameter value.</td>
  * <td>{@code findByStartTimeLessThan(startedBefore)}</td>
  * <td style="font-family:sans-serif; font-size:0.8em">Key-value<br>Wide-Column</td></tr>
  *
  * <tr style="vertical-align: top; background-color:#eee"><td>{@code LessThanEqual}</td>
- * <td>numeric, strings, time</td>
+ * <td>sortable basic types</td>
  * <td>Requires that the entity's attribute value be at least as small as the parameter value.</td>
  * <td>{@code findByAgeLessThanEqual(maximumAge)}</td>
  * <td style="font-family:sans-serif; font-size:0.8em">Key-value<br>Wide-Column</td></tr>

--- a/spec/src/main/asciidoc/method-query.asciidoc
+++ b/spec/src/main/asciidoc/method-query.asciidoc
@@ -12,8 +12,7 @@ public interface ProductRepository extends BasicRepository<Product, Long> {
   @OrderBy("price")
   List<Product> findByNameLike(String namePattern);
 
-  @OrderBy(value = "price", descending = true)
-  List<Product> findByNameLikeAndPriceLessThan(String namePattern, float priceBelow);
+  List<Product> findByNameLikeAndPriceLessThanOrderByPriceDesc(String namePattern, float priceBelow);
 
 }
 ----
@@ -28,7 +27,7 @@ The parsing of query method names follows a specific format:
 
 NOTE: This specification uses the terms subject and predicate in a way that aligns with industry terminology rather than how they are defined in English grammar.
 
-Queries can also handle entities with relation attributes by specifying the relationship using dot notation, with the dot converted to underscore so that it is a valid character within the method name. See Scenario 3 below for an example.
+Queries can also handle entities with relation attributes by specifying the relationship using dot notation, with the dot converted to underscore so that it is a valid character within the method name.
 
 Example query methods:
 
@@ -123,7 +122,7 @@ Jakarta Data implementations must support the following list of Query by Method 
 |Key-value, Wide-Column
 
 |Between
-|Find results where the property is between (inclusive of) the given values
+|Find results where the property is between (inclusive of) two given values, with the first value being the inclusive minimum and the second value being the inclusive maximum.
 |findByDateBetween
 |Key-value, Wide-Column
 
@@ -173,7 +172,7 @@ Jakarta Data implementations must support the following list of Query by Method 
 |Key-value, Wide-Column, Document, Graph
 
 |In
-|Find results where the property is one of the values that are contained within the given list
+|Find results where the property is one of the values that are contained within the given `Set`.
 |findByIdIn
 |Key-value, Wide-Column, Document, Graph
 
@@ -218,6 +217,20 @@ Jakarta Data implementations must support the following list of Query by Method 
 ====
 The "Not Required For" column indicates the database types for which the respective keyword is not required or applicable.
 ====
+
+Most _Query by Method Name_ conditions require a single value. The `Between` condition requires two values. `Null`, `True`, and `False` require none. The values for _Query by Method Name_ conditions are the parameter values that are supplied to the method, following the order in which the _Query by Method Name_ conditions appear within the method name.
+
+In the following example the value of the first parameter, `namePattern`, is used for `NameLike`, the values of the second and third parameters, `minYear` and `maxYear`, are used for `YearMadeBetween`, and the value of the fourth parameter, `maxPrice`, is used for `PriceLessThan`.
+
+[source,java]
+----
+List<Product> findByNameLikeAndYearMadeBetweenAndPriceLessThan(String namePattern,
+                                                               int minYear,
+                                                               int maxYear,
+                                                               float maxPrice,
+                                                               Limit limit,
+                                                               Sort<?>... sorts)
+----
 
 ===== Patterns
 


### PR DESCRIPTION
This pull aims to improve on some of the deficiencies that were found in Query by Method Name documentation under #576 such as the data type to use when supplying a value for the `In` keyword, discussion of how method parameters are mapped to conditions, calling out which conditions require 0 or 2 method parameters instead of 1.  Also, I have hopefully improved on the types column of the Query by Method Name keyword table to switch to better match up with the Basic Types that are defined earlier in the document.  I wasn't sure if we should also switch "string" to explicitly indicate "String", "char", and "Character" or if lower case "string" is sufficient, so I left that for now.