### PR TITLE
Verify behavior based on Database type

### DIFF
--- a/tck-dist/pom.xml
+++ b/tck-dist/pom.xml
@@ -92,7 +92,7 @@
     <artifactId>maven-dependency-plugin</artifactId>
     <version>3.6.1</version>
     <executions>
-	<!-- Load TCK dependency location as variable -->
+    <!-- Load TCK dependency location as variable -->
      <execution>
       <phase>initialize</phase>
       <goals>

--- a/tck-dist/src/main/pom.xml
+++ b/tck-dist/src/main/pom.xml
@@ -30,8 +30,8 @@
  <version>1.0-SNAPSHOT</version>
   
   <modules>
-	  <module>starter/ee-pom.xml</module>
-	  <module>starter/se-pom.xml</module>
+      <module>starter/ee-pom.xml</module>
+      <module>starter/se-pom.xml</module>
   </modules>
  
  </project>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -104,7 +104,7 @@
       <version>${jakarta.transaction.version}</version>
       <scope>provided</scope>
     </dependency>
-	
+    
     <dependency>
       <groupId>jakarta.validation</groupId>
       <artifactId>jakarta.validation-api</artifactId>

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/DatabaseType.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/DatabaseType.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
  * This enum represents the configured DatabaseType based on the {@link TestProperty} databaseType
  */
 public enum DatabaseType {
-    UNKNOWN(Integer.MAX_VALUE), //No database type was configured
+    OTHER(Integer.MAX_VALUE), //No database type was configured
     RELATIONAL(100),
     GRAPH(50),
     DOCUMENT(40),
@@ -36,7 +36,7 @@ public enum DatabaseType {
     }
     
     public static DatabaseType valueOfIgnoreCase(String value) {
-        return Arrays.stream(DatabaseType.values()).filter(type -> type.name().equalsIgnoreCase(value)).findAny().orElse(DatabaseType.UNKNOWN);
+        return Arrays.stream(DatabaseType.values()).filter(type -> type.name().equalsIgnoreCase(value)).findAny().orElse(DatabaseType.OTHER);
     }
     
     public boolean isKeywordSupportAtOrBelow(DatabaseType benchmark) {

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/DatabaseType.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/DatabaseType.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.framework.utilities;
+
+import java.util.Arrays;
+
+/**
+ * This enum represents the configured DatabaseType based on the {@link TestProperty} databaseType
+ */
+public enum DatabaseType {
+    UNKNOWN, //No database type was configured
+    RELATIONAL,
+    COLUMN,
+    DOCUMENT,
+    GRAPH,
+    KEY_VALUE;
+    
+    public static DatabaseType valueOfIgnoreCase(String value) {
+        return Arrays.stream(DatabaseType.values()).filter(type -> type.name().equalsIgnoreCase(value)).findAny().orElse(DatabaseType.UNKNOWN);
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/DatabaseType.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/DatabaseType.java
@@ -21,14 +21,25 @@ import java.util.Arrays;
  * This enum represents the configured DatabaseType based on the {@link TestProperty} databaseType
  */
 public enum DatabaseType {
-    UNKNOWN, //No database type was configured
-    RELATIONAL,
-    COLUMN,
-    DOCUMENT,
-    GRAPH,
-    KEY_VALUE;
+    UNKNOWN(Integer.MAX_VALUE), //No database type was configured
+    RELATIONAL(100),
+    GRAPH(50),
+    DOCUMENT(40),
+    TIME_SERIES(30),
+    COLUMN(20),
+    KEY_VALUE(10);
+    
+    private int flexibility;
+    
+    private DatabaseType(int flexibility) {
+        this.flexibility = flexibility;
+    }
     
     public static DatabaseType valueOfIgnoreCase(String value) {
         return Arrays.stream(DatabaseType.values()).filter(type -> type.name().equalsIgnoreCase(value)).findAny().orElse(DatabaseType.UNKNOWN);
+    }
+    
+    public boolean isKeywordSupportAtOrBelow(DatabaseType benchmark) {
+        return this.flexibility <= benchmark.flexibility;
     }
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TestProperty.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TestProperty.java
@@ -56,9 +56,9 @@ public enum TestProperty {
             + "for repository to have consistency. "
             + "Default: none"),
     databaseType   (false, "jakarta.tck.database.type",
-            "The type of database being used. Valid values are " + Arrays.asList(DatabaseType.values()).toString()
-            + " (case insensitive). The database type is used to make assertions based on the underlying database. "
-            + "Default: UNKNOWN", "UNKNOWN"),
+            "The type of database being used. Valid values are " + Arrays.asList(DatabaseType.values()).toString() + " (case insensitive). "
+            + "The database type is used to make assertions based on the keywords supported by the underlying database. "
+            + "Default: OTHER", "OTHER"),
     databaseName   (false, "jakarta.tck.database.name",
             "The name of database being used. The database name is used to make assertions based on the underlying database. "
             + "Default: none"),

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TestProperty.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TestProperty.java
@@ -15,6 +15,7 @@
  */
 package ee.jakarta.tck.data.framework.utilities;
 
+import java.util.Arrays;
 import java.util.logging.Logger;
 
 import ee.jakarta.tck.data.framework.arquillian.extensions.TCKFrameworkAppender;
@@ -55,8 +56,8 @@ public enum TestProperty {
             + "for repository to have consistency. "
             + "Default: none"),
     databaseType   (false, "jakarta.tck.database.type",
-            "The type of database being used. Valid values are " + DatabaseType.values() 
-            + " (case insenstive). The database type is used to make assertions based on the underlying database. "
+            "The type of database being used. Valid values are " + Arrays.asList(DatabaseType.values()).toString()
+            + " (case insensitive). The database type is used to make assertions based on the underlying database. "
             + "Default: UNKNOWN", "UNKNOWN"),
     databaseName   (false, "jakarta.tck.database.name",
             "The name of database being used. The database name is used to make assertions based on the underlying database. "

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TestPropertyHandler.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TestPropertyHandler.java
@@ -83,7 +83,8 @@ public class TestPropertyHandler {
             if(prop.getKey().startsWith("java.")) {
                 continue;
             }
-            filteredProps.put(prop.getKey(), prop.getValue());
+            if(prop.isSet())
+                filteredProps.put(prop.getKey(), prop.getValue());
         }
         
         try {

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -57,6 +57,8 @@ import ee.jakarta.tck.data.framework.read.only.NaturalNumbers;
 import ee.jakarta.tck.data.framework.read.only.NaturalNumbersPopulator;
 import ee.jakarta.tck.data.framework.read.only.PositiveIntegers;
 import ee.jakarta.tck.data.framework.read.only.NaturalNumber.NumberType;
+import ee.jakarta.tck.data.framework.utilities.DatabaseType;
+import ee.jakarta.tck.data.framework.utilities.TestProperty;
 import ee.jakarta.tck.data.framework.utilities.TestPropertyUtility;
 import jakarta.data.Limit;
 import jakarta.data.Order;
@@ -111,6 +113,8 @@ public class EntityTests {
         assertNotNull(characters);
         AsciiCharactersPopulator.get().populate(characters);
     }
+    
+    private DatabaseType type = TestProperty.databaseType.getDatabaseType();
 
     @Assertion(id = "136", strategy = "Ensures that the prepopulation step for readonly entities was successful")
     public void ensureNaturalNumberPrepopulation() {
@@ -416,7 +420,16 @@ public class EntityTests {
 
     @Assertion(id = "133", strategy = "Use a repository method with Contains to query for a substring of a String attribute.")
     public void testContainsInString() {
-        Collection<AsciiCharacter> found = characters.findByHexadecimalContainsAndIsControlNot("4", true);
+        Collection<AsciiCharacter> found;
+        try {
+            found = characters.findByHexadecimalContainsAndIsControlNot("4", true);    
+        } catch (UnsupportedOperationException e) {
+            if(type == DatabaseType.DOCUMENT || type == DatabaseType.GRAPH) {
+                return; //passed
+            }
+            throw e;
+        }
+        
 
         assertEquals(List.of("24", "34",
                              "40", "41", "42", "43",
@@ -614,7 +627,17 @@ public class EntityTests {
     @Assertion(id = "133",
                strategy = "Use a repository method with findFirst3By that returns the first 3 results.")
     public void testFindFirst3() {
-        AsciiCharacter[] found = characters.findFirst3ByNumericValueGreaterThanEqualAndHexadecimalEndsWith(40, "4", Sort.asc("numericValue"));
+        AsciiCharacter[] found;
+        
+        try {
+        found = characters.findFirst3ByNumericValueGreaterThanEqualAndHexadecimalEndsWith(40, "4", Sort.asc("numericValue"));
+        } catch (UnsupportedOperationException e) {
+            if(type == DatabaseType.DOCUMENT || type == DatabaseType.GRAPH) {
+                return; //passed
+            }
+            throw e;
+        }
+        
         assertEquals(3, found.length);
         assertEquals('4', found[0].getThisCharacter());
         assertEquals('D', found[1].getThisCharacter());

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -424,7 +424,7 @@ public class EntityTests {
         try {
             found = characters.findByHexadecimalContainsAndIsControlNot("4", true);    
         } catch (UnsupportedOperationException e) {
-            if(type == DatabaseType.DOCUMENT || type == DatabaseType.GRAPH) {
+            if(type.isKeywordSupportAtOrBelow(DatabaseType.DOCUMENT)) {
                 return; //passed
             }
             throw e;
@@ -632,7 +632,7 @@ public class EntityTests {
         try {
         found = characters.findFirst3ByNumericValueGreaterThanEqualAndHexadecimalEndsWith(40, "4", Sort.asc("numericValue"));
         } catch (UnsupportedOperationException e) {
-            if(type == DatabaseType.DOCUMENT || type == DatabaseType.GRAPH) {
+            if(type.isKeywordSupportAtOrBelow(DatabaseType.DOCUMENT)) {
                 return; //passed
             }
             throw e;

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/signature/SignatureTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/signature/SignatureTests.java
@@ -24,6 +24,7 @@ import ee.jakarta.tck.data.framework.junit.anno.Assertion;
 import ee.jakarta.tck.data.framework.junit.anno.Signature;
 import ee.jakarta.tck.data.framework.junit.anno.Standalone;
 import ee.jakarta.tck.data.framework.signature.DataSignatureTestRunner;
+import ee.jakarta.tck.data.framework.utilities.TestProperty;
 
 @Standalone
 @AnyEntity
@@ -36,7 +37,7 @@ public class SignatureTests {
 
     @Assertion(id = "26", strategy = "Uses the sigtest-maven-plugin to execute signature tests on a Standalone JVM or on a Jakarta EE Server")
     public void testSignatures() throws Exception {
-        DataSignatureTestRunner.assertProjectSetup(true);
+        DataSignatureTestRunner.assertProjectSetup(TestProperty.skipDeployment.getBoolean());
         DataSignatureTestRunner runner = new DataSignatureTestRunner();
         runner.signatureTest();
     }


### PR DESCRIPTION
Fixes #768 

- Added two new properties:
  - jakarta.tck.database.type - So that we can write test logic based on database type, such as, column or graph
  - jakarta.tck.database.name - so that we can write test logic based on database name, such as, oracle or mongo
    - This is for future consideration and currently isn't used. 
- Fixed some spacing issues
- Only read system properties once instead of every time they are used.   