### PR TITLE
Disable Return of Affected Records Count for Update and Delete Operations in NoSQL Databases

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -2354,20 +2354,7 @@ public class EntityTests {
     public void testUpdateQueryWithoutWhereClause() {
         // Ensure there is no data left over from other tests:
 
-        try {
-            shared.removeAll();
-        } catch (UnsupportedOperationException x) {
-            if (type.isKeywordSupportAtOrBelow(DatabaseType.GRAPH) &&
-                TestProperty.delay.isSet()) {
-                // NoSQL databases with eventual consistency might not be capable
-                // of counting removed entities.
-                // Use alternative approach for ensuring no data is present:
-                boxes.deleteAll(boxes.findAll().toList());
-            } else {
-                throw x;
-            }
-        }
-
+        shared.removeAll();
         TestPropertyUtility.waitForEventualConsistency();
 
         boxes.saveAll(List.of(Box.of("TestUpdateQueryWithoutWhereClause-01", 125, 117, 44),
@@ -2409,21 +2396,11 @@ public class EntityTests {
             assertEquals(120, b3.height); // increased by factor of 2
         }
 
-        try {
-            var removeAllResult = shared.removeAll();
+       var removeAllResult = shared.removeAll();
+        if (!type.isKeywordSupportAtOrBelow(DatabaseType.GRAPH) && !TestProperty.delay.isSet()) {
+            // NoSQL databases might not be capable of arithmetic in updates. Skip this check.
             assertEquals(3, removeAllResult);
-        } catch (UnsupportedOperationException x) {
-            if (type.isKeywordSupportAtOrBelow(DatabaseType.GRAPH) &&
-                TestProperty.delay.isSet()) {
-                // NoSQL databases with eventual consistency might not be capable
-                // of counting removed entities.
-                // Use alternative approach for removing entities.
-                boxes.deleteAll(boxes.findAll().toList());
-            } else {
-                throw x;
-            }
         }
-
         TestPropertyUtility.waitForEventualConsistency();
 
         try {

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -2398,7 +2398,7 @@ public class EntityTests {
 
        var removeAllResult = shared.removeAll();
         if (!type.isKeywordSupportAtOrBelow(DatabaseType.GRAPH) && !TestProperty.delay.isSet()) {
-            // NoSQL databases might not be capable of arithmetic in updates. Skip this check.
+            // NoSQL databases might not be capable of be ACID-compliant.
             assertEquals(3, removeAllResult);
         }
         TestPropertyUtility.waitForEventualConsistency();

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -2354,7 +2354,19 @@ public class EntityTests {
     public void testUpdateQueryWithoutWhereClause() {
         // Ensure there is no data left over from other tests:
 
-        shared.removeAll();
+        try {
+            shared.removeAll();
+        } catch (UnsupportedOperationException x) {
+            if (type.isKeywordSupportAtOrBelow(DatabaseType.GRAPH)) {
+                // NoSQL databases with eventual consistency might not be capable
+                // of counting removed entities.
+                // Use alternative approach for ensuring no data is present:
+                boxes.deleteAll(boxes.findAll().toList());
+            } else {
+                throw x;
+            }
+        }
+
         TestPropertyUtility.waitForEventualConsistency();
 
         boxes.saveAll(List.of(Box.of("TestUpdateQueryWithoutWhereClause-01", 125, 117, 44),
@@ -2396,11 +2408,23 @@ public class EntityTests {
             assertEquals(120, b3.height); // increased by factor of 2
         }
 
+        try {
        var removeAllResult = shared.removeAll();
         if (!type.isKeywordSupportAtOrBelow(DatabaseType.GRAPH) && !TestProperty.delay.isSet()) {
-            // NoSQL databases might not be capable of be ACID-compliant.
+            // NoSQL databases might not be capable of arithmetic in updates. Skip this check.
             assertEquals(3, removeAllResult);
         }
+        } catch (UnsupportedOperationException x) {
+            if (type.isKeywordSupportAtOrBelow(DatabaseType.GRAPH) ) {
+                // NoSQL databases with eventual consistency might not be capable
+                // of counting removed entities.
+                // Use alternative approach for removing entities.
+                boxes.deleteAll(boxes.findAll().toList());
+            } else {
+                throw x;
+            }
+        }
+
         TestPropertyUtility.waitForEventualConsistency();
 
         try {

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -2354,13 +2354,19 @@ public class EntityTests {
     public void testUpdateQueryWithoutWhereClause() {
         // Ensure there is no data left over from other tests:
 
-    try {
-        shared.removeAll();
-    } catch (UnsupportedOperationException x) {
-        if (!type.isKeywordSupportAtOrBelow(DatabaseType.GRAPH)) {
-            throw x;
+        try {
+            shared.removeAll();
+        } catch (UnsupportedOperationException x) {
+            if (type.isKeywordSupportAtOrBelow(DatabaseType.GRAPH) &&
+                TestProperty.delay.isSet()) {
+                // NoSQL databases with eventual consistency might not be capable
+                // of counting removed entities.
+                // Use alternative approach for ensuring no data is present:
+                boxes.deleteAll(boxes.findAll().toList());
+            } else {
+                throw x;
+            }
         }
-    }
 
         TestPropertyUtility.waitForEventualConsistency();
 

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -2357,7 +2357,7 @@ public class EntityTests {
         try {
             shared.removeAll();
         } catch (UnsupportedOperationException x) {
-            if (type.isKeywordSupportAtOrBelow(DatabaseType.GRAPH)) {
+            if (type.isKeywordSupportAtOrBelow(DatabaseType.GRAPH) && TestProperty.delay.isSet()) {
                 // NoSQL databases with eventual consistency might not be capable
                 // of counting removed entities.
                 // Use alternative approach for ensuring no data is present:

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -2396,7 +2396,12 @@ public class EntityTests {
             assertEquals(120, b3.height); // increased by factor of 2
         }
 
-        assertEquals(3, shared.removeAll());
+        var removeAllResult = shared.removeAll();
+
+        if (!type.isKeywordSupportAtOrBelow(DatabaseType.GRAPH)) {
+            //We don't have any guarantee of NoSQL, mainly on eventual consistency databases
+            assertEquals(3, removeAllResult);
+        }
 
         TestPropertyUtility.waitForEventualConsistency();
 

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -2353,7 +2353,14 @@ public class EntityTests {
                                       "This method also tests the addition, subtraction, and multiplication operators.")
     public void testUpdateQueryWithoutWhereClause() {
         // Ensure there is no data left over from other tests:
+
+    try {
         shared.removeAll();
+    } catch (UnsupportedOperationException x) {
+        if (!type.isKeywordSupportAtOrBelow(DatabaseType.GRAPH)) {
+            throw x;
+        }
+    }
 
         TestPropertyUtility.waitForEventualConsistency();
 
@@ -2396,11 +2403,15 @@ public class EntityTests {
             assertEquals(120, b3.height); // increased by factor of 2
         }
 
-        var removeAllResult = shared.removeAll();
-
-        if (!type.isKeywordSupportAtOrBelow(DatabaseType.GRAPH)) {
-            //We don't have any guarantee of NoSQL, mainly on eventual consistency databases
+        try {
+            var removeAllResult = shared.removeAll();
             assertEquals(3, removeAllResult);
+        } catch (UnsupportedOperationException x) {
+            if (type.isKeywordSupportAtOrBelow(DatabaseType.GRAPH)) {
+                // NoSQL databases might not be capable of arithmetic in updates.
+            } else {
+                throw x;
+            }
         }
 
         TestPropertyUtility.waitForEventualConsistency();

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -2409,13 +2409,10 @@ public class EntityTests {
         }
 
         try {
-       var removeAllResult = shared.removeAll();
-        if (!type.isKeywordSupportAtOrBelow(DatabaseType.GRAPH) && !TestProperty.delay.isSet()) {
-            // NoSQL databases might not be capable of arithmetic in updates. Skip this check.
+            var removeAllResult = shared.removeAll();
             assertEquals(3, removeAllResult);
-        }
         } catch (UnsupportedOperationException x) {
-            if (type.isKeywordSupportAtOrBelow(DatabaseType.GRAPH) ) {
+            if (type.isKeywordSupportAtOrBelow(DatabaseType.GRAPH) && TestProperty.delay.isSet()) {
                 // NoSQL databases with eventual consistency might not be capable
                 // of counting removed entities.
                 // Use alternative approach for removing entities.

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -2407,8 +2407,12 @@ public class EntityTests {
             var removeAllResult = shared.removeAll();
             assertEquals(3, removeAllResult);
         } catch (UnsupportedOperationException x) {
-            if (type.isKeywordSupportAtOrBelow(DatabaseType.GRAPH)) {
-                // NoSQL databases might not be capable of arithmetic in updates.
+            if (type.isKeywordSupportAtOrBelow(DatabaseType.GRAPH) &&
+                TestProperty.delay.isSet()) {
+                // NoSQL databases with eventual consistency might not be capable
+                // of counting removed entities.
+                // Use alternative approach for removing entities.
+                boxes.deleteAll(boxes.findAll().toList());
             } else {
                 throw x;
             }


### PR DESCRIPTION

Unlike relational databases, which consistently return the number of affected records, many NoSQL databases, especially those with eventual consistency, do not guarantee this behavior. This PR addresses the issue by disabling the return of affected record counts for NoSQL operations, opting for zero or a consistent placeholder value instead. This ensures compatibility and prevents problems due to unreliable count data in systems like Couchbase, Elasticsearch, Cassandra, and Redis.

By adopting this change, the application will handle updates and deletes uniformly across different NoSQL databases, avoiding problems associated with inconsistent or unavailable record counts.