### PR TITLE
Fixing subtitle for Extension html file

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -14,7 +14,7 @@ body:
       required: true
     attributes:
       label: Specification Version
-      description: What version of the Concurrency Spec are you running using?
+      description: What version of the Data Spec are you running using?
       options:
         - 1.0.0-M3
         - 1.0.0-M2

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -107,6 +107,9 @@
                             <sourceDocumentName>method-query.asciidoc</sourceDocumentName>
                             <backend>html5</backend>
                             <outputFile>${gen-doc-dir}/jakarta-method-name-query-${project.version}.html</outputFile>
+                            <attributes>
+                                <doctitle>Jakarta Data: Query by Method Name Extension</doctitle>
+                            </attributes>
                         </configuration>
                     </execution>
                 </executions>
@@ -118,6 +121,7 @@
                     <embedAssets>true</embedAssets>
                     <attributes>
                         <license>Apache License v2.0</license>
+                        <specification>Jakarta Data</specification>
                         <revnumber>${project.version}</revnumber>
                         <revremark>${revremark}</revremark>
                         <revdate>${revisiondate}</revdate>

--- a/spec/src/main/asciidoc/chapters/license/license-efsl.adoc
+++ b/spec/src/main/asciidoc/chapters/license/license-efsl.adoc
@@ -1,6 +1,6 @@
 [subs="normal"]
 ....
-Specification: {doctitle}
+Specification: {specification}
 
 Version: {revnumber}
 


### PR DESCRIPTION
fixes #653

Sets the title for the html version of the new Extension file to:
`Jakarta Data: Query by Method Name Extension`

I had to switch the Specification to use a separate variable, to prevent the specification in the Extension file from using the doctitle.