### PR TITLE
Javadoc example for By annotation has return type that does not make sense

### DIFF
--- a/api/src/main/java/jakarta/data/repository/By.java
+++ b/api/src/main/java/jakarta/data/repository/By.java
@@ -51,7 +51,7 @@ import java.lang.annotation.Target;
  *                            &#64;By("lastName") String last);
  *
  *     &#64;Find
- *     Person findByCity(&#64;By("address.city") String city);
+ *     List&lt;Person&gt; findByCity(&#64;By("address.city") String city);
  * }
  * </pre>
  *
@@ -75,7 +75,7 @@ import java.lang.annotation.Target;
  *                            String lastname);
  *
  *     &#64;Find
- *     Person findByCity(String address_city);
+ *     List&lt;Person&gt; findByCity(String address_city);
  * }
  * </pre>
  */


### PR DESCRIPTION
An example in the By annotation Javadoc ought to be using a return type that can handle multiple results because the query can product multiple results.