### PR TITLE
Fix required property jakarta.tck.profile

### DIFF
--- a/tck-dist/src/main/asciidoc/sections/07.1se-mode.adoc
+++ b/tck-dist/src/main/asciidoc/sections/07.1se-mode.adoc
@@ -34,6 +34,9 @@ All test classes that support running in standalone mode are annotated with the 
 When running in standalone mode, include the group `<groups>standalone<groups>`.
 This will ensure that none of the core/web/full profile tests are run.
 
+When running in standalone mode, include the system property `<jakarta.tck.profile>none</jakarta.tck.profile>`.
+This will ensure that no deployments are created and that all tests are run on the client JVM.
+
 ==== Entity Modes
 
 All test classes in the TCK are annotated with `@NoSQL`, `@Persistence`, or `@AnyEntity` annotations.
@@ -48,7 +51,7 @@ It is recommended to avoid using `<excludedGroups>` as the surefire plugin has a
 where excluded groups do not have precedence over included groups. 
 
 Therefore, if you wanted to run standalone tests with a NoSQL entities you would 
-configure `<groups>standalone & nosql<groups>`.
+configure `<groups><![CDATA[standalone & nosql]]><groups>`.
 
 ==== Standalone Logging
 
@@ -62,5 +65,5 @@ Example se-pom.xml:
 
 [source, xml]
 ----
-include::{starterLoc}/se-pom.xml[tags=systemProperties;!signature;!standalone;!entity]
+include::{starterLoc}/se-pom.xml[tags=systemProperties;!signature;!standalone;!entity;!profile]
 ----

--- a/tck-dist/src/main/asciidoc/sections/07.1se-mode.adoc
+++ b/tck-dist/src/main/asciidoc/sections/07.1se-mode.adoc
@@ -34,7 +34,7 @@ All test classes that support running in standalone mode are annotated with the 
 When running in standalone mode, include the group `<groups>standalone<groups>`.
 This will ensure that none of the core/web/full profile tests are run.
 
-When running in standalone mode, optionally include the system property `<jakarta.tck.standalone>true</jakarta.tck.standalone>`.
+When running in standalone mode, optionally include the system property `<jakarta.tck.skip.deployment>true</jakarta.tck.skip.deployment>`.
 This will ensure that no deployments are created and that all tests are run on the client JVM.
 
 ==== Entity Modes

--- a/tck-dist/src/main/asciidoc/sections/07.1se-mode.adoc
+++ b/tck-dist/src/main/asciidoc/sections/07.1se-mode.adoc
@@ -34,7 +34,7 @@ All test classes that support running in standalone mode are annotated with the 
 When running in standalone mode, include the group `<groups>standalone<groups>`.
 This will ensure that none of the core/web/full profile tests are run.
 
-When running in standalone mode, include the system property `<jakarta.tck.profile>none</jakarta.tck.profile>`.
+When running in standalone mode, optionally include the system property `<jakarta.tck.standalone>true</jakarta.tck.standalone>`.
 This will ensure that no deployments are created and that all tests are run on the client JVM.
 
 ==== Entity Modes

--- a/tck-dist/src/main/asciidoc/sections/07.1se-mode.adoc
+++ b/tck-dist/src/main/asciidoc/sections/07.1se-mode.adoc
@@ -34,8 +34,8 @@ All test classes that support running in standalone mode are annotated with the 
 When running in standalone mode, include the group `<groups>standalone<groups>`.
 This will ensure that none of the core/web/full profile tests are run.
 
-When running in standalone mode, optionally include the system property `<jakarta.tck.skip.deployment>true</jakarta.tck.skip.deployment>`.
-This will ensure that no deployments are created and that all tests are run on the client JVM.
+When running in standalone mode, include the system property `<jakarta.tck.skip.deployment>true</jakarta.tck.skip.deployment>`.
+This will ensure that no Arquillian deployments are created and that all tests are run on the client JVM.
 
 ==== Entity Modes
 

--- a/tck-dist/src/main/asciidoc/sections/07.2ee-mode.adoc
+++ b/tck-dist/src/main/asciidoc/sections/07.2ee-mode.adoc
@@ -38,7 +38,7 @@ All test classes that require running on a Jakarta profile are annotated with th
 
 When running against a Jakarta profile, include the group that matches your supported profile. For example: `<groups>core<groups>`.
 
-When running against a Jakarta profile, include the system property `<jakarta.tck.standalone>false</jakarta.tck.standalone>`.
+When running against a Jakarta profile, include the system property `<jakarta.tck.skip.deployment>false</jakarta.tck.skip.deployment>`.
 This will ensure that Arquillian deploys test artifacts to a container and that tests are NOT run on the client JVM.
 
 ==== Entity Modes

--- a/tck-dist/src/main/asciidoc/sections/07.2ee-mode.adoc
+++ b/tck-dist/src/main/asciidoc/sections/07.2ee-mode.adoc
@@ -38,8 +38,8 @@ All test classes that require running on a Jakarta profile are annotated with th
 
 When running against a Jakarta profile, include the group that matches your supported profile. For example: `<groups>core<groups>`.
 
-When running against a Jakarta profile, optionally include the system property `<jakarta.tck.profile>core</jakarta.tck.profile>`.
-This will help differentiate between profile runs.
+When running against a Jakarta profile, include the system property `<jakarta.tck.standalone>false</jakarta.tck.standalone>`.
+This will ensure that Arquillian deploys test artifacts to a container and that tests are NOT run on the client JVM.
 
 ==== Entity Modes
 

--- a/tck-dist/src/main/asciidoc/sections/07.2ee-mode.adoc
+++ b/tck-dist/src/main/asciidoc/sections/07.2ee-mode.adoc
@@ -38,8 +38,8 @@ All test classes that require running on a Jakarta profile are annotated with th
 
 When running against a Jakarta profile, include the group that matches your supported profile. For example: `<groups>core<groups>`.
 
-When running against a Jakarta profile, include the system property `<jakarta.tck.skip.deployment>false</jakarta.tck.skip.deployment>`.
-This will ensure that Arquillian deploys test artifacts to a container and that tests are NOT run on the client JVM.
+When running against a Jakarta profile, optionally include the system property `<jakarta.tck.skip.deployment>false</jakarta.tck.skip.deployment>`.
+By default Arquillian will deploy test artifacts to a container.
 
 ==== Entity Modes
 

--- a/tck-dist/src/main/asciidoc/sections/07.2ee-mode.adoc
+++ b/tck-dist/src/main/asciidoc/sections/07.2ee-mode.adoc
@@ -38,6 +38,9 @@ All test classes that require running on a Jakarta profile are annotated with th
 
 When running against a Jakarta profile, include the group that matches your supported profile. For example: `<groups>core<groups>`.
 
+When running against a Jakarta profile, optionally include the system property `<jakarta.tck.profile>core</jakarta.tck.profile>`.
+This will help differentiate between profile runs.
+
 ==== Entity Modes
 
 All test classes in the TCK are annotated with `@NoSQL`, `@Persistence`, or `@AnyEntity` annotations.
@@ -52,7 +55,7 @@ It is recommended to avoid using `<excludedGroups>` as the surefire plugin has a
 where excluded groups do not have precedence over included groups. 
 
 Therefore, if you wanted to run core profile tests with a NoSQL entities you would 
-configure `<groups>core & nosql<groups>`.
+configure `<groups><![CDATA[core & nosql]]><groups>`.
 
 ==== Configure Arquillian
 
@@ -64,7 +67,7 @@ It is possible to configure the surefire plugin to past variables to the Arquill
 
 [source, xml]
 ----
-include::{starterLoc}/ee-pom.xml[tags=systemProperties;!logging;!signature;!standalone;!entity]
+include::{starterLoc}/ee-pom.xml[tags=systemProperties;!logging;!signature;!standalone;!entity;!profile]
 ----
 
 ==== Configure Jakarta EE Platform Server
@@ -84,7 +87,7 @@ Example ee-pom.xml:
 
 [source, xml]
 ----
-include::{starterLoc}/ee-pom.xml[tags=systemProperties;!arquillian;!signature;!standalone;!entity]
+include::{starterLoc}/ee-pom.xml[tags=systemProperties;!arquillian;!signature;!standalone;!entity;!profile]
 ----
 
 To enable logging for the Server side of tests, set the same system property on the JVM running your application server.

--- a/tck-dist/src/main/starter/ee-pom.xml
+++ b/tck-dist/src/main/starter/ee-pom.xml
@@ -169,8 +169,8 @@
       <java.util.logging.config.file>${basedir}/../logging.properties</java.util.logging.config.file>
       <!-- end::logging[] -->
       <!-- tag::profile[] -->
-      <!-- Optional, to differentiate between profile runs-->
-      <jakarta.tck.profile>[core|web|full]</jakarta.tck.profile>
+      <!-- Required, or else tests will run on client JVM -->
+      <jakarta.tck.standalone>false</jakarta.tck.standalone>
       <!-- end::profile[] -->
      </systemPropertyVariables>
      <!-- end::systemProperties[] -->

--- a/tck-dist/src/main/starter/ee-pom.xml
+++ b/tck-dist/src/main/starter/ee-pom.xml
@@ -170,7 +170,7 @@
       <!-- end::logging[] -->
       <!-- tag::profile[] -->
       <!-- Required, or else tests will run on client JVM -->
-      <jakarta.tck.standalone>false</jakarta.tck.standalone>
+      <jakarta.tck.skip.deployment>false</jakarta.tck.skip.deployment>
       <!-- end::profile[] -->
      </systemPropertyVariables>
      <!-- end::systemProperties[] -->

--- a/tck-dist/src/main/starter/ee-pom.xml
+++ b/tck-dist/src/main/starter/ee-pom.xml
@@ -169,7 +169,7 @@
       <java.util.logging.config.file>${basedir}/../logging.properties</java.util.logging.config.file>
       <!-- end::logging[] -->
       <!-- tag::profile[] -->
-      <!-- Required, or else tests will run on client JVM -->
+      <!-- Optional, Arquillian will deploy artifacts by default -->
       <jakarta.tck.skip.deployment>false</jakarta.tck.skip.deployment>
       <!-- end::profile[] -->
      </systemPropertyVariables>

--- a/tck-dist/src/main/starter/ee-pom.xml
+++ b/tck-dist/src/main/starter/ee-pom.xml
@@ -168,6 +168,10 @@
       <!-- tag::logging[] -->
       <java.util.logging.config.file>${basedir}/../logging.properties</java.util.logging.config.file>
       <!-- end::logging[] -->
+      <!-- tag::profile[] -->
+      <!-- Optional, to differentiate between profile runs-->
+      <jakarta.tck.profile>[core|web|full]</jakarta.tck.profile>
+      <!-- end::profile[] -->
      </systemPropertyVariables>
      <!-- end::systemProperties[] -->
      <!-- Supported tags 

--- a/tck-dist/src/main/starter/se-pom.xml
+++ b/tck-dist/src/main/starter/se-pom.xml
@@ -156,8 +156,8 @@
       <java.util.logging.config.file>${logging.config}</java.util.logging.config.file>
       <!-- end::logging[] -->
       <!-- tag::profile[] -->
-      <!-- Required to disable arquillian deployments -->
-      <jakarta.tck.profile>none</jakarta.tck.profile>
+      <!-- Optional, tests run on client JVM by default -->
+      <jakarta.tck.standalone>true</jakarta.tck.standalone>
       <!-- end::profile[] -->
      </systemPropertyVariables>
      <!-- end::systemProperties[] -->

--- a/tck-dist/src/main/starter/se-pom.xml
+++ b/tck-dist/src/main/starter/se-pom.xml
@@ -157,7 +157,7 @@
       <!-- end::logging[] -->
       <!-- tag::profile[] -->
       <!-- Optional, tests run on client JVM by default -->
-      <jakarta.tck.standalone>true</jakarta.tck.standalone>
+      <jakarta.tck.skip.deployment>true</jakarta.tck.skip.deployment>
       <!-- end::profile[] -->
      </systemPropertyVariables>
      <!-- end::systemProperties[] -->

--- a/tck-dist/src/main/starter/se-pom.xml
+++ b/tck-dist/src/main/starter/se-pom.xml
@@ -155,6 +155,10 @@
       <!-- tag::logging[] -->
       <java.util.logging.config.file>${logging.config}</java.util.logging.config.file>
       <!-- end::logging[] -->
+      <!-- tag::profile[] -->
+      <!-- Required to disable arquillian deployments -->
+      <jakarta.tck.profile>none</jakarta.tck.profile>
+      <!-- end::profile[] -->
      </systemPropertyVariables>
      <!-- end::systemProperties[] -->
      <!-- Supported tags 

--- a/tck-dist/src/main/starter/se-pom.xml
+++ b/tck-dist/src/main/starter/se-pom.xml
@@ -156,7 +156,7 @@
       <java.util.logging.config.file>${logging.config}</java.util.logging.config.file>
       <!-- end::logging[] -->
       <!-- tag::profile[] -->
-      <!-- Optional, tests run on client JVM by default -->
+      <!-- Required, Arquillian will deploy artifacts by default -->
       <jakarta.tck.skip.deployment>true</jakarta.tck.skip.deployment>
       <!-- end::profile[] -->
      </systemPropertyVariables>

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/junit/anno/Standalone.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/junit/anno/Standalone.java
@@ -35,7 +35,7 @@ import ee.jakarta.tck.data.framework.utilities.TestProperty;
  * 
  * <p>The dynamic method in which we achieve the ability to run these tests either
  * on the client JVM or container JVM depends on both the JUnit5 Standalone tag AND 
- * the system property: {@link TestProperty#standalone}  </p>
+ * the system property: {@link TestProperty#skipDeployment}  </p>
  * 
  * <p>If this property is "true" the Arquillian extension will be ignored,
  * otherwise we will attempt to deploy the test using Arquillian.</p>

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/junit/anno/Standalone.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/junit/anno/Standalone.java
@@ -35,9 +35,9 @@ import ee.jakarta.tck.data.framework.utilities.TestProperty;
  * 
  * <p>The dynamic method in which we achieve the ability to run these tests either
  * on the client JVM or container JVM depends on both the JUnit5 Standalone tag AND 
- * the system property: {@link TestProperty#profile}  </p>
+ * the system property: {@link TestProperty#standalone}  </p>
  * 
- * <p>If this property is "none" the Arquillian extension will be ignored,
+ * <p>If this property is "true" the Arquillian extension will be ignored,
  * otherwise we will attempt to deploy the test using Arquillian.</p>
  */
 @Target({ ElementType.TYPE })

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/junit/extensions/StandaloneExtension.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/junit/extensions/StandaloneExtension.java
@@ -47,7 +47,7 @@ public class StandaloneExtension extends ArquillianExtension implements BeforeAl
 
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
-        if (TestPropertyUtility.isStandalone()) {
+        if (TestPropertyUtility.skipDeployment()) {
             log.info("Running tests in standalone mode, arquillian will not create or deploy archives for test class: " + context.getTestClass().get().getCanonicalName());
             return;
         }
@@ -56,7 +56,7 @@ public class StandaloneExtension extends ArquillianExtension implements BeforeAl
 
     @Override
     public void afterAll(ExtensionContext context) throws Exception {
-        if (TestPropertyUtility.isStandalone()) {
+        if (TestPropertyUtility.skipDeployment()) {
             return;
         }
         super.afterAll(context);
@@ -64,7 +64,7 @@ public class StandaloneExtension extends ArquillianExtension implements BeforeAl
 
     @Override
     public void beforeEach(ExtensionContext context) throws Exception {
-        if (TestPropertyUtility.isStandalone()) {
+        if (TestPropertyUtility.skipDeployment()) {
             return;
         }
         super.beforeEach(context);
@@ -72,7 +72,7 @@ public class StandaloneExtension extends ArquillianExtension implements BeforeAl
 
     @Override
     public void afterEach(ExtensionContext context) throws Exception {
-        if (TestPropertyUtility.isStandalone()) {
+        if (TestPropertyUtility.skipDeployment()) {
             return;
         }
         super.afterEach(context);
@@ -81,7 +81,7 @@ public class StandaloneExtension extends ArquillianExtension implements BeforeAl
     @Override
     public void interceptTestTemplateMethod(Invocation<Void> invocation,
             ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
-        if (TestPropertyUtility.isStandalone()) {
+        if (TestPropertyUtility.skipDeployment()) {
             invocation.proceed();
             return;
         }
@@ -91,7 +91,7 @@ public class StandaloneExtension extends ArquillianExtension implements BeforeAl
     @Override
     public void interceptTestMethod(Invocation<Void> invocation, ReflectiveInvocationContext<Method> invocationContext,
             ExtensionContext extensionContext) throws Throwable {
-        if (TestPropertyUtility.isStandalone()) {
+        if (TestPropertyUtility.skipDeployment()) {
             invocation.proceed();
             return;
         }
@@ -101,7 +101,7 @@ public class StandaloneExtension extends ArquillianExtension implements BeforeAl
     @Override
     public void interceptBeforeEachMethod(Invocation<Void> invocation,
             ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
-        if (TestPropertyUtility.isStandalone()) {
+        if (TestPropertyUtility.skipDeployment()) {
             invocation.proceed();
             return;
         }
@@ -111,7 +111,7 @@ public class StandaloneExtension extends ArquillianExtension implements BeforeAl
     @Override
     public void interceptAfterEachMethod(Invocation<Void> invocation,
             ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
-        if (TestPropertyUtility.isStandalone()) {
+        if (TestPropertyUtility.skipDeployment()) {
             invocation.proceed();
             return;
         }
@@ -121,7 +121,7 @@ public class StandaloneExtension extends ArquillianExtension implements BeforeAl
     @Override
     public void interceptBeforeAllMethod(Invocation<Void> invocation,
             ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
-        if (TestPropertyUtility.isStandalone()) {
+        if (TestPropertyUtility.skipDeployment()) {
             invocation.proceed();
             return;
         }
@@ -131,7 +131,7 @@ public class StandaloneExtension extends ArquillianExtension implements BeforeAl
     @Override
     public void interceptAfterAllMethod(Invocation<Void> invocation,
             ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext) throws Throwable {
-        if (TestPropertyUtility.isStandalone()) {
+        if (TestPropertyUtility.skipDeployment()) {
             invocation.proceed();
             return;
         }
@@ -140,7 +140,7 @@ public class StandaloneExtension extends ArquillianExtension implements BeforeAl
 
     @Override
     public void handleTestExecutionException(ExtensionContext context, Throwable throwable) throws Throwable {
-        if (TestPropertyUtility.isStandalone()) {
+        if (TestPropertyUtility.skipDeployment()) {
             throw throwable;
         }
         super.handleTestExecutionException(context, throwable);

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TestProperty.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TestProperty.java
@@ -37,13 +37,13 @@ public enum TestProperty {
     javaVer     (true,  "java.version",               "Full version of the java executable"),
     
     //TCK specific properties
-    standalone    (false,  "jakarta.tck.skip.deployment",  "If true, run in SE mode and do not use Arquillian deployment, if false run in EE mode and use Arquillian deployments. "
-            + "Default: true", "true"),
-    pollFrequency (false, "jakarta.tck.poll.frequency",    "Time in seconds between polls of the repository to verify read-only data was successfully written. "
+    skipDeployment (false,  "jakarta.tck.skip.deployment",  "If true, run in SE mode and do not use Arquillian deployment, if false run in EE mode and use Arquillian deployments. "
+            + "Default: false", "false"),
+    pollFrequency  (false, "jakarta.tck.poll.frequency",    "Time in seconds between polls of the repository to verify read-only data was successfully written. "
             + "Default: 1 second", "1"),
-    pollTimeout   (false, "jakarta.tck.poll.timeout",      "Time in seconds when we will stop polling to verify read-only data was successfully written. "
+    pollTimeout    (false, "jakarta.tck.poll.timeout",      "Time in seconds when we will stop polling to verify read-only data was successfully written. "
             + "Default: 60 seconds", "60"),
-    delay         (false, "jakarta.tck.consistency.delay", "Time in seconds after verifying read-only data was successfully written to respository "
+    delay          (false, "jakarta.tck.consistency.delay", "Time in seconds after verifying read-only data was successfully written to respository "
             + "for repository to have consistency. Default: none", ""),
     
     //Signature testing properties

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TestProperty.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TestProperty.java
@@ -37,8 +37,8 @@ public enum TestProperty {
     javaVer     (true,  "java.version",               "Full version of the java executable"),
     
     //TCK specific properties
-    profile       (false,  "jakarta.tck.profile",          "Set to 'none' to run in standalone mode. "
-            + "Optionally, set to 'core', 'web', or 'full' to differentiate between profile runs.", ""),
+    standalone    (false,  "jakarta.tck.standalone",       "Set the run mode of the TCK. If true, run in standalone (SE) mode, if false run in EE mode. "
+            + "Default: true", "true"),
     pollFrequency (false, "jakarta.tck.poll.frequency",    "Time in seconds between polls of the repository to verify read-only data was successfully written. "
             + "Default: 1 second", "1"),
     pollTimeout   (false, "jakarta.tck.poll.timeout",      "Time in seconds when we will stop polling to verify read-only data was successfully written. "

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TestProperty.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TestProperty.java
@@ -37,7 +37,7 @@ public enum TestProperty {
     javaVer     (true,  "java.version",               "Full version of the java executable"),
     
     //TCK specific properties
-    standalone    (false,  "jakarta.tck.standalone",       "Set the run mode of the TCK. If true, run in standalone (SE) mode, if false run in EE mode. "
+    standalone    (false,  "jakarta.tck.skip.deployment",  "If true, run in SE mode and do not use Arquillian deployment, if false run in EE mode and use Arquillian deployments. "
             + "Default: true", "true"),
     pollFrequency (false, "jakarta.tck.poll.frequency",    "Time in seconds between polls of the repository to verify read-only data was successfully written. "
             + "Default: 1 second", "1"),

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TestProperty.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TestProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -37,7 +37,8 @@ public enum TestProperty {
     javaVer     (true,  "java.version",               "Full version of the java executable"),
     
     //TCK specific properties
-    profile       (true,  "jakarta.tck.profile",           "The profile name which is used for reporting and determining the run mode."),
+    profile       (false,  "jakarta.tck.profile",          "Set to 'none' to run in standalone mode. "
+            + "Optionally, set to 'core', 'web', or 'full' to differentiate between profile runs.", ""),
     pollFrequency (false, "jakarta.tck.poll.frequency",    "Time in seconds between polls of the repository to verify read-only data was successfully written. "
             + "Default: 1 second", "1"),
     pollTimeout   (false, "jakarta.tck.poll.timeout",      "Time in seconds when we will stop polling to verify read-only data was successfully written. "

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TestPropertyUtility.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TestPropertyUtility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023, 2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -37,7 +37,7 @@ public class TestPropertyUtility {
      * @return - true if TCK is configured in standalone mode, false otherwise. 
      */
     public static boolean isStandalone() {
-        return TestProperty.profile.equals("none");
+        return TestProperty.profile.isSet() ? TestProperty.profile.equals("none") : false;
     }
     
     /**

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TestPropertyUtility.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TestPropertyUtility.java
@@ -36,8 +36,8 @@ public class TestPropertyUtility {
      * 
      * @return - true if TCK is configured in standalone mode, false otherwise. 
      */
-    public static boolean isStandalone() {
-        return Boolean.valueOf(TestProperty.standalone.getValue());
+    public static boolean skipDeployment() {
+        return Boolean.valueOf(TestProperty.skipDeployment.getValue());
     }
     
     /**

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TestPropertyUtility.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TestPropertyUtility.java
@@ -37,7 +37,7 @@ public class TestPropertyUtility {
      * @return - true if TCK is configured in standalone mode, false otherwise. 
      */
     public static boolean isStandalone() {
-        return TestProperty.profile.isSet() ? TestProperty.profile.equals("none") : false;
+        return Boolean.valueOf(TestProperty.standalone.getValue());
     }
     
     /**


### PR DESCRIPTION
Fixes #700 

- Updates TCK Dist docs to better explain the difference between `<groups>` and `<jakarta.tck.profile>` settings
- The TCK Dist doc said jakarta.tck.profile was optional, but the TCK would throw an error if it was not set.
  - Fixed the TCK to no longer throw an error when unset

@starksm64 - this fixes the issue you opened.

However, seeing as how the main purpose of `jakarta.tck.profile` is to determine if we need to run in standalone mode or not, would it be better to instead have a boolean property `jakarta.tck.standalone` that can be true or false to control this mode? 
This would help reduce the overlapping confusion between `groups` and `jakarta.tck.profile` (the `groups` configuration is not available to us at test time which is why we require a seperate property)
If so, I'd be interested in knowing what you (and others) think the default value should be?