### PR TITLE
Fix more javadoc broken by the PageRequest/Sort decoupling

### DIFF
--- a/api/src/main/java/jakarta/data/page/CursoredPage.java
+++ b/api/src/main/java/jakarta/data/page/CursoredPage.java
@@ -120,7 +120,7 @@ import java.util.NoSuchElementException;
  * &#64;OrderBy("birthYear")
  * &#64;OrderBy("id")
  * CursoredPage&lt;Customer&gt; getTopBuyers(int minOrders, float minSpent,
- *                                     PageRequest pageRequest, Order&lt;Customer&gt;} sort);
+ *                                     PageRequest pageRequest);
  * </pre>
  *
  * <p>Only queries which return entities may be used with cursor-based pagination

--- a/api/src/main/java/jakarta/data/page/PageRequest.java
+++ b/api/src/main/java/jakarta/data/page/PageRequest.java
@@ -37,20 +37,19 @@ import java.util.Optional;
  * <pre>
  * &#64;OrderBy("age")
  * &#64;OrderBy("ssn")
- * Person[] findByAgeBetween(int minAge, int maxAge,
- *         PageRequest&lt;Person&gt; pageRequest);
+ * Person[] findByAgeBetween(int minAge, int maxAge, PageRequest pageRequest);
  * </pre>
  *
  * <p>This method might be called as follows:</p>
  *
  * <pre>
  * var page = people.findByAgeBetween(35, 59,
- *         PageRequest.of(Person.class).size(100));
+ *                PageRequest.ofSize(100));
  * var results = page.content();
  * ...
  * while (page.hasNext()) {
  *     page = people.findByAgeBetween(35, 59,
- *             page.nextPageRequest().withoutTotal());
+ *                page.nextPageRequest().withoutTotal());
  *     results = page.content();
  *   ...
  * }
@@ -64,12 +63,6 @@ import java.util.Optional;
  * <li>a parameter of type {@code PageRequest} in combination with the
  *     keyword {@code First}.</li>
  * </ul>
- *
- *
- * <p>A repository method throws {@link jakarta.data.exceptions.DataException}
- * if the database is incapable of ordering the query results using the given
- * sort criteria.</p>
- *
  */
 public interface PageRequest {
 

--- a/api/src/main/java/jakarta/data/page/package-info.java
+++ b/api/src/main/java/jakarta/data/page/package-info.java
@@ -30,9 +30,10 @@
  * to allow data to be read in pages,</p>
  *
  * <pre>
- * PageRequest.of(Person.class).size(25).sortBy(Sort.asc("lastName"),
- *                                              Sort.asc("firstName"),
- *                                              Sort.asc("id")); // unique identifier
+ * Order&lt;Person&gt; sorts = Order.by(Sort.asc("lastName"),
+ *                                Sort.asc("firstName"),
+ *                                Sort.asc("id")); // unique identifier
+ * Page&lt;Person&gt; page1 = people.findByAge(50, sorts, PageRequest.ofSize(25));
  * </pre>
  *
  * <p>In the example above, even if multiple people have the same last names

--- a/api/src/main/java/jakarta/data/repository/BasicRepository.java
+++ b/api/src/main/java/jakarta/data/repository/BasicRepository.java
@@ -75,8 +75,9 @@ import static jakarta.data.repository.By.ID;
  *
  * boolean deleted = employees.deleteByBadgeNumber(emp.badgeNum);
  *
- * PageRequest&lt;Employee&gt; pageRequest = PageRequest.of(Employee.class).size(25).sortBy(Sort.asc("name"));
- * Page&lt;Employee&gt; page = people.findAll(pageRequest);
+ * PageRequest pageRequest = PageRequest.ofSize(25);
+ * Order&lt;Employee&gt; sorts = Order.by(Sort.asc("name"));
+ * Page&lt;Employee&gt; page = people.findAll(pageRequest, sorts);
  * </pre>
  *
  * <p>The module Javadoc provides an {@link jakarta.data/ overview} of Jakarta Data.</p>

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -757,7 +757,7 @@ import java.util.Set;
  * The results may even be limited to a positioned range. For example,</p>
  *
  * <pre>
- * &#64;Query("WHERE (fullPrice - salePrice) / fullPrice &gt;= ?1 ORDER BY salePrice DESC")
+ * &#64;Query("WHERE (fullPrice - salePrice) / fullPrice &gt;= ?1 ORDER BY salePrice DESC, id ASC")
  * Product[] highlyDiscounted(float minPercentOff, Limit limit);
  *
  * ...
@@ -772,12 +772,16 @@ import java.util.Set;
  * allows its results to be split and retrieved in pages. For example,</p>
  *
  * <pre>
- * Product[] findByNameLikeOrderByAmountSoldDescNameAsc(
- *           String pattern, PageRequest pageRequest);
+ * Product[] findByNameLikeOrderByAmountSoldDescIdAsc(
+ *                 String pattern, PageRequest pageRequest);
  * ...
- * page1 = products.findByNameLikeOrderByAmountSoldDescNameAsc(
- *                  "%phone%", PageRequest.ofSize(20));
+ * page1 = products.findByNameLikeOrderByAmountSoldDescIdAsc(
+ *                 "%phone%", PageRequest.ofSize(20));
  * </pre>
+ *
+ * <p>When using pagination, always ensure that the ordering is consistent
+ * across invocations. One way to achieve this is to include the unique
+ * identifier in the sort criteria.</p>
  *
  * <h3>Sorting</h3>
  *
@@ -793,7 +797,7 @@ import java.util.Set;
  *
  * page1 = products.findByNameLikeAndPriceBetween(
  *                 namePattern, minPrice, maxPrice, page1Request,
- *                 Order.by(Sort.desc("price"), Sort.asc("name"));
+ *                 Order.by(Sort.desc("price"), Sort.asc("id"));
  * </pre>
  *
  * <p>To supply sort criteria dynamically without using pagination, an
@@ -807,7 +811,7 @@ import java.util.Set;
  * found = products.findByNameLike(namePattern, Limit.of(25),
  *                                 Order.by(Sort.desc("price"),
  *                                          Sort.desc("amountSold"),
- *                                          Sort.asc("name")));
+ *                                          Sort.asc("id")));
  * </pre>
  *
  * <p>Generic, untyped {@link Sort} criteria can be supplied directly to a


### PR DESCRIPTION
Another pull to fix example code that was broken by PageRequest/Sort decoupling.
and I also spotted a few places where we have bad example code that isn't allowing for a consistent ordering when using pagination.