### PR TITLE
Iss722

### DIFF
--- a/tck-dist/pom.xml
+++ b/tck-dist/pom.xml
@@ -199,23 +199,6 @@
      </execution>
     </executions>
    </plugin>
-   <plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-javadoc-plugin</artifactId>
-    <version>${maven-javadoc-plugin.vesion}</version>
-
-    <executions>
-     <execution>
-      <id>attach-javadocs</id>
-      <goals>
-       <goal>jar</goal>
-      </goals>
-      <configuration>
-       <skippedModules>jakarta.data-parent</skippedModules>
-      </configuration>
-     </execution>
-    </executions>
-   </plugin>
   </plugins>
  </build>
 </project>

--- a/tck-dist/pom.xml
+++ b/tck-dist/pom.xml
@@ -60,7 +60,7 @@
    <artifactId>jakarta.data-tck</artifactId>
    <version>${jakarta.data.tck.version}</version>
   </dependency>
-    <!-- Provided dependencies for the TCK -->
+  <!-- Provided dependencies for the TCK -->
   <dependency>
     <groupId>jakarta.servlet</groupId>
     <artifactId>jakarta.servlet-api</artifactId>

--- a/tck-dist/src/main/assembly/assembly.xml
+++ b/tck-dist/src/main/assembly/assembly.xml
@@ -36,6 +36,11 @@
       <source>src/main/readme/README.md</source>
       <destName>README.md</destName>
     </file>
+    <!-- The jakarta.data-parent pom file -->
+    <file>
+      <source>../pom.xml</source>
+      <destName>artifacts/jakarta.data-parent-${project.version}.pom</destName>
+    </file>
   </files>
 
   <fileSets>
@@ -77,7 +82,6 @@
       <includes>
         <include>jakarta.data:jakarta.data-tck</include>
         <include>jakarta.data:jakarta.data-tck:jar:sources</include>
-        <include>jakarta.data:jakarta.data-parent</include>
       </includes>
       <useTransitiveDependencies>true</useTransitiveDependencies>
       <outputDirectory>artifacts</outputDirectory>


### PR DESCRIPTION
This fixes #722 by explicitly adding the jakarta.data-parent pom file to the dist artifacts. I tried several workarounds to get the javadoc plugin to not hang, but there is some bug in how it is handling a build from the project root when a submodule includes the parent in its dependencies.