### PR TITLE
TCK broken by #639

### DIFF
--- a/api/src/main/java/jakarta/data/page/Pagination.java
+++ b/api/src/main/java/jakarta/data/page/Pagination.java
@@ -17,10 +17,6 @@
  */
 package jakarta.data.page;
 
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -68,20 +64,6 @@ record Pagination(long page, int size, Mode mode, Cursor type, boolean requestTo
     @Override
     public PageRequest beforeCursor(Cursor cursor) {
         return new Pagination(page, size, Mode.CURSOR_PREVIOUS, cursor, requestTotal);
-    }
-
-
-    private static <E> List<E> combine(List<E> list, E element) {
-        int size = list.size();
-        if (size == 0) {
-            return java.util.List.of(element);
-        } else {
-            Object[] array = list.toArray(new Object[size + 1]);
-            array[size] = element;
-            @SuppressWarnings("unchecked")
-            List<E> newList = (List<E>) Collections.unmodifiableList(Arrays.asList(array));
-            return newList;
-        }
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/repository/BasicRepository.java
+++ b/api/src/main/java/jakarta/data/repository/BasicRepository.java
@@ -17,6 +17,7 @@
  */
 package jakarta.data.repository;
 
+import jakarta.data.Order;
 import jakarta.data.exceptions.OptimisticLockingFailureException;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
@@ -160,14 +161,15 @@ public interface BasicRepository<T, K> extends DataRepository<T, K> {
      * Returns a {@link Page} of entities according to the page request that is provided as the {@link PageRequest} parameter.
      *
      * @param pageRequest the request for a paginated result; must not be {@code null}.
+     * @param sortBy      sort criteria that must deterministically order the results; must not be {@code null}.
      * @return a page of entities; will never be {@code null}.
-     * @throws NullPointerException when {@code pageRequest} is {@code null}.
+     * @throws NullPointerException when {@code pageRequest} or {@code sortBy} is {@code null}.
      * @throws UnsupportedOperationException for Key-Value and Wide-Column databases when the {@link PageRequest.Mode#CURSOR_NEXT}
      * or {@link PageRequest.Mode#CURSOR_PREVIOUS} pagination mode is selected.
      * @see PageRequest.Mode
      */
     @Find
-    Page<T> findAll(PageRequest pageRequest);
+    Page<T> findAll(PageRequest pageRequest, Order<T> sortBy);
 
     /**
      * Deletes the entity with the given Id.

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
@@ -72,7 +72,7 @@ public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long>, I
 
     Optional<AsciiCharacter> findByNumericValue(int id);
 
-    Page<AsciiCharacter> findByNumericValueBetween(int min, int max, PageRequest<AsciiCharacter> pagination);
+    Page<AsciiCharacter> findByNumericValueBetween(int min, int max, PageRequest pagination, Order<AsciiCharacter> order);
 
     List<AsciiCharacter> findByNumericValueLessThanEqualAndNumericValueGreaterThanEqual(int max, int min);
 

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers.java
@@ -43,7 +43,7 @@ public interface NaturalNumbers extends BasicRepository<NaturalNumber, Long>, Id
     long countBy();
 
     CursoredPage<NaturalNumber> findByFloorOfSquareRootOrderByIdAsc(long sqrtFloor,
-                                                                    PageRequest<NaturalNumber> pagination);
+                                                                    PageRequest pagination);
 
     Stream<NaturalNumber> findByIdBetweenOrderByNumTypeAsc(long minimum,
                                                            long maximum,
@@ -58,20 +58,23 @@ public interface NaturalNumbers extends BasicRepository<NaturalNumber, Long>, Id
     List<NaturalNumber> findByIdLessThanEqual(long maximum, Sort<?>... sorts);
 
     Page<NaturalNumber> findByIdLessThanOrderByFloorOfSquareRootDesc(long exclusiveMax,
-                                                                     PageRequest<NaturalNumber> pagination);
+                                                                     PageRequest pagination,
+                                                                     Order<NaturalNumber> order);
 
     CursoredPage<NaturalNumber> findByNumTypeAndNumBitsRequiredLessThan(NumberType type,
                                                                         short bitsUnder,
-                                                                        PageRequest<NaturalNumber> pagination);
+                                                                        Order<NaturalNumber> order,
+                                                                        PageRequest pagination);
 
     NaturalNumber[] findByNumTypeNot(NumberType notThisType, Limit limit, Order<NaturalNumber> sorts);
 
     Page<NaturalNumber> findByNumTypeAndFloorOfSquareRootLessThanEqual(NumberType type,
                                                                        long maxSqrtFloor,
-                                                                       PageRequest<NaturalNumber> pagination);
+                                                                       PageRequest pagination,
+                                                                       Sort<NaturalNumber> sort);
 
     @Query("SELECT id WHERE isOdd = true AND id BETWEEN 21 AND ?1 ORDER BY id ASC")
-    Page<Long> oddsFrom21To(long max, PageRequest<NaturalNumber> pageRequest);
+    Page<Long> oddsFrom21To(long max, PageRequest pageRequest);
 
     @Query("WHERE isOdd = false AND numType = ee.jakarta.tck.data.framework.read.only.NaturalNumber.NumberType.PRIME")
     Optional<NaturalNumber> two();

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/PositiveIntegers.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/PositiveIntegers.java
@@ -23,6 +23,7 @@ import java.util.stream.Stream;
 import ee.jakarta.tck.data.framework.read.only.NaturalNumber.NumberType;
 import jakarta.data.Limit;
 import jakarta.data.Order;
+import jakarta.data.Sort;
 import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
@@ -45,7 +46,8 @@ public interface PositiveIntegers extends BasicRepository<NaturalNumber, Long> {
 
     CursoredPage<NaturalNumber> findByFloorOfSquareRootNotAndIdLessThanOrderByNumBitsRequiredDesc(long excludeSqrt,
                                                                                                   long eclusiveMax,
-                                                                                                  PageRequest<NaturalNumber> pagination);
+                                                                                                  PageRequest pagination,
+                                                                                                  Order<NaturalNumber> order);
 
     List<NaturalNumber> findByIsOddTrueAndIdLessThanEqualOrderByIdDesc(long max);
 
@@ -57,7 +59,7 @@ public interface PositiveIntegers extends BasicRepository<NaturalNumber, Long> {
 
     @Find
     Page<NaturalNumber> findMatching(long floorOfSquareRoot, Short numBitsRequired, NumberType numType,
-            PageRequest<NaturalNumber> pagination);
+            PageRequest pagination, Sort<?>... sorts);
 
     @Find
     Optional<NaturalNumber> findNumber(long id);
@@ -73,5 +75,7 @@ public interface PositiveIntegers extends BasicRepository<NaturalNumber, Long> {
     CursoredPage<NaturalNumber> withBitCountOrOfTypeAndBelow(@Param("bits") short bitsRequired,
                                                              @Param("type") NumberType numberType,
                                                              @Param("xmax") long exclusiveMax,
-                                                             PageRequest<?> pageRequest);
+                                                             Sort<NaturalNumber> sort1,
+                                                             Sort<NaturalNumber> sort2,
+                                                             PageRequest pageRequest);
 }


### PR DESCRIPTION
This pull gets the TCK compiling again.
The first step was to add an Order parameter to BasicRepository.findAll(PageRequest) which cannot behave properly without a deterministic ordering.
