### PR TITLE
Javadoc description of automatic query methods is incomplete

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Delete.java
+++ b/api/src/main/java/jakarta/data/repository/Delete.java
@@ -60,7 +60,7 @@ import java.lang.annotation.Target;
  * {@link jakarta.data.exceptions.OptimisticLockingFailureException}.
  * </p>
  *
- * <p>Alternatively, the {@code Delete} annotation may be used to annotate a repository method with no parameter of
+ * <p>Alternatively, the {@code Delete} annotation may be used to annotate a repository method with no parameter of an
  * entity type. Then the repository method is interpreted as a parameter-based automatic query method. The entity type
  * to be deleted is the primary entity type of the repository. The method return type must be {@code void}, {@code int},
  * or {@code long}. Every parameter of the annotated method must have exactly the same type and name (the parameter name

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -687,7 +687,9 @@ import java.util.Set;
  * <h2>Parameter-based automatic query methods</h2>
  *
  * <p>The {@link Find} annotation indicates that the repository method is
- * a parameter-based automatic query method. In this case, the method name
+ * a parameter-based automatic query method. The {@link Delete} annotation
+ * also indicates a parameter-based automatic query method when the
+ * method has no entity type parameters. In these cases, the method name
  * does not determine the semantics of the method, and the query conditions
  * are determined by the method parameters.</p>
  *
@@ -697,7 +699,8 @@ import java.util.Set;
  *     source, or a name assigned by {@link By @By}) as a persistent field
  *     or property of the entity class, or</li>
  * <li>be of type {@link jakarta.data.Limit}, {@link jakarta.data.Sort},
- *     {@link jakarta.data.Order}, or {@link jakarta.data.page.PageRequest}.</li>
+ *     {@link jakarta.data.Order}, or {@link jakarta.data.page.PageRequest}
+ *     - if the repository method is annotated with {@link Find}.</li>
  * </ul>
  *
  * <p>A parameter may be annotated with the {@link By} annotation to specify


### PR DESCRIPTION
While reading the section, "Parameter-based automatic query methods", in the module-info Javadoc, I noticed the section is a little bit misleading because it only mentions `@Find` being used to indicate automatic query methods. However, `@Delete` can also be used for automatic query methods (determined by the absence of an entity typed method parameter), as indicated by the `@Delete` Javadoc.  This PR clarifies the module-info Javadoc to acknowledge this, also clarifying that the special parameter types like PageRequest that it says you can use with automatic query methods are specifically for use with the `@Find` annotation, not `@Delete`.  There is no change in behavior or requirements here, only making this section of the module-info JavaDoc clear and consistent with the rest of the spec.

I also spotted a minor type (missing word) in the Delete annotation Javadoc and added it.