### PR TITLE
Extract Constant at PageRequest

### DIFF
--- a/api/src/main/java/jakarta/data/page/PageRequest.java
+++ b/api/src/main/java/jakarta/data/page/PageRequest.java
@@ -69,6 +69,9 @@ import java.util.Optional;
 public interface PageRequest {
 
 
+    int SIZE = 10;
+    int FIRST_PAGE = 1;
+
     /**
      * Creates a new page request with the given page number and with a default size of 10.
      *
@@ -77,7 +80,7 @@ public interface PageRequest {
      * @throws IllegalArgumentException when the page number is negative or zero.
      */
     static PageRequest ofPage(long pageNumber) {
-        return new Pagination(pageNumber, 10, Mode.OFFSET, null, true);
+        return new Pagination(pageNumber, SIZE, Mode.OFFSET, null, true);
     }
 
     /**
@@ -104,7 +107,7 @@ public interface PageRequest {
      * @throws IllegalArgumentException when maximum page size is negative or zero.
      */
     static PageRequest ofSize(int maxPageSize) {
-        return new Pagination(1, maxPageSize,  Mode.OFFSET, null, true);
+        return new Pagination(FIRST_PAGE, maxPageSize,  Mode.OFFSET, null, true);
     }
 
     /**

--- a/api/src/main/java/jakarta/data/page/PageRequest.java
+++ b/api/src/main/java/jakarta/data/page/PageRequest.java
@@ -73,7 +73,7 @@ public interface PageRequest {
      * to define a standard page size across paginated queries where only the page number is specified,
      * ensuring a consistent pagination behavior.
      */
-    int SIZE = 10;
+    int DEFAULT_SIZE = 10;
     /**
      * Represents the first page number in a series of pages. This constant is used to standardize the
      * starting point for pagination operations, particularly when creating new page requests with a default
@@ -89,7 +89,7 @@ public interface PageRequest {
      * @throws IllegalArgumentException when the page number is negative or zero.
      */
     static PageRequest ofPage(long pageNumber) {
-        return new Pagination(pageNumber, SIZE, Mode.OFFSET, null, true);
+        return new Pagination(pageNumber, DEFAULT_SIZE, Mode.OFFSET, null, true);
     }
 
     /**

--- a/api/src/main/java/jakarta/data/page/PageRequest.java
+++ b/api/src/main/java/jakarta/data/page/PageRequest.java
@@ -68,8 +68,17 @@ import java.util.Optional;
  */
 public interface PageRequest {
 
-
+    /**
+     * The default size of each page when no specific size is requested. This constant is used
+     * to define a standard page size across paginated queries where only the page number is specified,
+     * ensuring a consistent pagination behavior.
+     */
     int SIZE = 10;
+    /**
+     * Represents the first page number in a series of pages. This constant is used to standardize the
+     * starting point for pagination operations, particularly when creating new page requests with a default
+     * starting page, thereby ensuring that pagination always begins from the first set of results.
+     */
     int FIRST_PAGE = 1;
 
     /**


### PR DESCRIPTION
# Changes


- Extract constant and avoid magic number at the PageRequest
- Show the default value and the default page number explicitly.
- Also point where the first page number is, helping, because in some vendors the first page starts with "zero".