### PR TITLE
Static metamodel examples show bad coding practices

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/StaticMetamodel.java
+++ b/api/src/main/java/jakarta/data/metamodel/StaticMetamodel.java
@@ -35,6 +35,7 @@ import jakarta.data.Sort;
  *
  * <p>Jakarta Data defines the following conventions for static metamodel classes:</p>
  * <ul>
+ * <li>The metamodel class can be an interface or concrete class.</li>
  * <li>The name of the static metamodel class should consist of underscore ({@code _})
  *     followed by the entity class name.</li>
  * <li>Fields of type {@code String} should be named with all upper case.</li>
@@ -95,8 +96,10 @@ import jakarta.data.Sort;
  * for entities at compile time. The generated classes must be annotated with the
  * {@link jakarta.annotation.Generated @Generated} annotation. The fields may be
  * statically initialized, or they may be initialized by the provider during system
- * initialization. In the first case, the fields are declared {@code final}. In the
- * second case, the fields are declared non-{@code final} and {@code volatile}.</p>
+ * initialization. In the first case, the fields are declared {@code final} and the
+ * metamodel class can be an interface. In the second case, the fields are declared
+ * non-{@code final} and {@code volatile} and the metamodel class must be a concrete
+ * class.</p>
  *
  * <p>In cases where multiple Jakarta Data providers provide repositories for the same
  * entity type, no guarantees are made of the order in which the Jakarta Data providers

--- a/api/src/main/java/jakarta/data/metamodel/StaticMetamodel.java
+++ b/api/src/main/java/jakarta/data/metamodel/StaticMetamodel.java
@@ -66,19 +66,18 @@ import jakarta.data.Sort;
  *
  * <pre>
  * &#64;StaticMetamodel(Person.class)
- * public class _Person {
- *     // These can be uninitialized and non-final if you don't need to access them from annotations.
- *     public static final String SSN = "ssn";
- *     public static final String NAME = "name";
- *     public static final String NAME_FIRST = "name.first";
- *     public static final String NAME_LAST = "name.last";
- *     public static final String YEAROFBIRTH = "yearOfBirth";
+ * public interface _Person {
+ *     String SSN = "ssn";
+ *     String NAME = "name";
+ *     String NAME_FIRST = "name.first";
+ *     String NAME_LAST = "name.last";
+ *     String YEAROFBIRTH = "yearOfBirth";
  *
- *     public static final SortableAttribute&lt;Person&gt; ssn = new SortableAttributeRecord&lt;&gt;("ssn");
- *     public static final Attribute&lt;Person&gt; name = new AttributeRecord&lt;&gt;("name");
- *     public static final TextAttribute&lt;Person&gt; name_first = new TextAttributeRecord&lt;&gt;("name.first");
- *     public static final TextAttribute&lt;Person&gt; name_last = new TextAttributeRecord&lt;&gt;("name.last");
- *     public static final SortableAttribute&lt;Person&gt; yearOfBirth = new SortableAttributeRecord&lt;&gt;("yearOfBirth");
+ *     SortableAttribute&lt;Person&gt; ssn = new SortableAttributeRecord&lt;&gt;(SSN);
+ *     Attribute&lt;Person&gt; name = new AttributeRecord&lt;&gt;(NAME);
+ *     TextAttribute&lt;Person&gt; name_first = new TextAttributeRecord&lt;&gt;(NAME_FIRST);
+ *     TextAttribute&lt;Person&gt; name_last = new TextAttributeRecord&lt;&gt;(NAME_LAST);
+ *     SortableAttribute&lt;Person&gt; yearOfBirth = new SortableAttributeRecord&lt;&gt;(YEAROFBIRTH);
  * }
  * </pre>
  *

--- a/api/src/main/java/jakarta/data/metamodel/package-info.java
+++ b/api/src/main/java/jakarta/data/metamodel/package-info.java
@@ -34,10 +34,14 @@
  * }
  *
  * &#64;StaticMetamodel(Product.class)
- * public class _Product {
- *     public static volatile SortableAttribute&lt;Product&gt; id;
- *     public static volatile TextAttribute&lt;Product&gt; name;
- *     public static volatile SortableAttribute&lt;Product&gt; price);
+ * public interface _Product {
+ *     String ID = "id";
+ *     String NAME = "name";
+ *     String PRICE = "price";
+ *
+ *     SortableAttribute&lt;Product&gt; id = new SortableAttributeRecord&lt;&gt;(ID);
+ *     TextAttribute&lt;Product&gt; name = new TextAttributeRecord&lt;&gt;(NAME);
+ *     SortableAttribute&lt;Product&gt; price = new SortableAttributeRecord&lt;&gt;(PRICE);
  * }
  *
  * ...

--- a/spec/src/main/asciidoc/entity.asciidoc
+++ b/spec/src/main/asciidoc/entity.asciidoc
@@ -384,6 +384,7 @@ Jakarta Data provides a static metamodel that allows entity attributes to be acc
 
 For each entity class, the application developer or a compile-time annotation processor can define a corresponding metamodel class following a prescribed set of conventions.
 
+- The metamodel class can be an interface or concrete class.
 - The metamodel class must be annotated with `@StaticMetamodel`, specifying the entity class as its `value`.
 - The metamodel class contains one or more `public static` fields corresponding to persistent fields of the entity class.
 - The type of each of these fields must be either `java.lang.String`, `jakarta.data.metamodel.Attribute`, or a subinterface of `Attribute` from the package `jakarta.data.metamodel`.
@@ -394,7 +395,7 @@ The application can use the field values of the metamodel class to obtain artifa
 
 When an application programmer writes a static metamodel class for an entity by hand:
 
-- each field corresponding to a persistent field of an entity must have modifiers `public`, `static`, and `final`, and
+- each field corresponding to a persistent field of an entity must have modifiers `public`, `static`, and `final` (these are implicit when the metamodel class is an interface), and
 - the fields must be statically initialized.
 
 The static metamodel class is not required to include a field for every persistent field of the entity.


### PR DESCRIPTION
I noticed this while reviewing the PageRequest/Sort decoupling, but it is not actually related so I opened a separate PR for it.

The examples we give for static metamodel classes in the javadoc have some bad practices.  In one example, we are initializing all the fields and unnecessarily marking them `volatile` rather than `final`, which results in unsafe code that could accidentally be overwritten at run time with no benefit. I don't want anyone copy/pasting from that - either when they write an annotation processor or for direct use.

In another example, we aren't even using our own constants: `new SortableAttributeRecord&lt;&gt;("ssn");`
We already defined an `SSN` constant for the `"ssn"` value only a few lines above, and we should be using it here.

Also, these could be a lot cleaner with implicit `public static final` if using an interface class rather than a concrete class.

This pull makes the above changes.

One improvement that I didn't make, because it would go beyond being a bug fix and require an API change is to switch
`SortableAttribute<Person> ssn = new SortableAttributeRecord<>(SSN);` // uses class in impl package
to
`SortableAttribute<Person> ssn = SortableAttribute.of(SSN);`
so that we could avoid externalizing the impl package entirely. That would be something to think about for future.