### PR TITLE
EntityDefining was added without updating TCK

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/common/cdi/PersonEntity.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/common/cdi/PersonEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,9 +20,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import jakarta.data.spi.EntityDefining;
+
 /**
  * A custom entity annotation for testing.
  */
+@EntityDefining
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface PersonEntity {


### PR DESCRIPTION
#644 adds the requirement for custom entity defining annotations to be annotated with EntityDefining, but didn't update the one in the TCK.