### PR TITLE
Enhance contribuiting documentation

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -84,7 +84,7 @@ Follow one of these two methods to add DCO to your commits:
 ==== 1. Command line
 
 Follow the steps:
-**Step 1:** Configure your local git environment adding the same name and e-mail configured at your GitHub account. It helps to sign commits manually during reviews and suggestions.
+**Step 1:** Configure your local git environment adding the same name and e-mail configured at your GitHub account. This helps to sign commits manually during reviews and suggestions.
 
 [source, Bash]
 ----

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -124,3 +124,25 @@ If you found a bug or have an idea, check out the following sections before subm
 === Check the issue tracker
 
 All our issues are centralized in our https://github.com/jakartaee/data[**main repository**], it is quite likely that you will find a topic that is being discussed. Check the https://github.com/jakartaee/data/issues[**open issues**], another good way to start is https://github.com/jakartaee/data/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22[**good first issues**].
+
+
+**Types of Commits:**
+
+- **fix:** Any commit that patches a bug anywhere in the codebase
+- **feat:** Any commit that introduces a new feature or focuses on enhancing the scope of existing features
+- **breaking changes:** Any commit that has a footer "BREAKING CHANGE", or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
+- **other than fix and feat:** Any commit that consists of the following keywords: `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others. For other keywords refer to https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional[@commitlint/config-conventional] (based on the Angular convention)
+- **other footers:**<description> may be provided and follow a convention similar to https://git-scm.com/docs/git-interpret-trailers[git trailer format]
+
+**Examples of commits**
+
+- **Regular Commit Message:** This may be used for either fix or feat and can be written as `fix: <message>` or `feat: <message>`
+- **Commit with breaking change**: Example: A new feature being introduced as a breaking change can be written as `feat!: <message>`, this can also simply be written as a regular feat with the *BREAKING CHANGE* appended to it at the end of the commit
+- **Specific breaking change:**: Example: A breaking change introduced with a new feature somewhere in the api can be written as `feat(api)!: <message>`
+- **Changing the docs:** `docs: <message>`
+- **Regular commit message with specification:** A new feature introduced in the api can be written as `feat(api): <message>`
+
+**Formatting Commit messages**
+
+All commit messages must clearly state the change that takes place. Multiple paragraphs or bullet points explaining the changes in detail are encouraged. The message must contain the link to the issue that it is directed towards.
+If there are other people working on a particular issue which you wanted to work on as well, consider working together. If the commit influences a visual change, screenshots are encouraged

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -115,3 +115,12 @@ Signed-off-by: Name < e-mail address >
 Contact the project developers via the project's "dev" list.
 
 * https://dev.eclipse.org/mailman/listinfo/data-dev
+
+
+== Issues
+
+If you found a bug or have an idea, check out the following sections before submitting your contribution.
+
+=== Check the issue tracker
+
+All our issues are centralized in our https://github.com/jakartaee/data[**main repository**], it is quite likely that you will find a topic that is being discussed. Check the https://github.com/jakartaee/data/issues[**open issues**], another good way to start is https://github.com/jakartaee/data/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22[**good first issues**].

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -130,7 +130,7 @@ Because all of our issues are centralized in our https://github.com/jakartaee/da
 
 - **fix:** Any commit that patches a bug anywhere in the codebase
 - **feat:** Any commit that introduces a new feature or focuses on enhancing the scope of existing features
-- **breaking changes:** Any commit that has a footer "BREAKING CHANGE", or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.
+- **breaking changes:** Any commit that has a footer "BREAKING CHANGE", or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type. Breaking changes are discouraged and should generally be avoided if possible due to their adverse impacts on users.
 - **other than fix and feat:** Any commit that consists of the following keywords: `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others. For other keywords refer to https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional[@commitlint/config-conventional] (based on the Angular convention)
 - **other footers:**<description> may be provided and follow a convention similar to https://git-scm.com/docs/git-interpret-trailers[git trailer format]
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -109,3 +109,9 @@ You can also manually sign your commits during GitHub reviews and suggestions, f
 ----
 Signed-off-by: Name < e-mail address >
 ----
+
+== Contact
+
+Contact the project developers via the project's "dev" list.
+
+* https://dev.eclipse.org/mailman/listinfo/data-dev

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -123,7 +123,7 @@ If you found a bug or have an idea, check out the following sections before subm
 
 === Check the issue tracker
 
-All our issues are centralized in our https://github.com/jakartaee/data[**main repository**], it is quite likely that you will find a topic that is being discussed. Check the https://github.com/jakartaee/data/issues[**open issues**], another good way to start is https://github.com/jakartaee/data/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22[**good first issues**].
+Because all of our issues are centralized in our https://github.com/jakartaee/data[**main repository**], it is quite likely that you will find a similar topic that is being discussed. Check the https://github.com/jakartaee/data/issues[**open issues**]. Another good way to start is https://github.com/jakartaee/data/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22[**good first issues**].
 
 
 **Types of Commits:**

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -131,7 +131,7 @@ Because all of our issues are centralized in our https://github.com/jakartaee/da
 - **fix:** Any commit that patches a bug anywhere in the codebase
 - **feat:** Any commit that introduces a new feature or focuses on enhancing the scope of existing features
 - **breaking changes:** Any commit that has a footer "BREAKING CHANGE", or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type. Breaking changes are discouraged and should generally be avoided if possible due to their adverse impacts on users.
-- **other than fix and feat:** Any commit that consists of the following keywords: `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others. For other keywords refer to https://github.com/conventional-changelog/commitlint/tree/master/%40commitlint/config-conventional[@commitlint/config-conventional] (based on the Angular convention)
+- **other than fix and feat:** Any commit that consists of the following keywords: `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others. For other keywords refer to https://www.conventionalcommits.org/en/v1.0.0/[@commitlint/config-conventional] (based on the Angular convention)
 - **other footers:**<description> may be provided and follow a convention similar to https://git-scm.com/docs/git-interpret-trailers[git trailer format]
 
 **Examples of commits**

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -74,3 +74,38 @@ https://www.eclipse.org/projects/handbook/#resources-commit
 Contact the project developers via the project's "dev" list.
 
 * https://accounts.eclipse.org/mailing-list/data-dev
+
+=== Developer Certificate of Origin - DCO
+
+This is a security layer for the project and for the developers. It is mandatory.
+
+Follow one of these two methods to add DCO to your commits:
+
+==== 1. Command line
+
+Follow the steps:
+**Step 1:** Configure your local git environment adding the same name and e-mail configured at your GitHub account. It helps to sign commits manually during reviews and suggestions.
+
+[source, Bash]
+----
+git config --global user.name “Name”
+git config --global user.email “email@domain.com.br”
+----
+
+**Step 2:** Add the Signed-off-by line with the `'-s'` flag in the git commit command:
+
+[source, Bash]
+----
+$ git commit -s -m "This is my commit message"
+----
+
+==== 2. GitHub website
+
+You can also manually sign your commits during GitHub reviews and suggestions, follow the steps below:
+
+**Step 1:** When the commit changes box opens, manually type or paste your signature in the comment box, see the example:
+
+[source, Bash]
+----
+Signed-off-by: Name < e-mail address >
+----


### PR DESCRIPTION
# Changes

- After seeing the first contribution of a newcomer, I could see that we are missing some guides and information for new contributions. This PR works to fix it, enhance the documentation and explain more about the legal part and the commit message [using convention](https://www.conventionalcommits.org/en/v1.0.0/)