### PR TITLE
Increase the value to work with parenthesis

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -1989,6 +1989,7 @@ public class EntityTests {
                     positives.oddAndEqualToOrBelow(15L, 9L));
         } catch (UnsupportedOperationException x) {
             if (type.isKeywordSupportAtOrBelow(DatabaseType.DOCUMENT)) {
+                // Document, Column, and Key-Value databases might not be capable of parentheses.
                 // Column and Key-Value databases might not be capable of JDQL OR.
                 // Key-Value databases might not be capable of < in JDQL.
                 // Key-Value databases might not be capable of JDQL AND.

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -1988,7 +1988,7 @@ public class EntityTests {
                     List.of(15L, 7L, 5L, 3L, 1L),
                     positives.oddAndEqualToOrBelow(15L, 9L));
         } catch (UnsupportedOperationException x) {
-            if (type.isKeywordSupportAtOrBelow(DatabaseType.COLUMN)) {
+            if (type.isKeywordSupportAtOrBelow(DatabaseType.DOCUMENT)) {
                 // Column and Key-Value databases might not be capable of JDQL OR.
                 // Key-Value databases might not be capable of < in JDQL.
                 // Key-Value databases might not be capable of JDQL AND.


### PR DESCRIPTION
While working with parenthesis with Graph is true, we cannot confirm it with the document database.

Some document databases that don't support parenthesis:

- MongoDB 
- CouchDB
- RethinkDB
- Amazon DocumentDB
- Firebase Firestore
