### PR TITLE
change collection in TCK to use fetch=EAGER

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/Product.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/Product.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import jakarta.persistence.Basic;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Transient;
 import jakarta.persistence.Version;
@@ -31,7 +32,7 @@ public class Product {
         APPLIANCES, AUTOMOTIVE, CLOTHING, CRAFTS, ELECTRONICS, FURNITURE, GARDEN, GROCERY, OFFICE, PHARMACY, SPORTING_GOODS, TOOLS
     }
 
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.EAGER)
     private Set<Department> departments;
 
     @Basic(optional = false)


### PR DESCRIPTION
Jakarta Data repositories are stateless, and Jakarta Data entities are unmanaged objects, and thus lazy fetching is impossible.

However the TCK makes use of it at line 77 of `PersistenceTests`.

I have fixed this issue by changing the mapping of the `@ElementCollection` to `EAGER`.
