### PR TITLE
Updates needed for release review

### DIFF
--- a/.github/ISSUE_TEMPLATE/certification.yml
+++ b/.github/ISSUE_TEMPLATE/certification.yml
@@ -42,7 +42,10 @@ body:
       required: true
     attributes: 
       label: Technology Compatibility Kit (TCK) Validation
-      description: TCK SHA-256 fingerprint
+      description: |
+        SHA-256 Checksum
+        This is the checksum of the TCK Distribution zip, not the checksum for the TCK jar artifact.
+        Example: `shasum -a 256 jakarta.data-tck-dist-1.0.0.zip`
   - type: textarea
     id: tckResults
     validations:

--- a/.github/ISSUE_TEMPLATE/release.yml
+++ b/.github/ISSUE_TEMPLATE/release.yml
@@ -51,6 +51,8 @@ body:
             - [ ] [Modify the `draft` release on GitHub to be `pre-release` or `latest`](https://github.com/jakartaee/data/releases)
           #### Follow up
             - [ ] [Email a Jakarta steering committee member to promote the TCK Distribution publically](https://ci.eclipse.org/jakartaee-spec-committee/job/promote-release/)
+            - [ ] [Create pull request to https://github.com/jakartaee/specifications](https://github.com/jakartaee/specifications/blob/master/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md)
+              - upload [generated specification documentation](https://github.com/jakartaee/data/actions/workflows/specification.yml)
             - [ ] Update versions in non-build files, such as:
               Documentation:
               - [README.adoc](https://github.com/jakartaee/data/blob/main/README.adoc)

--- a/.github/workflows/specification.yml
+++ b/.github/workflows/specification.yml
@@ -1,0 +1,45 @@
+# This workflow automates the creation of Specification Documents
+# which will be copied into https://github.com/jakartaee/specifications
+
+name: Generate specification documentation
+
+on: 
+    workflow_dispatch:
+        inputs:
+            specVersion:
+                description: 'Major and Minor level of release. Example: 1.0'
+                required: true
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+    - name: Set up JDK 17
+      uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4.2.1
+      with:
+        java-version: 17
+        distribution: 'temurin'
+        cache: maven
+    - name: Generate specification docs
+      run: |
+        mvn package --file api/pom.xml -Dspec.version=${{ github.event.inputs.specVersion }}
+        mvn package --file spec/pom.xml -Drevremark=FINAL -Dspec.version=${{ github.event.inputs.specVersion }}
+    - name: Assemble documentation
+      run: |
+        mkdir documentation/
+        cp spec/target/generated-docs/jakarta-data-${{ github.event.inputs.specVersion }}.pdf   documentation/jakarta-data-${{ github.event.inputs.specVersion }}.pdf
+        cp spec/target/generated-docs/jakarta-method-name-query-${{ github.event.inputs.specVersion }}.pdf   documentation/jakarta-method-name-query-${{ github.event.inputs.specVersion }}.pdf
+
+        cp spec/target/generated-docs/jakarta-data-${{ github.event.inputs.specVersion }}.html  documentation/jakarta-data-${{ github.event.inputs.specVersion }}.html
+        cp spec/target/generated-docs/jakarta-method-name-query-${{ github.event.inputs.specVersion }}.html  documentation/jakarta-method-name-query-${{ github.event.inputs.specVersion }}.html
+
+        cp -r api/target/apidocs/ documentation/apidocs
+    - name: Upload documentation
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      with:
+        name: Specification Documentation
+        path: documentation/
+        if-no-files-found: error

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -33,6 +33,9 @@
 
     <properties>
         <assertj.version>3.25.3</assertj.version>
+        <!-- default is the same for backward compatibility reason
+        Easy to override when building with a system property -->
+        <spec.version>1.0</spec.version>
     </properties>
 
     <dependencies>
@@ -71,6 +74,47 @@
                         <arg>-parameters</arg>
                     </compilerArgs>
                 </configuration>
+            </plugin>
+
+
+            <!-- 
+            Create Javadoc for API jar
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.6.3</version>
+                <executions>
+                    <execution>
+                        <id>attach-api-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <source>17</source>
+                            <quiet>true</quiet>
+                            <additionalJOption>-Xdoclint:none</additionalJOption>
+                            <description>Jakarta Data API documentation</description>
+                            <doctitle>Jakarta Data API documentation</doctitle>
+                            <windowtitle>Jakarta Data API documentation</windowtitle>
+                            <header><![CDATA[<br>Jakarta Data API v${spec.version}]]></header>
+                            <bottom><![CDATA[
+Comments to: <a href="mailto:data-dev@eclipse.org">data-dev@eclipse.org</a>.<br>
+Copyright &#169; 2024 Eclipse Foundation. All rights reserved.<br>
+Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.]]>
+                            </bottom>
+                            <docfilessubdirs>true</docfilessubdirs>
+                            <groups>
+                                <group>
+                                    <title>Jakarta Data API Documentation</title>
+                                    <packages>
+                                        jakarta.data
+                                    </packages>
+                                </group>
+                            </groups>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/api/src/main/javadoc/doc-files/speclicense.html
+++ b/api/src/main/javadoc/doc-files/speclicense.html
@@ -1,0 +1,71 @@
+<html>
+<head>
+<title>Eclipse Foundation Specification License - v1.1</title>
+</head>
+<body>
+<h1>Eclipse Foundation Specification License - v1.1</h1>
+<p>By using and/or copying this document, or the Eclipse Foundation
+  document from which this statement is linked or incorporated by reference, you (the licensee) agree
+  that you have read, understood, and will comply with the following
+  terms and conditions:</p>
+
+<p>Permission to copy, and distribute the contents of this document, or
+  the Eclipse Foundation document from which this statement is linked, in
+  any medium for any purpose and without fee or royalty is hereby
+  granted, provided that you include the following on ALL copies of the
+  document, or portions thereof, that you use:</p>
+
+<ul>
+  <li> link or URL to the original Eclipse Foundation document.</li>
+  <li>All existing copyright notices, or if one does not exist, a notice
+      (hypertext is preferred, but a textual representation is permitted)
+    of the form: "Copyright © [$date-of-document]
+    Eclipse Foundation AISBL &lt;&lt;url to this license&gt;&gt;
+    "
+  </li>
+</ul>
+
+<p>Inclusion of the full text of this NOTICE must be provided. We
+  request that authorship attribution be provided in any software,
+  documents, or other items or products that you create pursuant to the
+  implementation of the contents of this document, or any portion
+  thereof.</p>
+
+<p>No right to create modifications or derivatives of Eclipse Foundation
+  documents is granted pursuant to this license, except anyone may
+  prepare and distribute derivative works and portions of this document
+  in software that implements the specification, in supporting materials
+  accompanying such software, and in documentation of such software,
+  PROVIDED that all such works include the notice below. HOWEVER, the
+  publication of derivative works of this document for use as a technical
+  specification is expressly prohibited.</p>
+
+<p>The notice is:</p>
+
+<p>"Copyright © 2022, 2024 Eclipse Foundation AISBL. This software or
+  document includes material copied from or derived from Jakarta Data and https://jakarta.ee/specifications/data/1.0/."</p>
+
+<h2>Disclaimers</h2>
+
+<p>THIS DOCUMENT IS PROVIDED "AS IS," AND TO THE EXTENT PERMITTED BY APPLICABLE LAW THE COPYRIGHT
+  HOLDERS AND THE ECLIPSE FOUNDATION AISBL MAKE NO REPRESENTATIONS OR
+  WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+  WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+  NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE
+  SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS
+  WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR
+  OTHER RIGHTS.</p>
+
+<p>TO THE EXTENT PERMITTED BY APPLICABLE LAW THE COPYRIGHT HOLDERS AND THE ECLIPSE FOUNDATION AISBL WILL NOT BE LIABLE
+  FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT
+  OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE
+  CONTENTS THEREOF.</p>
+
+<p>The name and trademarks of the copyright holders or the Eclipse
+  Foundation AISBL may NOT be used in advertising or publicity pertaining to
+  this document or its contents without specific, written prior
+  permission. Title to copyright in this document will at all times
+  remain with copyright holders.</p>
+
+</body>
+</html>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -39,6 +39,10 @@
         <revisiondate>${maven.build.timestamp}</revisiondate>
         <revremark>Draft</revremark>
         <gen-doc-dir>${project.build.directory}/generated-docs</gen-doc-dir>
+
+        <!-- default is the same for backward compatibility reason
+        Easy to override when building with a system property -->
+        <spec.version>1.0</spec.version>
     </properties>
 
     <build>
@@ -70,7 +74,7 @@
                         <configuration>
                             <sourceDocumentName>jakarta-data.adoc</sourceDocumentName>
                             <backend>pdf</backend>
-                            <outputFile>${gen-doc-dir}/jakarta-data-${project.version}.pdf</outputFile>
+                            <outputFile>${gen-doc-dir}/jakarta-data-${spec.version}.pdf</outputFile>
                         </configuration>
                     </execution>
                     <execution>
@@ -82,7 +86,7 @@
                         <configuration>
                             <sourceDocumentName>method-query.asciidoc</sourceDocumentName>
                             <backend>pdf</backend>
-                            <outputFile>${gen-doc-dir}/jakarta-method-name-query-${project.version}.pdf</outputFile>
+                            <outputFile>${gen-doc-dir}/jakarta-method-name-query-${spec.version}.pdf</outputFile>
                         </configuration>
                     </execution>
                     <execution>
@@ -94,7 +98,7 @@
                         <configuration>
                             <sourceDocumentName>jakarta-data.adoc</sourceDocumentName>
                             <backend>html5</backend>
-                            <outputFile>${gen-doc-dir}/jakarta-data-${project.version}.html</outputFile>
+                            <outputFile>${gen-doc-dir}/jakarta-data-${spec.version}.html</outputFile>
                         </configuration>
                     </execution>
                     <execution>
@@ -106,7 +110,7 @@
                         <configuration>
                             <sourceDocumentName>method-query.asciidoc</sourceDocumentName>
                             <backend>html5</backend>
-                            <outputFile>${gen-doc-dir}/jakarta-method-name-query-${project.version}.html</outputFile>
+                            <outputFile>${gen-doc-dir}/jakarta-method-name-query-${spec.version}.html</outputFile>
                             <attributes>
                                 <doctitle>Jakarta Data: Query by Method Name Extension</doctitle>
                             </attributes>
@@ -122,7 +126,7 @@
                     <attributes>
                         <license>Apache License v2.0</license>
                         <specification>Jakarta Data</specification>
-                        <revnumber>${project.version}</revnumber>
+                        <revnumber>${spec.version}</revnumber>
                         <revremark>${revremark}</revremark>
                         <revdate>${revisiondate}</revdate>
                         <sourceHighlighter>coderay</sourceHighlighter>

--- a/spec/src/main/asciidoc/chapters/license/license-efsl.adoc
+++ b/spec/src/main/asciidoc/chapters/license/license-efsl.adoc
@@ -13,10 +13,10 @@ Release: {revdate}
 
 Copyright (c) {inceptionYear}, {docyear} Eclipse Foundation.
 
-=== Eclipse Foundation Specification License
+=== Eclipse Foundation Specification License - v1.1
 
 By using and/or copying this document, or the Eclipse Foundation
-document from which this statement is linked, you (the licensee) agree
+document from which this statement is linked or incorporated by reference, you (the licensee) agree
 that you have read, understood, and will comply with the following
 terms and conditions:
 
@@ -30,7 +30,7 @@ document, or portions thereof, that you use:
 * All existing copyright notices, or if one does not exist, a notice
 (hypertext is preferred, but a textual representation is permitted)
 of the form: "Copyright (c) [$date-of-document]
-Eclipse Foundation, Inc. \<<url to this license>>"
+Eclipse Foundation AISBL https://www.eclipse.org/legal/efsl.php "
 
 Inclusion of the full text of this NOTICE must be provided. We
 request that authorship attribution be provided in any software,
@@ -49,14 +49,14 @@ specification is expressly prohibited.
 
 The notice is:
 
-"Copyright (c) {inceptionYear}, {docyear} Eclipse Foundation. This software or
+"Copyright (c) {inceptionYear}, {docyear} Eclipse Foundation AISBL.This software or
 document includes material copied from or derived from Jakarta Data and 
 https://jakarta.ee/specifications/data/."
 
 === Disclaimers
 
-THIS DOCUMENT IS PROVIDED &quot;AS IS,&quot; AND THE COPYRIGHT
-HOLDERS AND THE ECLIPSE FOUNDATION MAKE NO REPRESENTATIONS OR
+THIS DOCUMENT IS PROVIDED "AS IS," AND TO THE EXTENT PERMITTED BY APPLICABLE LAW THE COPYRIGHT
+HOLDERS AND THE ECLIPSE FOUNDATION AISBL MAKE NO REPRESENTATIONS OR
 WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
 WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
 NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE
@@ -64,13 +64,13 @@ SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS
 WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR
 OTHER RIGHTS.
 
-THE COPYRIGHT HOLDERS AND THE ECLIPSE FOUNDATION WILL NOT BE LIABLE
+TO THE EXTENT PERMITTED BY APPLICABLE LAW THE COPYRIGHT HOLDERS AND THE ECLIPSE FOUNDATION AISBL WILL NOT BE LIABLE
 FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT
 OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE
 CONTENTS THEREOF.
 
 The name and trademarks of the copyright holders or the Eclipse
-Foundation may NOT be used in advertising or publicity pertaining to
+Foundation AISBL may NOT be used in advertising or publicity pertaining to
 this document or its contents without specific, written prior
 permission. Title to copyright in this document will at all times
 remain with copyright holders.

--- a/tck-dist/src/main/asciidoc/data-tck-reference-guide.adoc
+++ b/tck-dist/src/main/asciidoc/data-tck-reference-guide.adoc
@@ -17,12 +17,13 @@
 :SigPluginVersion: 2.3
 :SigPluginGAV: jakarta.tck:sigtest-maven-plugin:{SigPluginVersion}
 
-
 :JavaVersion1: 17
 :JavaVersion2: 21
 
 :TCKProcess: 1.3
 :TCKProcessDoc: https://jakarta.ee/committees/specification/tckprocess
+
+:last-update-label!:
 
 include::sections/01preface.adoc[]
 

--- a/tck-dist/src/main/asciidoc/sections/09running.adoc
+++ b/tck-dist/src/main/asciidoc/sections/09running.adoc
@@ -10,6 +10,6 @@ $ mvn clean test
 
 === Expected Output
 
-Here is example output when successfully running the starter project:
+Here is example output when successfully running (full profile + persistence entity) the starter project:
 
 include::generated/expected-output.adoc[]


### PR DESCRIPTION
Here are a list of things I got called out for when doing the Concurrency Release Review.
Figured I'd get them fixed in Data before the we open up a Release Review: 

- Update certification doc to eliminate confusion on what SHA Checksum to use TCK Dist zip vs TCK jar
- Generated spec docs need only major/minor versions (1.0) vs (1.0.0)
- Update EFSL license to version 1.1
- Test counts in TCK documentation can be confusing. 