### PR TITLE
improvements to Query by Method Name grammar

### DIFF
--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -362,8 +362,8 @@ import java.util.Set;
  * must have a method name that begins with one of the following prefixes and
  * must not include the {@code @Find} annotation, {@code @Query} annotation, or
  * any lifecycle annotations on the method or any data access related annotations
- * on the method parameters. Query conditions
- * are determined by the portion of the method name following the {@code By} keyword.</p>
+ * on the method parameters. Query conditions are determined by the portion of
+ * the method name following the {@code By} keyword.</p>
  *
  * <table id="methodNamePrefixes" style="width: 100%">
  * <caption><b>Query By Method Name</b></caption>
@@ -373,25 +373,21 @@ import java.util.Set;
  * <td style="vertical-align: top; width: 65%"><b>Example</b></td>
  * </tr>
  *
- * <tr style="vertical-align: top"><td>{@code countBy}</td>
+ * <tr style="vertical-align: top"><td>{@code count}</td>
  * <td>counts the number of entities</td>
  * <td>{@code countByAgeGreaterThanEqual(ageLimit)}</td></tr>
  *
- * <tr style="vertical-align: top; background-color:#eee"><td>{@code deleteBy}</td>
+ * <tr style="vertical-align: top; background-color:#eee"><td>{@code delete}</td>
  * <td>for delete operations</td>
  * <td>{@code deleteByStatus("DISCONTINUED")}</td></tr>
  *
- * <tr style="vertical-align: top"><td>{@code existsBy}</td>
+ * <tr style="vertical-align: top"><td>{@code exists}</td>
  * <td>for determining existence</td>
  * <td>{@code existsByYearHiredAndWageLessThan(2022, 60000)}</td></tr>
  *
- * <tr style="vertical-align: top; background-color:#eee"><td>{@code find...By}</td>
+ * <tr style="vertical-align: top; background-color:#eee"><td>{@code find}</td>
  * <td>for find operations</td>
  * <td>{@code findByHeightBetween(minHeight, maxHeight)}</td></tr>
- *
- * <tr style="vertical-align: top"><td>{@code updateBy}</td>
- * <td>for simple update operations</td>
- * <td>{@code updateByIdSetModifiedOnAddPrice(productId, now, 10.0)}</td></tr>
  * </table>
  *
  * <p>The conditions are defined by the portion of the repository method name
@@ -601,7 +597,7 @@ import java.util.Set;
  * {@code WithQuarter}, {@code WithSecond}, {@code WithWeek}, {@code WithYear}.
  * </p>
  * <p>
- * Reserved for find...By and count...By: {@code Distinct}.
+ * Reserved for {@code find} and {@code count}: {@code Distinct}.
  * </p>
  * <p>
  * Reserved for updates: {@code Add}, {@code Divide}, {@code Multiply}, {@code Set}, {@code Subtract}.
@@ -625,10 +621,7 @@ import java.util.Set;
  * <h3>Return types for Query by Method Name</h3>
  *
  * <p>The following is a table of valid return types.
- * The <b>Method</b> column shows name patterns for Query by Method Name.
- * For example, to identify the valid return types for a method,
- * {@code findByName}, that accepts a {@code PageRequest} parameter,
- * refer to the row for {@code find...By...(..., PageRequest)}.</p>
+ * The <b>Method</b> column shows name patterns for Query by Method Name.</p>
  *
  * <table style="width: 100%">
  * <caption><b>Return Types for Query by Method Name</b></caption>
@@ -638,39 +631,37 @@ import java.util.Set;
  * <td style="vertical-align: top"><b>Notes</b></td>
  * </tr>
  *
- * <tr style="vertical-align: top; background-color:#eee"><td>{@code countBy...}</td>
+ * <tr style="vertical-align: top; background-color:#eee"><td>{@code count}</td>
  * <td>{@code long},
  * <br>{@code int}</td>
  * <td></td></tr>
  *
- * <tr style="vertical-align: top"><td>{@code deleteBy...},
- * <br>{@code updateBy...}</td>
+ * <tr style="vertical-align: top"><td>{@code delete}</td>
  * <td>{@code void},
- * <br>{@code boolean},
  * <br>{@code long},
  * <br>{@code int}</td>
  * <td></td></tr>
  *
- * <tr style="vertical-align: top; background-color:#eee"><td>{@code existsBy...}</td>
+ * <tr style="vertical-align: top; background-color:#eee"><td>{@code exists}</td>
  * <td>{@code boolean}</td>
- * <td>For determining existence.</td></tr>
+ * <td>For determining existence</td></tr>
  *
- * <tr style="vertical-align: top"><td>{@code find...By...}</td>
+ * <tr style="vertical-align: top"><td>{@code find}</td>
  * <td>{@code E},
  * <br>{@code Optional<E>}</td>
  * <td>For queries returning a single item (or none)</td></tr>
  *
- * <tr style="vertical-align: top; background-color:#eee"><td>{@code find...By...}</td>
+ * <tr style="vertical-align: top; background-color:#eee"><td>{@code find}</td>
  * <td>{@code E[]},
  * <br>{@code List<E>}</td>
- * <td>For queries where it is possible to return more than 1 item.</td></tr>
+ * <td>For queries where it is possible to return more than 1 item</td></tr>
  *
- * <tr style="vertical-align: top"><td>{@code find...By...}</td>
+ * <tr style="vertical-align: top"><td>{@code find}</td>
  * <td>{@code Stream<E>}</td>
- * <td>The caller must arrange to {@link java.util.stream.BaseStream#close() close}
- * all streams that it obtains from repository methods.</td></tr>
+ * <td>The caller must call {@link java.util.stream.BaseStream#close() close}
+ * for every stream returned by the repository method</td></tr>
  *
- * <tr style="vertical-align: top; background-color:#eee"><td>{@code find...By...(..., PageRequest)}</td>
+ * <tr style="vertical-align: top; background-color:#eee"><td>{@code find} accepting {@link PageRequest}</td>
  * <td>{@code Page<E>}, {@code CursoredPage<E>}</td>
  * <td>For use with pagination</td></tr>
  *

--- a/spec/src/main/asciidoc/method-query.asciidoc
+++ b/spec/src/main/asciidoc/method-query.asciidoc
@@ -105,10 +105,9 @@ Query methods allow developers to create database queries using method naming co
 [source,bnf]
 ----
 query : find | action
-find : "find" specification order?
-action : ("delete" | "update" | "count" | "exists") restriction
-specification : "All" ignoredText? | limit? ignoredText? "By" predicate
-restriction : "All" ignoredText? | ignoredText? "By" predicate
+find : "find" limit? ignoredText? restriction? order?
+action : ("delete" | "update" | "count" | "exists") ignoredText? restriction?
+restriction : "By" predicate
 limit : "First" max?
 predicate : condition (("And" | "Or") condition)*
 condition : property "IgnoreCase"? "Not"? operator?

--- a/spec/src/main/asciidoc/method-query.asciidoc
+++ b/spec/src/main/asciidoc/method-query.asciidoc
@@ -149,7 +149,7 @@ Explanation of the BNF elements:
 - `identifier`: A legal Java identifier, not containing an underscore.
 - `max`: A whole number greater than zero.
 - `order`: Specifies that results of a `find` query should be sorted lexicographically, with respect to one or more order items.
-- `orderItem`: An field used to sort results, where `Asc` or `Desc` specifies the sorting direction.
+- `orderItem`: A field used to sort results, where `Asc` or `Desc` specifies the sorting direction.
 
 === Query by Method Name Keywords
 
@@ -158,19 +158,19 @@ The following tables list the _Query by Method Name_ keywords that must be suppo
 |===
 |Keyword |Description| Not Required For
 
-|findBy
+|`findBy`
 |General query method returning entities.
 |Key-value, Wide-Column
 
-|deleteBy
+|`deleteBy`
 |Delete query method returning either no result (void) or the delete count.
 |Key-value, Wide-Column
 
-|countBy
+|`countBy`
 |Count projection returning a numeric result.
 |Key-value, Wide-Column
 
-|existsBy
+|`existsBy`
 |Exists projection, returning as a `boolean` result.
 |Key-value, Wide-Column
 |===
@@ -184,109 +184,109 @@ Jakarta Data implementations must support the following list of Query by Method 
 |===
 |Keyword |Description | Method signature Sample| Not Required For
 
-|And
+|`And`
 |The `And` operator requires both conditions to match.
-|findByNameAndYear
+|`findByNameAndYear`
 |Key-value, Wide-Column
 
-|Or
+|`Or`
 |The `Or` operator requires at least one of the conditions to match.
-|findByNameOrYear
+|`findByNameOrYear`
 |Key-value, Wide-Column
 
-|Not
+|`Not`
 |Negates the condition that immediately follows the `Not` keyword. When used without a subsequent keyword, means not equal to.
-|findByNameNotLike
+|`findByNameNotLike`
 |Key-value, Wide-Column
 
-|Between
+|`Between`
 |Find results where the property is between (inclusive of) two given values, with the first value being the inclusive minimum and the second value being the inclusive maximum.
-|findByDateBetween
+|`findByDateBetween`
 |Key-value, Wide-Column
 
-|Contains
+|`Contains`
 |Matches String values with the given substring, which can be a pattern.
-|findByProductNameContains
+|`findByProductNameContains`
 |Key-value, Wide-Column, Document, Graph
 
-|EndsWith
+|`EndsWith`
 |Matches String values with the given ending, which can be a pattern.
-|findByProductNameEndsWith
+|`findByProductNameEndsWith`
 |Key-value, Wide-Column, Document, Graph
 
-|First
+|`First`
 |For a query with ordered results, limits the quantity of results to the number following First, or if there is no subsequent number, to a single result.
-|findFirst10By
+|`findFirst10By`
 |Key-value, Wide-Column, Document, Graph
 
-|LessThan
+|`LessThan`
 |Find results where the property is less than the given value
-|findByAgeLessThan
+|`findByAgeLessThan`
 |Key-value, Wide-Column
 
-|GreaterThan
+|`GreaterThan`
 |Find results where the property is greater than the given value
-|findByAgeGreaterThan
+|`findByAgeGreaterThan`
 |Key-value, Wide-Column
 
-|LessThanEqual
+|`LessThanEqual`
 |Find results where the property is less than or equal to the given value
-|findByAgeLessThanEqual
+|`findByAgeLessThanEqual`
 |Key-value, Wide-Column
 
-|GreaterThanEqual
+|`GreaterThanEqual`
 |Find results where the property is greater than or equal to the given value
-|findByAgeGreaterThanEqual
+|`findByAgeGreaterThanEqual`
 |Key-value, Wide-Column
 
-|Like
+|`Like`
 |Matches String values against the given pattern.
-|findByTitleLike
+|`findByTitleLike`
 |Key-value, Wide-Column, Document, Graph
 
-|IgnoreCase
+|`IgnoreCase`
 |Requests that string values be compared independent of case for query conditions and ordering.
-|findByStreetNameIgnoreCaseLike
+|`findByStreetNameIgnoreCaseLike`
 |Key-value, Wide-Column, Document, Graph
 
-|In
+|`In`
 |Find results where the property is one of the values that are contained within the given `Set`.
-|findByIdIn
+|`findByIdIn`
 |Key-value, Wide-Column, Document, Graph
 
-|Null
+|`Null`
 |Finds results where the property has a null value.
-|findByYearRetiredNull
+|`findByYearRetiredNull`
 |Key-value, Wide-Column, Document, Graph
 
-|StartsWith
+|`StartsWith`
 |Matches String values with the given beginning, which can be a pattern.
-|findByFirstNameStartsWith
+|`findByFirstNameStartsWith`
 |Key-value, Wide-Column, Document, Graph
 
-|True
+|`True`
 |Finds results where the property has a boolean value of true.
-|findBySalariedTrue
+|`findBySalariedTrue`
 |Key-value, Wide-Column
 
-|False
+|`False`
 |Finds results where the property has a boolean value of false.
-|findByCompletedFalse
+|`findByCompletedFalse`
 |Key-value, Wide-Column
 
-|OrderBy
+|`OrderBy`
 |Specify a static sorting order followed by one or more ordered pairings of a property path and direction (`Asc` or `Desc`). The direction `Asc` can be omitted from the final property listed, in which case ascending order is implied for that property.
-|findByAgeOrderByHeightDescIdAsc findByAgeOrderById
+|`findByAgeOrderByHeightDescIdAsc` `findByAgeOrderById`
 |Key-value, Wide-Column
 
-|Desc
+|`Desc`
 |Specify a static sorting order of descending.
-|findByNameOrderByAgeDesc
+|`findByNameOrderByAgeDesc`
 |Key-value, Wide-Column
 
-|Asc
+|`Asc`
 |Specify a static sorting order of ascending.
-|findByNameOrderByAgeAsc
+|`findByNameOrderByAgeAsc`
 |Key-value, Wide-Column
 
 |===

--- a/spec/src/main/asciidoc/method-query.asciidoc
+++ b/spec/src/main/asciidoc/method-query.asciidoc
@@ -104,16 +104,16 @@ Query methods allow developers to create database queries using method naming co
 
 [source,bnf]
 ----
-query ::= find | action
-find :: = "find" ignoredText? specification order?
-action ::= ("delete" | "update" | "count" | "exists") ignoredText? restriction
-specification ::= "All" | limit? "By" predicate
-restriction ::= "All" | "By" predicate
-limit ::= "First" max?
-predicate ::= condition (("And" | "Or") condition)*
-condition ::= property "IgnoreCase"? "Not"? operator?
-operator ::=
-      "Contains"
+query : find | action
+find : "find" ignoredText? specification order?
+action : ("delete" | "update" | "count" | "exists") ignoredText? restriction
+specification : "All" | limit? "By" predicate
+restriction : "All" | "By" predicate
+limit : "First" max?
+predicate : condition (("And" | "Or") condition)*
+condition : property "IgnoreCase"? "Not"? operator?
+operator
+    : "Contains"
     | "EndsWith"
     | "StartsWith"
     | "LessThan"
@@ -126,11 +126,11 @@ operator ::=
     | "Null"
     | "True"
     | "False"
-property ::= identifier | identifier "_" property
-identifier ::= word
-max ::= digit+
-order ::= "OrderBy" (property | orderItem+)
-orderItem ::= property ("Asc" | "Desc")
+property : identifier | identifier "_" property
+identifier : word
+max : digit+
+order : "OrderBy" (property | orderItem+)
+orderItem : property ("Asc" | "Desc")
 ----
 
 Explanation of the BNF elements:

--- a/spec/src/main/asciidoc/method-query.asciidoc
+++ b/spec/src/main/asciidoc/method-query.asciidoc
@@ -104,35 +104,39 @@ Query methods allow developers to create database queries using method naming co
 
 [source,bnf]
 ----
-<query-method> ::= <subject> <predicate> [<order-clause>]
-<subject> ::= (<action> | "find" <find-expression>) [<ignored-text>] "By"
-<action> ::= "find" | "delete" | "update" | "count" | "exists"
-<find-expression> ::= "First" [<positive-integer>]
+<query-method> ::= <find> | <action>
+<find> :: = "find" [<ignored-text>] <specification> [<order-clause>]
+<action> ::= ("delete" | "update" | "count" | "exists") [<ignored-text>] <restriction>
+<specification> ::= "All" | [<limit>] "By" <predicate>
+<restriction> ::= "All" | "By" <predicate>
+<limit> ::= "First" [<positive-integer>]
 <predicate> ::= <condition> { ("And" | "Or") <condition> }
 <condition> ::= <property> ["IgnoreCase"] ["Not"] [<operator>]
 <operator> ::= "Contains" | "EndsWith" | "StartsWith" | "LessThan"| "LessThanEqual" | "GreaterThan" | "GreaterThanEqual" | "Between" | "Like" | "In" | "Null" | "True" | "False"
 <property> ::= <identifier> | <identifier> "_" <property>
 <identifier> ::= <word>
 <positive-integer> ::= <digit> { <digit> }
-<order-clause> ::= "OrderBy" { <order-item> } ( <order-item> | <property> )
+<order-clause> ::= "OrderBy" (<property> | <order-item> {<order-item>})
 <order-item> ::= <property> ("Asc" | "Desc")
 ----
 
 Explanation of the BNF elements:
 
-- `<query-method>`: Represents a query method, which consists of a subject, a predicate, and an optional order clause.
-- `<subject>`: Defines the action (e.g., "find" or "delete") followed by an optional expression and "By."
-- `<action>`: Specifies the action, such as "find" or "delete."
-- `<find-expression>`: Represents an optional expression for find operations, such as "First10."
-- `<ignored-text>`: Optional text that does not contain "By".
-- `<predicate>`: Represents the query's condition or filtering criteria, which can include multiple conditions separated by "And" or "Or."
+- `<query-method>`: May be a `find` query, or an `update`, `delete`, `count`, or `exists` operation.
+- `<find>`: A `find` query has a specification of records to be retrieved, and optional sorting.
+- `<action>`: Any other kind of operation has only a restriction to a subset of records.
+- `<specification>`: A `find` query may retrieve all records, or may restrict the records retrieved by a predicate and an optional limit.
+- `<restriction>`: Any other kind of operation may apply to all records or to a subset of records restricted by a predicate
+- `<limit>`: Limits the records retrieved by a `find` query to a hardcoded maximum, such as "First10."
+- `<ignored-text>`: Optional text that does not contain `By` or `All`.
+- `<predicate>`: Represents the query's condition or filtering criteria, which can include multiple conditions separated by `And` or `Or`.
 - `<condition>`: Specifies a property and an operator for the condition.
-- `<operator>`: Defines the operator for the condition, like "Between" or "LessThan." When absent, equality is implied.
+- `<operator>`: Defines the operator for the condition, like `Between` or "LessThan." When absent, equality is implied.
 - `<property>`: Represents a property name, which can include underscores for nested properties.
 - `<identifier>`: Represents a word (e.g., property names, action names, etc.).
 - `<positive-integer>`: Represents a whole number greater than zero.
-- `<order-clause>`: Specifies the optional order clause, starting with "OrderBy" and followed by one or more order items.
-- `<order-item>`: Represents an ordered collection of entity attributes by which to sort results, including an optional "Asc" or "Desc" to specify the sort direction.
+- `<order-clause>`: Specifies the optional order clause, starting with `OrderBy` and followed by one or more order items.
+- `<order-item>`: Represents an ordered collection of entity attributes by which to sort results, including an optional `Asc` or `Desc` to specify the sort direction.
 
 === Query by Method Name Keywords
 
@@ -306,15 +310,15 @@ For relational databases, the logical operator `And` takes precedence over `Or`,
 The return type of a Query by Method Name is determined as indicated in the following table, where `E` is the queried entity type.
 
 |===
-|Action |Return type| Notes
+|Operation |Return type| Notes
 
-|`countBy...` |`long` or `int` |
-|`updateBy...`|`void`, `boolean`, `long`,`int`|
-|`existsBy...`|`boolean`|
-|`find...By...`|`E` or `Optional<E>`|For queries returning a single item (or none)
-|`find...By...`|`E[]` or `List<E>`|For queries where it is possible to return more than one item
-|`find...By...`|`Stream<E>`|The caller must call `java.util.stream.BaseStream.close()` for every stream returned by the repository method.
-|`find...By...` accepting a `PageRequest`|`Page<E>` or `CursoredPage<E>`|For use with pagination.
+|`count` |`long` or `int` |
+|`update`|`void`, `boolean`, `long`,`int`|
+|`exists`|`boolean`|
+|`find`|`E` or `Optional<E>`|For queries returning a single item (or none)
+|`find`|`E[]` or `List<E>`|For queries where it is possible to return more than one item
+|`find`|`Stream<E>`|The caller must call `java.util.stream.BaseStream.close()` for every stream returned by the repository method.
+|`find` accepting a `PageRequest`|`Page<E>` or `CursoredPage<E>`|For use with pagination.
 |===
 
 

--- a/spec/src/main/asciidoc/method-query.asciidoc
+++ b/spec/src/main/asciidoc/method-query.asciidoc
@@ -105,10 +105,10 @@ Query methods allow developers to create database queries using method naming co
 [source,bnf]
 ----
 query : find | action
-find : "find" ignoredText? specification order?
-action : ("delete" | "update" | "count" | "exists") ignoredText? restriction
-specification : "All" | limit? "By" predicate
-restriction : "All" | "By" predicate
+find : "find" specification order?
+action : ("delete" | "update" | "count" | "exists") restriction
+specification : "All" ignoredText? | limit? ignoredText? "By" predicate
+restriction : "All" ignoredText? | ignoredText? "By" predicate
 limit : "First" max?
 predicate : condition (("And" | "Or") condition)*
 condition : property "IgnoreCase"? "Not"? operator?

--- a/spec/src/main/asciidoc/method-query.asciidoc
+++ b/spec/src/main/asciidoc/method-query.asciidoc
@@ -126,7 +126,7 @@ operator
     | "Null"
     | "True"
     | "False"
-property : identifier | identifier "_" property
+property : identifier ("_" identifier)*
 identifier : word
 max : digit+
 order : "OrderBy" (property | orderItem+)

--- a/spec/src/main/asciidoc/method-query.asciidoc
+++ b/spec/src/main/asciidoc/method-query.asciidoc
@@ -106,7 +106,7 @@ Query methods allow developers to create database queries using method naming co
 ----
 query : find | action
 find : "find" limit? ignoredText? restriction? order?
-action : ("delete" | "update" | "count" | "exists") ignoredText? restriction?
+action : ("delete" | "count" | "exists") ignoredText? restriction?
 restriction : "By" predicate
 limit : "First" max?
 predicate : condition (("And" | "Or") condition)*
@@ -134,19 +134,18 @@ orderItem : property ("Asc" | "Desc")
 
 Explanation of the BNF elements:
 
-- `query`: May be a `find` query, or an `update`, `delete`, `count`, or `exists` operation.
-- `find`: A `find` query has a specification of records to be retrieved, and optional sorting.
+- `query`: May be a `find` query, or a `delete`, `count`, or `exists` operation.
+- `find`: A `find` query has an optional limit and optional restriction on records to be retrieved, and optional sorting.
 - `action`: Any other kind of operation has only a restriction to a subset of records.
-- `specification`: A `find` query may retrieve all records, or may restrict the records retrieved by a predicate and an optional limit.
-- `restriction`: Any other kind of operation may apply to all records or to a subset of records restricted by a predicate
+- `restriction`: Restricts the records returned to those which satisfy a predicate
 - `limit`: Limits the records retrieved by a `find` query to a hardcoded maximum, such as `First10`.
 - `ignoredText`: Optional text that does not contain `By`, `All`, or `First`.
-- `predicate`: Represents the query's condition or filtering criteria, which can include multiple conditions separated by `And` or `Or`.
-- `condition`: Specifies a property and an operator for the condition.
-- `operator`: Defines the operator for the condition, like `Between` or `LessThan`. When absent, equality is implied.
+- `predicate`: A filtering criteria, which may include multiple conditions separated by `And` or `Or`.
+- `condition`: A property of the queried entity and an operator.
+- `operator`: An operator belonging to a condition, for example, `Between` or `LessThan`. When absent, equality is implied.
 - `property`: A property name, which can include underscores for nested properties.
 - `identifier`: A legal Java identifier, not containing an underscore.
-- `max`: A whole number greater than zero.
+- `max`: A positive whole number.
 - `order`: Specifies that results of a `find` query should be sorted lexicographically, with respect to one or more order items.
 - `orderItem`: A field used to sort results, where `Asc` or `Desc` specifies the sorting direction.
 
@@ -154,23 +153,24 @@ Explanation of the BNF elements:
 
 The following tables list the _Query by Method Name_ keywords that must be supported by Jakarta Data providers, except where explicitly indicated for a type of database.
 
+[cols="12,~,25"]
 |===
-|Keyword |Description| Not Required For
+| Action | Description | Not Required For
 
-|`findBy`
-|General query method returning entities.
+|`find`
+|Returns entity instances representing the records which satisfy the restriction, or representing all records if there is no restriction.
 |Key-value, Wide-Column
 
-|`deleteBy`
-|Delete query method returning either no result (void) or the delete count.
+|`delete`
+|Deletes every record which satisfy the restriction, or all records if there is no restriction, and returns either no result (`void`) or the number of records deleted.
 |Key-value, Wide-Column
 
-|`countBy`
-|Count projection returning a numeric result.
+|`count`
+|Returns the number of records which satisfy the restriction, or the total number of records if there is no restriction.
 |Key-value, Wide-Column
 
-|`existsBy`
-|Exists projection, returning as a `boolean` result.
+|`exists`
+|Returns `true` if at least one record satisfies the restriction or if there is at least one record in the database when there is no restriction.
 |Key-value, Wide-Column
 |===
 
@@ -180,8 +180,9 @@ The "Not Required For" column indicates the database types for which the respect
 ====
 Jakarta Data implementations must support the following list of Query by Method Name keywords, except where indicated for a database type. A repository method must raise `java.lang.UnsupportedOperationException` or a more specific subclass of the exception if the database does not provide the requested functionality.
 
+[cols="15,~,~,25"]
 |===
-|Keyword |Description | Method signature Sample| Not Required For
+| Keyword |Description | Method signature Sample | Not Required For
 
 |`And`
 |The `And` operator requires both conditions to match.
@@ -321,16 +322,17 @@ For relational databases, the logical operator `And` takes precedence over `Or`,
 
 The return type of a Query by Method Name is determined as indicated in the following table, where `E` is the queried entity type.
 
+[cols="25,20,~"]
 |===
-|Operation |Return type| Notes
+| Operation | Return type | Notes
 
-|`count` |`long` or `int` |
-|`update`|`void`, `boolean`, `long`,`int`|
-|`exists`|`boolean`|
-|`find`|`E` or `Optional<E>`|For queries returning a single item (or none)
-|`find`|`E[]` or `List<E>`|For queries where it is possible to return more than one item
-|`find`|`Stream<E>`|The caller must call `java.util.stream.BaseStream.close()` for every stream returned by the repository method.
-|`find` accepting a `PageRequest`|`Page<E>` or `CursoredPage<E>`|For use with pagination.
+| `count` | `long` or `int` |
+| `delete`| `void`,`long`,`int` |
+| `exists`| `boolean` |
+| `find` | `E` or `Optional<E>` | For queries returning a single item (or none)
+| `find` | `E[]` or `List<E>`| For queries where it is possible to return more than one item
+| `find` | `Stream<E>` | The caller must call `java.util.stream.BaseStream.close()` for every stream returned by the repository method
+| `find` accepting a `PageRequest` | `Page<E>` or `CursoredPage<E>` | For use with pagination
 |===
 
 

--- a/spec/src/main/asciidoc/method-query.asciidoc
+++ b/spec/src/main/asciidoc/method-query.asciidoc
@@ -141,7 +141,7 @@ Explanation of the BNF elements:
 - `specification`: A `find` query may retrieve all records, or may restrict the records retrieved by a predicate and an optional limit.
 - `restriction`: Any other kind of operation may apply to all records or to a subset of records restricted by a predicate
 - `limit`: Limits the records retrieved by a `find` query to a hardcoded maximum, such as `First10`.
-- `ignoredText`: Optional text that does not contain `By` or `All`.
+- `ignoredText`: Optional text that does not contain `By`, `All`, or `First`.
 - `predicate`: Represents the query's condition or filtering criteria, which can include multiple conditions separated by `And` or `Or`.
 - `condition`: Specifies a property and an operator for the condition.
 - `operator`: Defines the operator for the condition, like `Between` or `LessThan`. When absent, equality is implied.

--- a/spec/src/main/asciidoc/method-query.asciidoc
+++ b/spec/src/main/asciidoc/method-query.asciidoc
@@ -104,39 +104,52 @@ Query methods allow developers to create database queries using method naming co
 
 [source,bnf]
 ----
-<query-method> ::= <find> | <action>
-<find> :: = "find" [<ignored-text>] <specification> [<order-clause>]
-<action> ::= ("delete" | "update" | "count" | "exists") [<ignored-text>] <restriction>
-<specification> ::= "All" | [<limit>] "By" <predicate>
-<restriction> ::= "All" | "By" <predicate>
-<limit> ::= "First" [<positive-integer>]
-<predicate> ::= <condition> { ("And" | "Or") <condition> }
-<condition> ::= <property> ["IgnoreCase"] ["Not"] [<operator>]
-<operator> ::= "Contains" | "EndsWith" | "StartsWith" | "LessThan"| "LessThanEqual" | "GreaterThan" | "GreaterThanEqual" | "Between" | "Like" | "In" | "Null" | "True" | "False"
-<property> ::= <identifier> | <identifier> "_" <property>
-<identifier> ::= <word>
-<positive-integer> ::= <digit> { <digit> }
-<order-clause> ::= "OrderBy" (<property> | <order-item> {<order-item>})
-<order-item> ::= <property> ("Asc" | "Desc")
+query ::= find | action
+find :: = "find" ignoredText? specification order?
+action ::= ("delete" | "update" | "count" | "exists") ignoredText? restriction
+specification ::= "All" | limit? "By" predicate
+restriction ::= "All" | "By" predicate
+limit ::= "First" max?
+predicate ::= condition (("And" | "Or") condition)*
+condition ::= property "IgnoreCase"? "Not"? operator?
+operator ::=
+      "Contains"
+    | "EndsWith"
+    | "StartsWith"
+    | "LessThan"
+    | "LessThanEqual"
+    | "GreaterThan"
+    | "GreaterThanEqual"
+    | "Between"
+    | "Like"
+    | "In"
+    | "Null"
+    | "True"
+    | "False"
+property ::= identifier | identifier "_" property
+identifier ::= word
+max ::= digit+
+order ::= "OrderBy" (property | orderItem+)
+orderItem ::= property ("Asc" | "Desc")
 ----
 
 Explanation of the BNF elements:
 
-- `<query-method>`: May be a `find` query, or an `update`, `delete`, `count`, or `exists` operation.
-- `<find>`: A `find` query has a specification of records to be retrieved, and optional sorting.
-- `<action>`: Any other kind of operation has only a restriction to a subset of records.
-- `<specification>`: A `find` query may retrieve all records, or may restrict the records retrieved by a predicate and an optional limit.
-- `<restriction>`: Any other kind of operation may apply to all records or to a subset of records restricted by a predicate
-- `<limit>`: Limits the records retrieved by a `find` query to a hardcoded maximum, such as "First10."
-- `<ignored-text>`: Optional text that does not contain `By` or `All`.
-- `<predicate>`: Represents the query's condition or filtering criteria, which can include multiple conditions separated by `And` or `Or`.
-- `<condition>`: Specifies a property and an operator for the condition.
-- `<operator>`: Defines the operator for the condition, like `Between` or "LessThan." When absent, equality is implied.
-- `<property>`: Represents a property name, which can include underscores for nested properties.
-- `<identifier>`: Represents a word (e.g., property names, action names, etc.).
-- `<positive-integer>`: Represents a whole number greater than zero.
-- `<order-clause>`: Specifies the optional order clause, starting with `OrderBy` and followed by one or more order items.
-- `<order-item>`: Represents an ordered collection of entity attributes by which to sort results, including an optional `Asc` or `Desc` to specify the sort direction.
+- `query`: May be a `find` query, or an `update`, `delete`, `count`, or `exists` operation.
+- `find`: A `find` query has a specification of records to be retrieved, and optional sorting.
+- `action`: Any other kind of operation has only a restriction to a subset of records.
+- `specification`: A `find` query may retrieve all records, or may restrict the records retrieved by a predicate and an optional limit.
+- `restriction`: Any other kind of operation may apply to all records or to a subset of records restricted by a predicate
+- `limit`: Limits the records retrieved by a `find` query to a hardcoded maximum, such as `First10`.
+- `ignoredText`: Optional text that does not contain `By` or `All`.
+- `predicate`: Represents the query's condition or filtering criteria, which can include multiple conditions separated by `And` or `Or`.
+- `condition`: Specifies a property and an operator for the condition.
+- `operator`: Defines the operator for the condition, like `Between` or `LessThan`. When absent, equality is implied.
+- `property`: A property name, which can include underscores for nested properties.
+- `identifier`: A legal Java identifier, not containing an underscore.
+- `max`: A whole number greater than zero.
+- `order`: Specifies that results of a `find` query should be sorted lexicographically, with respect to one or more order items.
+- `orderItem`: An field used to sort results, where `Asc` or `Desc` specifies the sorting direction.
 
 === Query by Method Name Keywords
 

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers.java
@@ -40,7 +40,7 @@ import ee.jakarta.tck.data.framework.read.only.NaturalNumber.NumberType;
 @Repository
 public interface NaturalNumbers extends BasicRepository<NaturalNumber, Long>, IdOperations {
 
-    long countBy();
+    long countAll();
 
     CursoredPage<NaturalNumber> findByFloorOfSquareRootOrderByIdAsc(long sqrtFloor,
                                                                     PageRequest pagination);

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbersPopulator.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbersPopulator.java
@@ -29,7 +29,7 @@ public class NaturalNumbersPopulator implements Populator<NaturalNumbers> {
     
     @Override
     public boolean isPopulated(NaturalNumbers repo) {
-       return repo.countBy() == 100L;
+       return repo.countAll() == 100L;
     }
     
     @Override

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -113,7 +113,7 @@ public class EntityTests {
 
     @Assertion(id = "136", strategy = "Ensures that the prepopulation step for readonly entities was successful")
     public void ensureNaturalNumberPrepopulation() {
-        assertEquals(100L, numbers.countBy());
+        assertEquals(100L, numbers.countAll());
         assertTrue(numbers.findById(0L).isEmpty(), "Zero should not have been in the set of natural numbers.");
         assertFalse(numbers.findById(10L).get().isOdd());
     }

--- a/tck/src/main/java/ee/jakarta/tck/data/web/validation/Rectangles.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/web/validation/Rectangles.java
@@ -36,13 +36,13 @@ public interface Rectangles extends DataRepository<Rectangle, String> {
     List<Rectangle> saveAll(@Valid List<Rectangle> entities);
     
     @PositiveOrZero
-    long countBy();
+    long countAll();
 
     @Find
     Stream<Rectangle> findAll();
     
-    void deleteAllBy();
+    void deleteAll();
 
     @Size(min = 0, max = 3)
-    List<Rectangle> findAllByOrderByIdAsc();
+    List<Rectangle> findAllOrderById();
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/web/validation/ValidationTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/web/validation/ValidationTests.java
@@ -51,7 +51,7 @@ public class ValidationTests {
     
     @BeforeEach
     public void cleanup() {
-        rectangles.deleteAllBy();
+        rectangles.deleteAll();
         TestPropertyUtility.waitForEventualConsistency();
     }
     
@@ -64,7 +64,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(1, rectangles.countBy());
+        assertEquals(1, rectangles.countAll());
         assertRectangleFields(validRect, getResults().get(0));
         
         // Save All
@@ -78,7 +78,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(4, rectangles.countBy(), "Number of results was incorrect");
+        assertEquals(4, rectangles.countAll(), "Number of results was incorrect");
         
         //validate
         List<Rectangle> resultRects = getResults();
@@ -100,7 +100,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(0, rectangles.countBy(), "No rectangles should have presisted to database while violating constraints.");
+        assertEquals(0, rectangles.countAll(), "No rectangles should have presisted to database while violating constraints.");
         assertEquals(4, resultingException.getConstraintViolations().size(), "Incorrect number of constraint violations.");
         
         // Save All
@@ -118,7 +118,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(0, rectangles.countBy(), "No rectangles should have presisted to database while violating constraints.");
+        assertEquals(0, rectangles.countAll(), "No rectangles should have presisted to database while violating constraints.");
         assertEquals(5, resultingException.getConstraintViolations().size(), "Incorrect number of constraint violations.");        
     }
     
@@ -131,7 +131,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(1, rectangles.countBy(), "Number of results was incorrect");
+        assertEquals(1, rectangles.countAll(), "Number of results was incorrect");
         assertRectangleFields(validRect, getResults().get(0));
         
         // Update
@@ -140,7 +140,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(1, rectangles.countBy(), "Number of results was incorrect");
+        assertEquals(1, rectangles.countAll(), "Number of results was incorrect");
         assertRectangleFields(updatedRect, getResults().get(0));     
     }
     
@@ -158,7 +158,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(4, rectangles.countBy(), "Number of results was incorrect");
+        assertEquals(4, rectangles.countAll(), "Number of results was incorrect");
         
         // Update All
         List<Rectangle> updatedRects = List.of(
@@ -171,7 +171,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(4, rectangles.countBy(), "Number of results was incorrect");
+        assertEquals(4, rectangles.countAll(), "Number of results was incorrect");
         
         // Verify All
         List<Rectangle> resultRects = getResults();
@@ -190,7 +190,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(1, rectangles.countBy(), "Number of results was incorrect");
+        assertEquals(1, rectangles.countAll(), "Number of results was incorrect");
         
         // Update
         Rectangle updatedInvalidRect = new Rectangle("RECT-040", -5L, -5L, -5, -5);
@@ -200,7 +200,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(1, rectangles.countBy(), "Number of results was incorrect");
+        assertEquals(1, rectangles.countAll(), "Number of results was incorrect");
         assertEquals(4, resultingException.getConstraintViolations().size());
         
         // Verify
@@ -223,7 +223,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(4, rectangles.countBy(), "Number of results was incorrect");
+        assertEquals(4, rectangles.countAll(), "Number of results was incorrect");
         
         // Update All
         List<Rectangle> invalidRects = List.of(
@@ -238,7 +238,7 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(4, rectangles.countBy(), "Number of results was incorrect");
+        assertEquals(4, rectangles.countAll(), "Number of results was incorrect");
         assertEquals(4, resultingException.getConstraintViolations().size());
         
         // Verify
@@ -261,10 +261,10 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(3, rectangles.countBy(), "Number of results was incorrect");
+        assertEquals(3, rectangles.countAll(), "Number of results was incorrect");
         
         // Get
-        List<Rectangle> resultRects = rectangles.findAllByOrderByIdAsc();
+        List<Rectangle> resultRects = rectangles.findAllOrderById();
         
         // Verify
         for(int i = 0; i < resultRects.size(); i++) {
@@ -288,11 +288,11 @@ public class ValidationTests {
         
         TestPropertyUtility.waitForEventualConsistency();
         
-        assertEquals(4, rectangles.countBy(), "Number of results was incorrect");
+        assertEquals(4, rectangles.countAll(), "Number of results was incorrect");
         
         // Get
         resultingException = assertThrows(ConstraintViolationException.class, () -> {
-            rectangles.findAllByOrderByIdAsc(); //returns 4 results when max is 3
+            rectangles.findAllOrderById(); //returns 4 results when max is 3
         });
         
         // Verify


### PR DESCRIPTION
In light of #657 I took a close look at this and I propose the following improvements:

1. only `find` queries can have sorting
2. introduce `All` keyword to allow queries with no restriction, resolving #657
3. simplify `OrderBy` to disallow "weird" things
4. rewrite the grammar using a more readable (ANTLR-style) syntax
