### PR TITLE
fix broken links to Query by Method Name

### DIFF
--- a/spec/src/main/asciidoc/entity.asciidoc
+++ b/spec/src/main/asciidoc/entity.asciidoc
@@ -334,7 +334,7 @@ For example, Jakarta Persistence allows the entity name to be specified via the 
 
 ==== Persistent Field Names
 
-Each persistent field of an entity, as defined above in <<Persistent Fields>>, or of an embeddable class, as defined in <<Embedded Fields and Embeddable Classes>>, must be assigned a name, allowing the persistent field to be referenced by an <<Parameter-based automatic query methods,automatic query method>>, a <<Query by Method Name>>, or from a query specified within the <<Annotated Query methods,`@Query` annotation>>.
+Each persistent field of an entity, as defined above in <<Persistent Fields>>, or of an embeddable class, as defined in <<Embedded Fields and Embeddable Classes>>, must be assigned a name, allowing the persistent field to be referenced by an <<Parameter-based automatic query methods,automatic query method>>, a Query by Method Name, or from a query specified within the <<Annotated Query methods,`@Query` annotation>>.
 
 - when direct field access is used, the name of a persistent field is simply the name of the Java field, but
 - when property-based access is used, the name of the field is derived from the accessor methods.

--- a/spec/src/main/asciidoc/portability.asciidoc
+++ b/spec/src/main/asciidoc/portability.asciidoc
@@ -29,7 +29,7 @@ IMPORTANT: For any NoSQL database type not covered here, such as time series dat
 
 ==== Wide-Column Databases
 
-Wide-column databases offer more query flexibility, even allowing the use of secondary indexes, albeit potentially impacting performance. When interacting with wide-column databases, Jakarta Data requires the implementation of the `BasicRepository` along with all of its methods, including Query by Method Name. However, developers should be mindful that certain query keywords, such as "And" or "Or," may not be universally supported in these databases. The full set of required keywords is documented in the section of the Jakarta Data module Javadoc that is titled "Reserved Keywords for Query by Method Name".
+Wide-column databases offer more query flexibility, even allowing the use of secondary indexes, albeit potentially impacting performance. When interacting with wide-column databases, Jakarta Data requires the implementation of the `BasicRepository` along with all of its methods. However, developers should be mindful that certain query keywords, such as "And" or "Or," may not be universally supported in these databases. The full set of required keywords is documented in the section of the Jakarta Data module Javadoc that is titled "Reserved Keywords for Query by Method Name".
 
 ==== Document Databases
 

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -26,7 +26,7 @@ Every abstract method of the interface is usually either:
 
 - an entity instance <<Lifecycle methods,_lifecycle method_>>,
 - an <<Annotated Query methods,_annotated query method_>>,
-- an _automatic query method_ with <<Parameter-based automatic query methods,parameter-based conditions>> or <<Query by Method Name>>, or
+- an _automatic query method_ with <<Parameter-based automatic query methods,parameter-based conditions>> or defined using the Query by Method Name extension, or
 - a <<Resource accessor methods,_resource accessor method_>>.
 
 A repository may declare lifecycle methods for a single entity type, or for multiple related entity types.
@@ -266,7 +266,7 @@ reject such a method declaration at compile time.
 
 === Special Parameters for Limits, Sorting, and Pagination
 
-An <<Annotated Query methods,annotated>>, <<Parameter-based automatic query methods,parameter-based>>, or <<Query by Method Name,method name>> query method may have _special parameters_ of type `Limit`, `Order`, `Sort`, or `PageRequest` if the method return type indicates that the method may return multiple entities, that is, if the return type is:
+An <<Annotated Query methods,annotated>>, <<Parameter-based automatic query methods,parameter-based>>, or Query by Method Name query method may have _special parameters_ of type `Limit`, `Order`, `Sort`, or `PageRequest` if the method return type indicates that the method may return multiple entities, that is, if the return type is:
 
 - an array type,
 - `List` or `Stream`, or


### PR DESCRIPTION
That's in a different document now.