### PR TITLE
PageRequest toString wrongly states a cursor has multiple keys

### DIFF
--- a/api/src/main/java/jakarta/data/page/PageRequestCursor.java
+++ b/api/src/main/java/jakarta/data/page/PageRequestCursor.java
@@ -38,7 +38,7 @@ class PageRequestCursor implements PageRequest.Cursor {
     PageRequestCursor(Object... key) {
         this.key = key;
         if (key == null || key.length == 0)
-            throw new IllegalArgumentException("No key values were provided.");
+            throw new IllegalArgumentException("No values were provided.");
     }
 
     @Override
@@ -69,6 +69,6 @@ class PageRequestCursor implements PageRequest.Cursor {
     @Override
     public String toString() {
         return "Cursor@" + Integer.toHexString(hashCode()) +
-                " with " + key.length + " keys";
+                " with " + key.length + " values";
     }
 }

--- a/api/src/main/java/jakarta/data/page/Pagination.java
+++ b/api/src/main/java/jakarta/data/page/Pagination.java
@@ -68,7 +68,7 @@ record Pagination(long page, int size, Mode mode, Cursor type, boolean requestTo
                 .append(", size=").append(size)
                 .append(", mode=").append(mode);
         if (type != null) {
-            s.append(", ").append(type.size()).append(" keys");
+            s.append(", cursor size=").append(type.size());
         }
         return s.append("}").toString();
     }

--- a/api/src/test/java/jakarta/data/page/PageRequestCursorTest.java
+++ b/api/src/test/java/jakarta/data/page/PageRequestCursorTest.java
@@ -130,10 +130,10 @@ class PageRequestCursorTest {
         assertSoftly(softly -> {
 
             softly.assertThat(afterKeySet.toString())
-              .isEqualTo("PageRequest{page=1, size=200, mode=CURSOR_NEXT, 2 keys}");
+              .isEqualTo("PageRequest{page=1, size=200, mode=CURSOR_NEXT, cursor size=2}");
 
             softly.assertThat(beforeKeySet.toString())
-                    .isEqualTo("PageRequest{page=1, size=100, mode=CURSOR_PREVIOUS, 2 keys}");
+                    .isEqualTo("PageRequest{page=1, size=100, mode=CURSOR_PREVIOUS, cursor size=2}");
 
         });
     }


### PR DESCRIPTION
toString of both Pagination (PageRequest) and PageRequestCursor (Cursor) both output a string that says the cursor has X number of keys. This is inaccurate. There is only one key, which is formed by all of the values.  This PR makes corrections to the toString output.