### PR TITLE
Inconsistent method signature in pagination example

### DIFF
--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -798,7 +798,11 @@ import java.util.Set;
  * For example,</p>
  *
  * <pre>
- * Product[] findByNameLike(String pattern, PageRequest pageRequest, Order&lt;Product&gt; order);
+ * Product[] findByNameLikeAndPriceBetween(String pattern,
+ *                                         float minPrice,
+ *                                         float maxPrice,
+ *                                         PageRequest pageRequest,
+ *                                         Order&lt;Product&gt; order);
  *
  * ...
  * PageRequest page1Request = PageRequest.ofSize(25);


### PR DESCRIPTION
Javadoc has a section about pagination which has an example method

```
* Product[] findByNameLike(String pattern, PageRequest pageRequest, Order&lt;Product&gt; order);
```

that is supposed to be used for the following example usage pattern,

```
 * page1 = products.findByNameLikeAndPriceBetween(
 *                 namePattern, minPrice, maxPrice, page1Request,
 *                 Order.by(Sort.desc("price"), Sort.asc("id"));
```

The two are inconsistent. The methods have different names and accept a different number of parameters.

This PR updates them to match so that the example will make more sense.
