### PR TITLE
Clarifies the order and avoid the vendor start with One instead of Zero

### DIFF
--- a/spec/src/main/asciidoc/query-language.asciidoc
+++ b/spec/src/main/asciidoc/query-language.asciidoc
@@ -43,6 +43,8 @@ A _named parameter_ is a legal Java identifier prefixed with the `:` character, 
 
 An _ordinal parameter_ is a decimal integer prefixed with the `?` character, for example, `?1`.
 
+The first parameter is referred to as `?1`, and the second parameter is referred to as `?2`.
+
 ==== Operators and punctuation
 
 The character sequences `+`, `-`, `*`, `/`, `||`, `=`, `<`, `>`, `<>`, `&lt;=`, `>=` are _operators_.

--- a/spec/src/main/asciidoc/query-language.asciidoc
+++ b/spec/src/main/asciidoc/query-language.asciidoc
@@ -43,7 +43,7 @@ A _named parameter_ is a legal Java identifier prefixed with the `:` character, 
 
 An _ordinal parameter_ is a decimal integer prefixed with the `?` character, for example, `?1`.
 
-The first parameter is referred to as `?1`, and the second parameter is referred to as `?2`.
+Ordinal parameters are numbered sequentially, starting with `?1`.
 
 ==== Operators and punctuation
 


### PR DESCRIPTION
I put a tiny detail where we explicitly say that the parameter starts with one instead of zero.
