### PR TITLE
Adding sample of descending property to OrderBy Javadoc

### DIFF
--- a/api/src/main/java/jakarta/data/repository/OrderBy.java
+++ b/api/src/main/java/jakarta/data/repository/OrderBy.java
@@ -59,7 +59,7 @@ import java.lang.annotation.Target;
  *     {@code true}.</li>
  * </ul>
  * 
- * The default sort is ascending. The {@code descending} property can be
+ * The default sort order is ascending. The {@code descending} member can be
  * used to specify the sort direction.
  * <pre>
  * &#64;OrderBy(value = "price", descending = true)

--- a/api/src/main/java/jakarta/data/repository/OrderBy.java
+++ b/api/src/main/java/jakarta/data/repository/OrderBy.java
@@ -60,7 +60,7 @@ import java.lang.annotation.Target;
  * </ul>
  * 
  * The default sort order is ascending. The {@code descending} member can be
- * used to specify the sort direction.
+ * used to specify the sort direction.</p>
  * <pre>
  * &#64;OrderBy(value = "price", descending = true)
  * {@code Stream<Product>} findByPriceLessThanEqual(double maxPrice);

--- a/api/src/main/java/jakarta/data/repository/OrderBy.java
+++ b/api/src/main/java/jakarta/data/repository/OrderBy.java
@@ -49,7 +49,7 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * <p>The interpretation of ascending and descending order is determined
- * by the database, but, in general:
+ * by the database, but, in general:</p>
  * <ul>
  * <li>ascending order for numeric values is the natural order with
  *     smaller numbers before larger numbers,</li>
@@ -59,7 +59,7 @@ import java.lang.annotation.Target;
  *     {@code true}.</li>
  * </ul>
  * 
- * The default sort order is ascending. The {@code descending} member can be
+ * <p>The default sort order is ascending. The {@code descending} member can be
  * used to specify the sort direction.</p>
  * <pre>
  * &#64;OrderBy(value = "price", descending = true)

--- a/api/src/main/java/jakarta/data/repository/OrderBy.java
+++ b/api/src/main/java/jakarta/data/repository/OrderBy.java
@@ -58,6 +58,13 @@ import java.lang.annotation.Target;
  * <li>ascending order for boolean values places {@code false} before
  *     {@code true}.</li>
  * </ul>
+ * 
+ * The default sort is ascending. The {@code descending} property can be
+ * used to specify the sort direction.
+ * <pre>
+ * &#64;OrderBy(value = "price", descending = true)
+ * {@code Stream<Product>} findByPriceLessThanEqual(double maxPrice);
+ * </pre>
  *
  * <p>A repository method with an {@code @OrderBy} annotation must not
  * have:</p>


### PR DESCRIPTION
I noticed the class javadoc for `@OrderBy` doesn't mention or show an example of the `descending` property. I'm not sure if it's the case for other IDE's but in VSCode, the javadoc shown when hovering over an annotation doesn't include the properties, so without a description in the class javadoc, the availability of the `descending` property may not be obvious.