### PR TITLE
next() and previous() are confusing the purpose of PageRequest

### DIFF
--- a/api/src/main/java/jakarta/data/page/CursoredPage.java
+++ b/api/src/main/java/jakarta/data/page/CursoredPage.java
@@ -192,10 +192,9 @@ public interface CursoredPage<T> extends Page<T> {
      * when matching entities are added prior to the first page and the
      * previous page is requested) by assigning a page number of {@code 1}
      * to such pages. This means that there can be multiple consecutive pages
-     * numbered {@code 1} and that
-     * {@code currentPage.previousPageRequest().next().page()}
-     * cannot be relied upon to return a page number that is equal to the
-     * current page number.</p>
+     * numbered {@code 1} and that navigating to the previous page and then
+     * forward again cannot be relied upon to return a page number that is
+     * equal to the current page number.</p>
      *
      * @return pagination information for requesting the previous page.
      * @throws NoSuchElementException if the current page is empty or if

--- a/api/src/main/java/jakarta/data/page/Page.java
+++ b/api/src/main/java/jakarta/data/page/Page.java
@@ -109,8 +109,8 @@ public interface Page<T> extends Iterable<T> {
 
 
     /**
-     * Returns a request for the {@linkplain PageRequest#next() next} page if
-     * {@link #hasNext()} indicates there might be a next page.
+     * Returns a request for the next page if {@link #hasNext()} indicates there
+     * might be a next page.
      *
      * @return a request for the next page.
      * @throws NoSuchElementException if it is known that there is no next page.
@@ -122,8 +122,8 @@ public interface Page<T> extends Iterable<T> {
 
 
     /**
-     * <p>Returns a request for the {@link PageRequest#previous() previous} page,
-     * if {@link #hasPrevious()} indicates there might be a previous page.</p>
+     * <p>Returns a request for the previous page, if {@link #hasPrevious()}
+     * indicates there might be a previous page.</p>
      *
      * @return a request for the previous page.
      * @throws NoSuchElementException if it is known that there is no previous page.

--- a/api/src/main/java/jakarta/data/page/PageRequest.java
+++ b/api/src/main/java/jakarta/data/page/PageRequest.java
@@ -197,40 +197,6 @@ public interface PageRequest {
      */
     boolean requestTotal();
 
-
-    /**
-     * <p>Returns the {@code PageRequest} requesting the next page if
-     * using offset pagination.</p>
-     *
-     * <p>If using cursor-based pagination, traversal of pages must only be done
-     * via the {@link CursoredPage#nextPageRequest()},
-     * {@link CursoredPage#previousPageRequest()}, or
-     * {@linkplain CursoredPage#cursor(int) cursor},
-     * not with this method.</p>
-     *
-     * @return The next PageRequest.
-     * @throws UnsupportedOperationException if this {@code PageRequest}
-     *         has a {@link PageRequest.Cursor Cursor}.
-     */
-    PageRequest next();
-
-    /**
-     * <p>Returns the {@code PageRequest} requesting the previous page
-     * if using offset pagination, or null if this is the first page, that
-     * is, when {@link #page()} returns {@code 1}.</p>
-     *
-     * <p>If using cursor-based pagination, traversal of pages must only be done
-     * via the {@link CursoredPage#nextPageRequest()},
-     * {@link CursoredPage#previousPageRequest()}, or
-     * {@linkplain CursoredPage#cursor(int) cursor},
-     * not with this method.</p>
-     *
-     * @return The previous PageRequest, or null if this is the first page.
-     * @throws UnsupportedOperationException if this {@code PageRequest}
-     *         has a {@link PageRequest.Cursor Cursor}.
-     */
-    PageRequest previous();
-
     /**
      * <p>Creates a new page request with the same pagination information,
      * but with the specified page number.</p>

--- a/api/src/main/java/jakarta/data/page/Pagination.java
+++ b/api/src/main/java/jakarta/data/page/Pagination.java
@@ -72,26 +72,6 @@ record Pagination(long page, int size, Mode mode, Cursor type, boolean requestTo
     }
 
     @Override
-    public PageRequest next() {
-        if (mode == Mode.OFFSET) {
-            return new Pagination(page + 1, this.size, Mode.OFFSET, null, requestTotal);
-        } else {
-            throw new UnsupportedOperationException("Not supported for cursor-based pagination. Instead use afterKey or afterCursor " +
-                    "to provide a cursor or obtain the nextPageRequest from a CursoredPage.");
-        }
-    }
-
-    @Override
-    public PageRequest previous() {
-        if (mode == Mode.OFFSET) {
-            return page()<=1 ? null : new Pagination(page - 1, this.size, Mode.OFFSET, null, requestTotal);
-        } else {
-            throw new UnsupportedOperationException("Not supported for cursor-based pagination. Instead use beforeKey or beforeCursor " +
-                    "to provide a cursor or obtain the previousPageRequest from a CursoredPage.");
-        }
-    }
-
-    @Override
     public String toString() {
         StringBuilder s = new StringBuilder(mode == Mode.OFFSET ? 100 : 150)
                 .append("PageRequest{page=").append(page)

--- a/api/src/main/java/jakarta/data/page/impl/PageRecord.java
+++ b/api/src/main/java/jakarta/data/page/impl/PageRecord.java
@@ -84,7 +84,7 @@ public record PageRecord<T>(PageRequest pageRequest, List<T> content, long total
         if (!hasNext()) {
             throw new NoSuchElementException();
         }
-        return pageRequest.next();
+        return pageRequest.page(pageRequest.page() + 1);
     }
 
     @Override
@@ -97,7 +97,7 @@ public record PageRecord<T>(PageRequest pageRequest, List<T> content, long total
         if (!hasPrevious()) {
             throw new NoSuchElementException();
         }
-        return pageRequest.previous();
+        return pageRequest.page(pageRequest.page() - 1);
     }
 
     @Override

--- a/api/src/test/java/jakarta/data/page/PageRequestTest.java
+++ b/api/src/test/java/jakarta/data/page/PageRequestTest.java
@@ -53,20 +53,6 @@ class PageRequestTest {
     }
 
     @Test
-    @DisplayName("Should navigate next")
-    void shouldNext() {
-        PageRequest pageRequest = PageRequest.ofSize(1).page(2);
-        PageRequest next = pageRequest.next();
-
-        assertSoftly(softly -> {
-            softly.assertThat(pageRequest.page()).isEqualTo(2L);
-            softly.assertThat(pageRequest.size()).isEqualTo(1);
-            softly.assertThat(next.page()).isEqualTo(3L);
-            softly.assertThat(next.size()).isEqualTo(1);
-        });
-    }
-
-    @Test
     @DisplayName("Should create a new PageRequest at the given page with a default size of 10")
     void shouldCreatePage() {
         PageRequest pageRequest = PageRequest.ofPage(5);

--- a/api/src/test/java/jakarta/data/page/PaginationTest.java
+++ b/api/src/test/java/jakarta/data/page/PaginationTest.java
@@ -20,10 +20,7 @@ package jakarta.data.page;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
-
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class PaginationTest {
 
@@ -35,16 +32,4 @@ class PaginationTest {
                 .isThrownBy(() -> new Pagination(1, 10, PageRequest.Mode.CURSOR_NEXT, null, true));
     }
 
-    @Test
-    @DisplayName("Should throw UnsupportedOperationException when key is not supported")
-    void shouldThrowExceptionWhenKeysetIsNotSupported() {
-        assertThatThrownBy(() -> {
-            Pagination pagination = new Pagination(1, 10,
-                                                        PageRequest.Mode.CURSOR_NEXT,
-                                                        new PageRequestCursor("me", 200),
-                                                        true);
-            pagination.next();
-        }).isInstanceOf(UnsupportedOperationException.class)
-                .hasMessage("Not supported for cursor-based pagination. Instead use afterKey or afterCursor to provide a cursor or obtain the nextPageRequest from a CursoredPage.");
-    }
 }


### PR DESCRIPTION
Covers some of the issues behind #672 by removing next() and previous() from PageRequest. Those methods are causing confusion about the purpose of PageRequest.  PageRequest is already a builder that collects the configuration for requesting a next page.  It is out of place for it to have operations on it that relate to navigation.  It is not even capable of performing those operations correctly as evidenced by its own JavaDoc which states those operations fail and don't work with cursor-based pagination. They aren't even safe for offset-based pagination because they will keep telling you there are more and more next pages to request with ever increasing page numbers even when no such pages exist.  The next() method is highly likely to lead some users to write code with an infinite loop.  The correct way to perform page traversal is with Page.hasNext()/hasPrevious() and Page.nextPageRequest() and previousPageRequest(). These methods properly account for both types of pagination and are built to inform the user when there cannot be a next or previous page, and, if the user neglects to check if there can be a next/previous page, to fail instead of looping infinitely.