### PR TITLE
fix bug in TCK testVersionedInsertUpdateDelete()

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/PersistenceEntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/PersistenceEntityTests.java
@@ -331,6 +331,7 @@ public class PersistenceEntityTests {
             // expected
         }
 
+        prod2.setVersionNum(prod2InitialVersion);
         try {
             catalog.remove(prod2); // still at old version
             fail("Must raise OptimisticLockingFailureException for entity with non-matching version.");


### PR DESCRIPTION
If `modify()` increments the version number before throwing, the `delete()` call will succeed instead of failing.

A general rule of JPA is that one must discard entity instances after receiving an error, since there is simply no way to know if they are in sync with the database.

This test disobeys that rule, and reuses an instance after a thrown exception. Whether the version number of this instance has been incremented before the exception is thrown is 100% provider dependent and JPA makes absolutely no guarantees.

The simplest fix is to just set the version number back to the initial version. A better fix would be to not reuse the instance.