### PR TITLE
TCK cannot expect sorting on enum

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumber.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumber.java
@@ -39,6 +39,7 @@ public class NaturalNumber implements Serializable {
     // Sorting on enum types is vendor-specific in Jakarta Data.
     // Use numTypeOrdinal for sorting instead.
     @jakarta.nosql.Column
+    @jakarta.persistence.Enumerated(jakarta.persistence.EnumType.STRING)
     private NumberType numType; // enum of ONE | PRIME | COMPOSITE
 
     @jakarta.nosql.Column

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumber.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -36,8 +36,13 @@ public class NaturalNumber implements Serializable {
     @jakarta.nosql.Column
     private Short numBitsRequired;
 
+    // Sorting on enum types is vendor-specific in Jakarta Data.
+    // Use numTypeOrdinal for sorting instead.
     @jakarta.nosql.Column
     private NumberType numType; // enum of ONE | PRIME | COMPOSITE
+
+    @jakarta.nosql.Column
+    private int numTypeOrdinal; // ordinal value of numType
 
     @jakarta.nosql.Column
     private long floorOfSquareRoot;
@@ -72,6 +77,14 @@ public class NaturalNumber implements Serializable {
 
     public void setNumType(NumberType numType) {
         this.numType = numType;
+    }
+
+    public int getNumTypeOrdinal() {
+        return numTypeOrdinal;
+    }
+
+    public void setNumTypeOrdinal(int value) {
+        numTypeOrdinal = value;
     }
 
     public long getFloorOfSquareRoot() {

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers.java
@@ -45,9 +45,9 @@ public interface NaturalNumbers extends BasicRepository<NaturalNumber, Long>, Id
     CursoredPage<NaturalNumber> findByFloorOfSquareRootOrderByIdAsc(long sqrtFloor,
                                                                     PageRequest pagination);
 
-    Stream<NaturalNumber> findByIdBetweenOrderByNumTypeAsc(long minimum,
-                                                           long maximum,
-                                                           Order<NaturalNumber> sorts);
+    Stream<NaturalNumber> findByIdBetweenOrderByNumTypeOrdinalAsc(long minimum,
+                                                                  long maximum,
+                                                                  Order<NaturalNumber> sorts);
 
     List<NaturalNumber> findByIdGreaterThanEqual(long minimum,
                                                  Limit limit,

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbersPopulator.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbersPopulator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -44,11 +44,13 @@ public class NaturalNumbersPopulator implements Populator<NaturalNumbers> {
                 boolean isOdd = id % 2 == 1;
                 long sqrRoot = squareRoot(id);
                 boolean isPrime = isOdd ? isPrime(id, sqrRoot) : (id == 2);
+                NumberType numType = isOne ? NumberType.ONE : isPrime ? NumberType.PRIME : NumberType.COMPOSITE;
                 
                 inst.setId(id);
                 inst.setOdd(isOdd);
                 inst.setNumBitsRequired(bitsRequired(id));
-                inst.setNumType(isOne ? NumberType.ONE : isPrime ? NumberType.PRIME : NumberType.COMPOSITE);
+                inst.setNumType(numType);
+                inst.setNumTypeOrdinal(numType.ordinal());
                 inst.setFloorOfSquareRoot(sqrRoot);
                 
                 dictonary.add(inst);

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -146,7 +146,7 @@ public class EntityTests {
 
         // custom method from NaturalNumbers:
         try {
-            Stream<NaturalNumber> found = numbers.findByIdBetweenOrderByNumTypeAsc(
+            Stream<NaturalNumber> found = numbers.findByIdBetweenOrderByNumTypeOrdinalAsc(
                     50L, 59L,
                     Order.by(Sort.asc("id")));
             List<Long> list = found
@@ -1488,7 +1488,7 @@ public class EntityTests {
                     40L,
                     Limit.range(6, 10),
                     Order.by(
-                            Sort.asc("numType"), // primes first
+                            Sort.asc("numTypeOrdinal"), // primes first
                             Sort.asc("id")));
         } catch (UnsupportedOperationException x) {
             if (type.isKeywordSupportAtOrBelow(DatabaseType.COLUMN)) {
@@ -1725,7 +1725,7 @@ public class EntityTests {
                           "followed by the dynamic sort criteria when the value(s) being compared by the static criteria match.")
     public void testOrderByHasPrecedenceOverPageRequestSorts() {
         PageRequest pagination = PageRequest.ofSize(8);
-        Order<NaturalNumber> order = Order.by(Sort.asc("numType"), Sort.desc("id"));
+        Order<NaturalNumber> order = Order.by(Sort.asc("numTypeOrdinal"), Sort.desc("id"));
 
         Page<NaturalNumber> page;
         try {
@@ -1778,7 +1778,7 @@ public class EntityTests {
     public void testOrderByHasPrecedenceOverSorts() {
         Stream<NaturalNumber> nums;
         try {
-            nums = numbers.findByIdBetweenOrderByNumTypeAsc(
+            nums = numbers.findByIdBetweenOrderByNumTypeOrdinalAsc(
                     5L, 24L,
                     Order.by(Sort.desc("floorOfSquareRoot"), Sort.asc("id")));
         } catch (UnsupportedOperationException x) {


### PR DESCRIPTION
Fixes #830

This corrects the error in the TCK where it expects sorting on an enum attribute to be done in a particular way, which [per the spec is vendor specific](https://github.com/jakartaee/data/issues/830#issuecomment-2308476456).

Because this fix is needed in the 1.0.1 maintenance release, it should be as minimal as possible to fix the TCK, which is achieved by adding an entity attribute for the ordinal value and switching a few places in the TCK to sort on that value instead of the enum.