### PR TITLE
Resolve build failure from LifecycleEvent:51

### DIFF
--- a/api/src/main/java/jakarta/data/event/LifecycleEvent.java
+++ b/api/src/main/java/jakarta/data/event/LifecycleEvent.java
@@ -48,10 +48,10 @@ package jakarta.data.event;
  *
  * @param <E> the entity type
  */
-public abstract class LifecycleEvent<E> {
+public class LifecycleEvent<E> {
     private final E entity;
 
-    public LifecycleEvent(E entity) {
+    protected LifecycleEvent(E entity) {
         this.entity = entity;
     }
 


### PR DESCRIPTION
I brought in the latest code and tried to build, but it fails here,

```
[WARNING] PMD Failure: jakarta.data.event.LifecycleEvent:51 Rule:AbstractClassWithoutAbstractMethod Priority:3 This abstract class does not have any abstract methods.
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Jakarta Data 1.0.1-SNAPSHOT:
[INFO] 
[INFO] Jakarta Data ....................................... SUCCESS [  5.347 s]
[INFO] Jakarta Data API ................................... FAILURE [ 13.975 s]
[INFO] Jakarta Data Specification ......................... SKIPPED
[INFO] Jakarta Data Technology Compatibility Kit .......... SKIPPED
[INFO] Jakarta Data Technology Compatibility Kit Distribution SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  19.425 s
[INFO] Finished at: 2024-12-05T14:53:33-06:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-pmd-plugin:3.26.0:check (default) on project jakarta.data-api: PMD 7.7.0 has found 1 violation. For more details see: ...
```

This PR is one way to resolve the failure.