### PR TITLE
Update useage of maven-javadoc-plugin

### DIFF
--- a/.github/workflows/specification.yml
+++ b/.github/workflows/specification.yml
@@ -36,7 +36,7 @@ jobs:
         cp spec/target/generated-docs/jakarta-data-${{ github.event.inputs.specVersion }}.html  documentation/jakarta-data-${{ github.event.inputs.specVersion }}.html
         cp spec/target/generated-docs/jakarta-method-name-query-${{ github.event.inputs.specVersion }}.html  documentation/jakarta-method-name-query-${{ github.event.inputs.specVersion }}.html
 
-        cp -r api/target/apidocs/ documentation/apidocs
+        cp -r api/target/reports/apidocs/ documentation/apidocs
     - name: Upload documentation
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -154,18 +154,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <executions>
                     <execution>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- ~ Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+ ~ Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
  ~
  ~ This program and the accompanying materials are made available under the
  ~ terms of the Eclipse Public License v. 2.0, which is available at
@@ -197,9 +197,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.10.1</version>
         <executions>
           <execution>
-            <id>attach-api-javadocs</id>
+            <id>attach-tck-javadocs</id>
             <goals>
               <goal>jar</goal>
             </goals>


### PR DESCRIPTION
- Output directory of apidocs was switched from `/target/` to `/target/reports/` as of maven-javadoc-plugin:3.10.0
- Remove maven-javadoc-plugin from parent pom and let each module decide if it creates javadoc
- Update the tck module to use the same version of the maven-javadoc-plugin plugin as the api module to avoid errors