### PR TITLE
update Restrictions to standardize on attribute terminology

### DIFF
--- a/api/src/main/java/jakarta/data/BasicRestriction.java
+++ b/api/src/main/java/jakarta/data/BasicRestriction.java
@@ -18,9 +18,9 @@
 package jakarta.data;
 
 public interface BasicRestriction<T> extends Restriction<T> {
-    Operator comparison();
+    String attribute();
 
-    String field();
+    Operator comparison();
 
     @Override
     BasicRestriction<T> negate();

--- a/api/src/main/java/jakarta/data/BasicRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/BasicRestrictionRecord.java
@@ -24,18 +24,18 @@ package jakarta.data;
 import java.util.Objects;
 
 record BasicRestrictionRecord<T>(
-        String field,
+        String attribute,
         Operator comparison,
         Object value) implements BasicRestriction<T> {
 
     BasicRestrictionRecord {
-        Objects.requireNonNull(field, "Field must not be null");
+        Objects.requireNonNull(attribute, "Attribute must not be null");
     }
 
     @Override
     public BasicRestriction<T> negate() {
         return new BasicRestrictionRecord<>(
-                field,
+                attribute,
                 comparison.negate(),
                 value);
     }

--- a/api/src/main/java/jakarta/data/Restrict.java
+++ b/api/src/main/java/jakarta/data/Restrict.java
@@ -53,83 +53,83 @@ public class Restrict {
 
     public static <T, V extends Comparable<V>> Restriction<T> between(V min,
                                                                       V max,
-                                                                      String field) {
-        return all(greaterThanEqual(min, field),
-                   lessThanEqual(max, field));
+                                                                      String attribute) {
+        return all(greaterThanEqual(min, attribute),
+                   lessThanEqual(max, attribute));
     }
 
     // TODO Need to think more about how to best cover negation of multiple
     // and then make negation of Single consistent with it
 
-    public static <T> TextRestriction<T> contains(String substring, String field) {
+    public static <T> TextRestriction<T> contains(String substring, String attribute) {
         String pattern = toLikeEscaped(CHAR_WILDCARD, STRING_WILDCARD, true, substring, true);
-        return new TextRestrictionRecord<>(field, Operator.LIKE, ESCAPED, pattern);
+        return new TextRestrictionRecord<>(attribute, Operator.LIKE, ESCAPED, pattern);
     }
 
-    public static <T> TextRestriction<T> endsWith(String suffix, String field) {
+    public static <T> TextRestriction<T> endsWith(String suffix, String attribute) {
         String pattern = toLikeEscaped(CHAR_WILDCARD, STRING_WILDCARD, true, suffix, false);
-        return new TextRestrictionRecord<>(field, Operator.LIKE, ESCAPED, pattern);
+        return new TextRestrictionRecord<>(attribute, Operator.LIKE, ESCAPED, pattern);
     }
 
-    public static <T> Restriction<T> equalTo(Object value, String field) {
-        return new BasicRestrictionRecord<>(field, Operator.EQUAL, value);
+    public static <T> Restriction<T> equalTo(Object value, String attribute) {
+        return new BasicRestrictionRecord<>(attribute, Operator.EQUAL, value);
     }
 
-    public static <T> TextRestriction<T> equalTo(String value, String field) {
-        return new TextRestrictionRecord<>(field, Operator.EQUAL, value);
+    public static <T> TextRestriction<T> equalTo(String value, String attribute) {
+        return new TextRestrictionRecord<>(attribute, Operator.EQUAL, value);
     }
 
-    public static <T, V extends Comparable<V>> Restriction<T> greaterThan(V value, String field) {
-        return new BasicRestrictionRecord<>(field, Operator.GREATER_THAN, value);
+    public static <T, V extends Comparable<V>> Restriction<T> greaterThan(V value, String attribute) {
+        return new BasicRestrictionRecord<>(attribute, Operator.GREATER_THAN, value);
     }
 
-    public static <T> TextRestriction<T> greaterThan(String value, String field) {
-        return new TextRestrictionRecord<>(field, Operator.GREATER_THAN, value);
+    public static <T> TextRestriction<T> greaterThan(String value, String attribute) {
+        return new TextRestrictionRecord<>(attribute, Operator.GREATER_THAN, value);
     }
 
-    public static <T, V extends Comparable<V>> Restriction<T> greaterThanEqual(V value, String field) {
-        return new BasicRestrictionRecord<>(field, Operator.GREATER_THAN_EQUAL, value);
+    public static <T, V extends Comparable<V>> Restriction<T> greaterThanEqual(V value, String attribute) {
+        return new BasicRestrictionRecord<>(attribute, Operator.GREATER_THAN_EQUAL, value);
     }
 
-    public static <T> TextRestriction<T> greaterThanEqual(String value, String field) {
-        return new TextRestrictionRecord<>(field, Operator.GREATER_THAN_EQUAL, value);
+    public static <T> TextRestriction<T> greaterThanEqual(String value, String attribute) {
+        return new TextRestrictionRecord<>(attribute, Operator.GREATER_THAN_EQUAL, value);
     }
 
-    public static <T> Restriction<T> in(Set<Object> values, String field) {
-        return new BasicRestrictionRecord<>(field, Operator.IN, values);
+    public static <T> Restriction<T> in(Set<Object> values, String attribute) {
+        return new BasicRestrictionRecord<>(attribute, Operator.IN, values);
     }
 
-    public static <T, V extends Comparable<V>> Restriction<T> lessThan(V value, String field) {
-        return new BasicRestrictionRecord<>(field, Operator.LESS_THAN, value);
+    public static <T, V extends Comparable<V>> Restriction<T> lessThan(V value, String attribute) {
+        return new BasicRestrictionRecord<>(attribute, Operator.LESS_THAN, value);
     }
 
-    public static <T> TextRestriction<T> lessThan(String value, String field) {
-        return new TextRestrictionRecord<>(field, Operator.LESS_THAN, value);
+    public static <T> TextRestriction<T> lessThan(String value, String attribute) {
+        return new TextRestrictionRecord<>(attribute, Operator.LESS_THAN, value);
     }
 
-    public static <T, V extends Comparable<V>> Restriction<T> lessThanEqual(V value, String field) {
-        return new BasicRestrictionRecord<>(field, Operator.LESS_THAN_EQUAL, value);
+    public static <T, V extends Comparable<V>> Restriction<T> lessThanEqual(V value, String attribute) {
+        return new BasicRestrictionRecord<>(attribute, Operator.LESS_THAN_EQUAL, value);
     }
 
-    public static <T> TextRestriction<T> lessThanEqual(String value, String field) {
-        return new TextRestrictionRecord<>(field, Operator.LESS_THAN_EQUAL, value);
+    public static <T> TextRestriction<T> lessThanEqual(String value, String attribute) {
+        return new TextRestrictionRecord<>(attribute, Operator.LESS_THAN_EQUAL, value);
     }
 
     // TODO this would be possible if Pattern is added, but is it even useful?
-    //public static <T> TextRestriction<T> like(Pattern pattern, String field) {
-    //    return new TextRestriction<>(field, Operator.LIKE, ESCAPED, pattern);
+    //public static <T> TextRestriction<T> like(Pattern pattern, String attribute) {
+    //    return new TextRestriction<>(attribute, Operator.LIKE, ESCAPED, pattern);
     //}
 
-    public static <T> TextRestriction<T> like(String pattern, String field) {
-        return new TextRestrictionRecord<>(field, Operator.LIKE, pattern);
+    public static <T> TextRestriction<T> like(String pattern, String attribute) {
+        return new TextRestrictionRecord<>(attribute, Operator.LIKE, pattern);
     }
 
     public static <T> TextRestriction<T> like(String pattern,
                                                char charWildcard,
                                                char stringWildcard,
-                                               String field) {
+                                               String attribute) {
         String p = toLikeEscaped(charWildcard, stringWildcard, false, pattern, false);
-        return new TextRestrictionRecord<>(field, Operator.LIKE, ESCAPED, p);
+        return new TextRestrictionRecord<>(attribute, Operator.LIKE, ESCAPED, p);
     }
 
     // convenience method for those who would prefer to avoid .negate()
@@ -138,48 +138,48 @@ public class Restrict {
         return restriction.negate();
     }
 
-    public static <T> Restriction<T> notEqualTo(Object value, String field) {
-        return new BasicRestrictionRecord<>(field, Operator.NOT_EQUAL, value);
+    public static <T> Restriction<T> notEqualTo(Object value, String attribute) {
+        return new BasicRestrictionRecord<>(attribute, Operator.NOT_EQUAL, value);
     }
 
-    public static <T> TextRestriction<T> notEqualTo(String value, String field) {
-        return new TextRestrictionRecord<>(field, Operator.NOT_EQUAL, value);
+    public static <T> TextRestriction<T> notEqualTo(String value, String attribute) {
+        return new TextRestrictionRecord<>(attribute, Operator.NOT_EQUAL, value);
     }
 
-    public static <T> TextRestriction<T> notContains(String substring, String field) {
+    public static <T> TextRestriction<T> notContains(String substring, String attribute) {
         String pattern = toLikeEscaped(CHAR_WILDCARD, STRING_WILDCARD, true, substring, true);
-        return new TextRestrictionRecord<>(field, Operator.NOT_LIKE, ESCAPED, pattern);
+        return new TextRestrictionRecord<>(attribute, Operator.NOT_LIKE, ESCAPED, pattern);
     }
 
-    public static <T> TextRestriction<T> notEndsWith(String suffix, String field) {
+    public static <T> TextRestriction<T> notEndsWith(String suffix, String attribute) {
         String pattern = toLikeEscaped(CHAR_WILDCARD, STRING_WILDCARD, true, suffix, false);
-        return new TextRestrictionRecord<>(field, Operator.NOT_LIKE, ESCAPED, pattern);
+        return new TextRestrictionRecord<>(attribute, Operator.NOT_LIKE, ESCAPED, pattern);
     }
 
-    public static <T> Restriction<T> notIn(Set<Object> values, String field) {
-        return new BasicRestrictionRecord<>(field, Operator.NOT_IN, values);
+    public static <T> Restriction<T> notIn(Set<Object> values, String attribute) {
+        return new BasicRestrictionRecord<>(attribute, Operator.NOT_IN, values);
     }
 
-    public static <T> TextRestriction<T> notLike(String pattern, String field) {
-        return new TextRestrictionRecord<>(field, Operator.NOT_LIKE, pattern);
+    public static <T> TextRestriction<T> notLike(String pattern, String attribute) {
+        return new TextRestrictionRecord<>(attribute, Operator.NOT_LIKE, pattern);
     }
 
     public static <T> TextRestriction<T> notLike(String pattern,
                                                   char charWildcard,
                                                   char stringWildcard,
-                                                  String field) {
+                                                  String attribute) {
         String p = toLikeEscaped(charWildcard, stringWildcard, false, pattern, false);
-        return new TextRestrictionRecord<>(field, Operator.NOT_LIKE, ESCAPED, p);
+        return new TextRestrictionRecord<>(attribute, Operator.NOT_LIKE, ESCAPED, p);
     }
 
-    public static <T> TextRestriction<T> notStartsWith(String prefix, String field) {
+    public static <T> TextRestriction<T> notStartsWith(String prefix, String attribute) {
         String pattern = toLikeEscaped(CHAR_WILDCARD, STRING_WILDCARD, false, prefix, true);
-        return new TextRestrictionRecord<>(field, Operator.NOT_LIKE, ESCAPED, pattern);
+        return new TextRestrictionRecord<>(attribute, Operator.NOT_LIKE, ESCAPED, pattern);
     }
 
-    public static <T> TextRestriction<T> startsWith(String prefix, String field) {
+    public static <T> TextRestriction<T> startsWith(String prefix, String attribute) {
         String pattern = toLikeEscaped(CHAR_WILDCARD, STRING_WILDCARD, false, prefix, true);
-        return new TextRestrictionRecord<>(field, Operator.LIKE, ESCAPED, pattern);
+        return new TextRestrictionRecord<>(attribute, Operator.LIKE, ESCAPED, pattern);
     }
 
     /**

--- a/api/src/main/java/jakarta/data/TextRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/TextRestrictionRecord.java
@@ -24,14 +24,14 @@ package jakarta.data;
 import java.util.Objects;
 
 record TextRestrictionRecord<T>(
-        String field,
+        String attribute,
         Operator comparison,
         boolean isCaseSensitive,
         boolean isEscaped,
         String value) implements TextRestriction<T> {
 
     TextRestrictionRecord {
-        Objects.requireNonNull(field, "Field must not be null");
+        Objects.requireNonNull(attribute, "Attribute must not be null");
     }
 
     TextRestrictionRecord(String field, Operator comparison, boolean escaped, String value) {
@@ -44,14 +44,14 @@ record TextRestrictionRecord<T>(
 
     @Override
     public TextRestriction<T> ignoreCase() {
-        return new TextRestrictionRecord<>(field, comparison, false, isEscaped, value);
+        return new TextRestrictionRecord<>(attribute, comparison, false, isEscaped, value);
     }
 
     @Override
     public TextRestriction<T> negate() {
 
         return new TextRestrictionRecord<>(
-                field,
+                attribute,
                 comparison.negate(),
                 isCaseSensitive,
                 isEscaped,

--- a/api/src/test/java/jakarta/data/BasicRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/BasicRestrictionRecordTest.java
@@ -33,7 +33,7 @@ class BasicRestrictionRecordTest {
         BasicRestrictionRecord<String> restriction = new BasicRestrictionRecord<>("title", Operator.EQUAL, "Java Guide");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.field()).isEqualTo("title");
+            soft.assertThat(restriction.attribute()).isEqualTo("title");
             soft.assertThat(restriction.comparison()).isEqualTo(Operator.EQUAL);
             soft.assertThat(restriction.value()).isEqualTo("Java Guide");
         });
@@ -46,7 +46,7 @@ class BasicRestrictionRecordTest {
                         .negate();
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.field()).isEqualTo("title");
+            soft.assertThat(restriction.attribute()).isEqualTo("title");
             soft.assertThat(restriction.comparison()).isEqualTo(Operator.NOT_EQUAL);
             soft.assertThat(restriction.value()).isEqualTo("Java Guide");
         });
@@ -58,7 +58,7 @@ class BasicRestrictionRecordTest {
         BasicRestrictionRecord<String> restriction = new BasicRestrictionRecord<>("title", Operator.EQUAL, null);
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.field()).isEqualTo("title");
+            soft.assertThat(restriction.attribute()).isEqualTo("title");
             soft.assertThat(restriction.comparison()).isEqualTo(Operator.EQUAL);
             soft.assertThat(restriction.value()).isNull();
         });
@@ -114,16 +114,16 @@ class BasicRestrictionRecordTest {
                 (BasicRestriction<Book>) Restrict.<Book>notEqualTo((Object) "Unknown", "author");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(negatedRestriction.field()).isEqualTo("author");
+            soft.assertThat(negatedRestriction.attribute()).isEqualTo("author");
             soft.assertThat(negatedRestriction.comparison()).isEqualTo(Operator.NOT_EQUAL);
             soft.assertThat(negatedRestriction.value()).isEqualTo("Unknown");
         });
     }
 
     @Test
-    void shouldThrowExceptionWhenFieldIsNull() {
+    void shouldThrowExceptionWhenAttributeIsNull() {
         assertThatThrownBy(() -> new BasicRestrictionRecord<>(null, Operator.EQUAL, "testValue"))
                 .isInstanceOf(NullPointerException.class)
-                .hasMessage("Field must not be null");
+                .hasMessage("Attribute must not be null");
     }
 }

--- a/api/src/test/java/jakarta/data/RestrictTest.java
+++ b/api/src/test/java/jakarta/data/RestrictTest.java
@@ -28,13 +28,13 @@ class RestrictTest {
 
     @Test
     void shouldCreateEqualToRestriction() {
-        Restriction<String> restriction = Restrict.equalTo("value", "field");
+        Restriction<String> restriction = Restrict.equalTo("value", "attributeName");
 
         assertThat(restriction).isInstanceOf(TextRestrictionRecord.class);
 
         TextRestrictionRecord<String> basic = (TextRestrictionRecord<String>) restriction;
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(basic.field()).isEqualTo("field");
+            soft.assertThat(basic.attribute()).isEqualTo("attributeName");
             soft.assertThat(basic.comparison()).isEqualTo(Operator.EQUAL);
             soft.assertThat(basic.value()).isEqualTo("value");
         });
@@ -42,13 +42,13 @@ class RestrictTest {
 
     @Test
     void shouldCreateNotEqualToRestriction() {
-        Restriction<String> restriction = Restrict.notEqualTo("value", "field");
+        Restriction<String> restriction = Restrict.notEqualTo("value", "attributeName");
 
         assertThat(restriction).isInstanceOf(TextRestrictionRecord.class);
 
         TextRestrictionRecord<String> basic = (TextRestrictionRecord<String>) restriction;
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(basic.field()).isEqualTo("field");
+            soft.assertThat(basic.attribute()).isEqualTo("attributeName");
             soft.assertThat(basic.comparison()).isEqualTo(Operator.NOT_EQUAL);
             soft.assertThat(basic.value()).isEqualTo("value");
         });
@@ -56,8 +56,8 @@ class RestrictTest {
 
     @Test
     void shouldCombineAllRestrictionsWithNegation() {
-        Restriction<String> r1 = Restrict.notEqualTo("value1", "field1");
-        Restriction<String> r2 = Restrict.greaterThan(100, "field2");
+        Restriction<String> r1 = Restrict.notEqualTo("value1", "attributeName1");
+        Restriction<String> r2 = Restrict.greaterThan(100, "attributeName2");
 
         Restriction<String> combined = Restrict.all(r1, r2);
 
@@ -73,10 +73,10 @@ class RestrictTest {
 
     @Test
     void shouldCreateContainsRestriction() {
-        TextRestriction<String> restriction = Restrict.contains("substring", "field");
+        TextRestriction<String> restriction = Restrict.contains("substring", "attributeName");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.field()).isEqualTo("field");
+            soft.assertThat(restriction.attribute()).isEqualTo("attributeName");
             soft.assertThat(restriction.comparison()).isEqualTo(Operator.LIKE);
             soft.assertThat(restriction.value()).isEqualTo("%substring%");
         });
@@ -84,10 +84,10 @@ class RestrictTest {
 
     @Test
     void shouldCreateNegatedContainsRestriction() {
-        TextRestriction<String> restriction = Restrict.notContains("substring", "field");
+        TextRestriction<String> restriction = Restrict.notContains("substring", "attributeName");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.field()).isEqualTo("field");
+            soft.assertThat(restriction.attribute()).isEqualTo("attributeName");
             soft.assertThat(restriction.comparison()).isEqualTo(Operator.NOT_LIKE);
             soft.assertThat(restriction.value()).isEqualTo("%substring%");
         });
@@ -95,10 +95,10 @@ class RestrictTest {
 
     @Test
     void shouldCreateStartsWithRestriction() {
-        TextRestriction<String> restriction = Restrict.startsWith("prefix", "field");
+        TextRestriction<String> restriction = Restrict.startsWith("prefix", "attributeName");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.field()).isEqualTo("field");
+            soft.assertThat(restriction.attribute()).isEqualTo("attributeName");
             soft.assertThat(restriction.comparison()).isEqualTo(Operator.LIKE);
             soft.assertThat(restriction.value()).isEqualTo("prefix%");
         });
@@ -106,10 +106,10 @@ class RestrictTest {
 
     @Test
     void shouldCreateNegatedStartsWithRestriction() {
-        TextRestriction<String> restriction = Restrict.notStartsWith("prefix", "field");
+        TextRestriction<String> restriction = Restrict.notStartsWith("prefix", "attributeName");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.field()).isEqualTo("field");
+            soft.assertThat(restriction.attribute()).isEqualTo("attributeName");
             soft.assertThat(restriction.comparison()).isEqualTo(Operator.NOT_LIKE);
             soft.assertThat(restriction.value()).isEqualTo("prefix%");
         });
@@ -117,10 +117,10 @@ class RestrictTest {
 
     @Test
     void shouldCreateEndsWithRestriction() {
-        TextRestriction<String> restriction = Restrict.endsWith("suffix", "field");
+        TextRestriction<String> restriction = Restrict.endsWith("suffix", "attributeName");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.field()).isEqualTo("field");
+            soft.assertThat(restriction.attribute()).isEqualTo("attributeName");
             soft.assertThat(restriction.comparison()).isEqualTo(Operator.LIKE);
             soft.assertThat(restriction.value()).isEqualTo("%suffix");
         });
@@ -128,10 +128,10 @@ class RestrictTest {
 
     @Test
     void shouldCreateNegatedEndsWithRestriction() {
-        TextRestriction<String> restriction = Restrict.notEndsWith("suffix", "field");
+        TextRestriction<String> restriction = Restrict.notEndsWith("suffix", "attributeName");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.field()).isEqualTo("field");
+            soft.assertThat(restriction.attribute()).isEqualTo("attributeName");
             soft.assertThat(restriction.comparison()).isEqualTo(Operator.NOT_LIKE);
             soft.assertThat(restriction.value()).isEqualTo("%suffix");
         });
@@ -139,14 +139,14 @@ class RestrictTest {
 
     @Test
     void shouldEscapeToLikePatternCorrectly() {
-        String result = Restrict.endsWith("test_value", "fieldName").value();
+        String result = Restrict.endsWith("test_value", "attributeName").value();
 
         assertThat(result).isEqualTo("%test\\_value");
     }
 
     @Test
     void shouldThrowExceptionForInvalidWildcard() {
-        assertThatThrownBy(() -> Restrict.like("pattern_value", '_', '_', "fieldName"))
+        assertThatThrownBy(() -> Restrict.like("pattern_value", '_', '_', "attributeName"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Cannot use the same character (_) for both types of wildcards.");
     }

--- a/api/src/test/java/jakarta/data/TextRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/TextRestrictionRecordTest.java
@@ -36,7 +36,7 @@ class TextRestrictionRecordTest {
         );
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.field()).isEqualTo("title");
+            soft.assertThat(restriction.attribute()).isEqualTo("title");
             soft.assertThat(restriction.comparison()).isEqualTo(Operator.LIKE);
             soft.assertThat(restriction.value()).isEqualTo("%Java%");
             soft.assertThat(restriction.isCaseSensitive()).isTrue();
@@ -53,7 +53,7 @@ class TextRestrictionRecordTest {
         );
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.field()).isEqualTo("title");
+            soft.assertThat(restriction.attribute()).isEqualTo("title");
             soft.assertThat(restriction.comparison()).isEqualTo(Operator.NOT_LIKE);
             soft.assertThat(restriction.value()).isEqualTo("%Java%");
             soft.assertThat(restriction.isCaseSensitive()).isTrue();
@@ -74,7 +74,7 @@ class TextRestrictionRecordTest {
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(caseInsensitiveRestriction).isInstanceOf(TextRestrictionRecord.class);
             TextRestrictionRecord<String> textRestriction = (TextRestrictionRecord<String>) caseInsensitiveRestriction;
-            soft.assertThat(textRestriction.field()).isEqualTo("title");
+            soft.assertThat(textRestriction.attribute()).isEqualTo("title");
             soft.assertThat(textRestriction.comparison()).isEqualTo(Operator.LIKE);
             soft.assertThat(textRestriction.value()).isEqualTo("%Java%");
             soft.assertThat(textRestriction.isCaseSensitive()).isFalse();
@@ -92,7 +92,7 @@ class TextRestrictionRecordTest {
         );
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.field()).isEqualTo("title");
+            soft.assertThat(restriction.attribute()).isEqualTo("title");
             soft.assertThat(restriction.comparison()).isEqualTo(Operator.LIKE);
             soft.assertThat(restriction.value()).isEqualTo("%Java%");
             soft.assertThat(restriction.isCaseSensitive()).isTrue();
@@ -149,7 +149,7 @@ class TextRestrictionRecordTest {
         );
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.field()).isEqualTo("author");
+            soft.assertThat(restriction.attribute()).isEqualTo("author");
             soft.assertThat(restriction.comparison()).isEqualTo(Operator.NOT_EQUAL);
             soft.assertThat(restriction.value()).isEqualTo("John Doe");
             soft.assertThat(restriction.isCaseSensitive()).isTrue();
@@ -158,9 +158,9 @@ class TextRestrictionRecordTest {
     }
 
     @Test
-    void shouldThrowExceptionWhenFieldIsNullInTextRestriction() {
+    void shouldThrowExceptionWhenAttributeIsNullInTextRestriction() {
         assertThatThrownBy(() -> new TextRestrictionRecord<>(null, Operator.LIKE, "testValue"))
                 .isInstanceOf(NullPointerException.class)
-                .hasMessage("Field must not be null");
+                .hasMessage("Attribute must not be null");
     }
 }

--- a/api/src/test/java/jakarta/data/metamodel/AttributeTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/AttributeTest.java
@@ -37,7 +37,7 @@ class AttributeTest {
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
             BasicRestriction<String> basic = (BasicRestriction<String>) restriction;
-            soft.assertThat(basic.field()).isEqualTo("testAttribute");
+            soft.assertThat(basic.attribute()).isEqualTo("testAttribute");
             soft.assertThat(basic.value()).isEqualTo("testValue");
             soft.assertThat(basic.comparison()).isEqualTo(Operator.EQUAL);
         });
@@ -50,7 +50,7 @@ class AttributeTest {
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
             BasicRestriction<String> basic = (BasicRestriction<String>) restriction;
-            soft.assertThat(basic.field()).isEqualTo("testAttribute");
+            soft.assertThat(basic.attribute()).isEqualTo("testAttribute");
             soft.assertThat(basic.value()).isEqualTo("testValue");
             soft.assertThat(basic.comparison()).isEqualTo(Operator.NOT_EQUAL);
         });
@@ -63,7 +63,7 @@ class AttributeTest {
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
             BasicRestriction<String> basic = (BasicRestriction<String>) restriction;
-            soft.assertThat(basic.field()).isEqualTo("testAttribute");
+            soft.assertThat(basic.attribute()).isEqualTo("testAttribute");
             soft.assertThat(basic.value()).isEqualTo(Set.of("value1", "value2"));
             soft.assertThat(basic.comparison()).isEqualTo(Operator.IN);
         });
@@ -83,7 +83,7 @@ class AttributeTest {
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
             BasicRestriction<String> basic = (BasicRestriction<String>) restriction;
-            soft.assertThat(basic.field()).isEqualTo("testAttribute");
+            soft.assertThat(basic.attribute()).isEqualTo("testAttribute");
             soft.assertThat(basic.value()).isEqualTo(Set.of("value1", "value2"));
             soft.assertThat(basic.comparison()).isEqualTo(Operator.NOT_IN);
         });
@@ -103,7 +103,7 @@ class AttributeTest {
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
             BasicRestriction<String> basic = (BasicRestriction<String>) restriction;
-            soft.assertThat(basic.field()).isEqualTo("testAttribute");
+            soft.assertThat(basic.attribute()).isEqualTo("testAttribute");
             soft.assertThat(basic.value()).isNull();
             soft.assertThat(basic.comparison()).isEqualTo(Operator.EQUAL);
         });
@@ -116,7 +116,7 @@ class AttributeTest {
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
             BasicRestriction<String> basic = (BasicRestriction<String>) restriction;
-            soft.assertThat(basic.field()).isEqualTo("testAttribute");
+            soft.assertThat(basic.attribute()).isEqualTo("testAttribute");
             soft.assertThat(basic.value()).isNull();
             soft.assertThat(basic.comparison()).isEqualTo(Operator.NOT_EQUAL);
         });

--- a/api/src/test/java/jakarta/data/metamodel/SortableAttributeTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/SortableAttributeTest.java
@@ -53,7 +53,7 @@ class SortableAttributeTest {
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
             BasicRestriction<String> basic = (BasicRestriction<String>) restriction;
-            soft.assertThat(basic.field()).isEqualTo("testAttribute");
+            soft.assertThat(basic.attribute()).isEqualTo("testAttribute");
             soft.assertThat(basic.value()).isEqualTo(10);
             soft.assertThat(basic.comparison()).isEqualTo(Operator.GREATER_THAN);
         });
@@ -66,7 +66,7 @@ class SortableAttributeTest {
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
             BasicRestriction<String> basic = (BasicRestriction<String>) restriction;
-            soft.assertThat(basic.field()).isEqualTo("testAttribute");
+            soft.assertThat(basic.attribute()).isEqualTo("testAttribute");
             soft.assertThat(basic.value()).isEqualTo(10);
             soft.assertThat(basic.comparison()).isEqualTo(Operator.GREATER_THAN_EQUAL);
         });
@@ -79,7 +79,7 @@ class SortableAttributeTest {
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
             BasicRestriction<String> basic = (BasicRestriction<String>) restriction;
-            soft.assertThat(basic.field()).isEqualTo("testAttribute");
+            soft.assertThat(basic.attribute()).isEqualTo("testAttribute");
             soft.assertThat(basic.value()).isEqualTo(10);
             soft.assertThat(basic.comparison()).isEqualTo(Operator.LESS_THAN);
         });
@@ -92,7 +92,7 @@ class SortableAttributeTest {
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
             BasicRestriction<String> basic = (BasicRestriction<String>) restriction;
-            soft.assertThat(basic.field()).isEqualTo("testAttribute");
+            soft.assertThat(basic.attribute()).isEqualTo("testAttribute");
             soft.assertThat(basic.value()).isEqualTo(10);
             soft.assertThat(basic.comparison()).isEqualTo(Operator.LESS_THAN_EQUAL);
         });
@@ -111,14 +111,14 @@ class SortableAttributeTest {
             Restriction<String> lowerBound = composite.restrictions().get(0);
             soft.assertThat(lowerBound).isInstanceOf(BasicRestriction.class);
             BasicRestriction<String> lower = (BasicRestriction<String>) lowerBound;
-            soft.assertThat(lower.field()).isEqualTo("testAttribute");
+            soft.assertThat(lower.attribute()).isEqualTo("testAttribute");
             soft.assertThat(lower.value()).isEqualTo(5);
             soft.assertThat(lower.comparison()).isEqualTo(Operator.GREATER_THAN_EQUAL);
 
             Restriction<String> upperBound = composite.restrictions().get(1);
             soft.assertThat(upperBound).isInstanceOf(BasicRestriction.class);
             BasicRestriction<String> upper = (BasicRestriction<String>) upperBound;
-            soft.assertThat(upper.field()).isEqualTo("testAttribute");
+            soft.assertThat(upper.attribute()).isEqualTo("testAttribute");
             soft.assertThat(upper.value()).isEqualTo(15);
             soft.assertThat(upper.comparison()).isEqualTo(Operator.LESS_THAN_EQUAL);
         });

--- a/api/src/test/java/jakarta/data/metamodel/TextAttributeTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/TextAttributeTest.java
@@ -58,7 +58,7 @@ class TextAttributeTest {
         TextRestriction<String> restriction = testAttribute.contains("testValue");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.field()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
             soft.assertThat(restriction.value()).isEqualTo("%testValue%");
             soft.assertThat(restriction.comparison()).isEqualTo(Operator.LIKE);
         });
@@ -69,7 +69,7 @@ class TextAttributeTest {
         TextRestriction<String> restriction = testAttribute.startsWith("testValue");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.field()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
             soft.assertThat(restriction.value()).isEqualTo("testValue%");
             soft.assertThat(restriction.comparison()).isEqualTo(Operator.LIKE);
         });
@@ -80,7 +80,7 @@ class TextAttributeTest {
         TextRestriction<String> restriction = testAttribute.endsWith("testValue");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.field()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
             soft.assertThat(restriction.value()).isEqualTo("%testValue");
             soft.assertThat(restriction.comparison()).isEqualTo(Operator.LIKE);
         });
@@ -91,7 +91,7 @@ class TextAttributeTest {
         TextRestriction<String> restriction = testAttribute.like("%test%");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.field()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
             soft.assertThat(restriction.value()).isEqualTo("%test%");
             soft.assertThat(restriction.comparison()).isEqualTo(Operator.LIKE);
         });
@@ -102,7 +102,7 @@ class TextAttributeTest {
         TextRestriction<String> restriction = testAttribute.notContains("testValue");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.field()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
             soft.assertThat(restriction.value()).isEqualTo("%testValue%");
             soft.assertThat(restriction.comparison()).isEqualTo(Operator.NOT_LIKE);
         });
@@ -113,7 +113,7 @@ class TextAttributeTest {
         TextRestriction<String> restriction = testAttribute.notLike("%test%");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.field()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
             soft.assertThat(restriction.value()).isEqualTo("%test%");
             soft.assertThat(restriction.comparison()).isEqualTo(Operator.NOT_LIKE);
         });
@@ -124,7 +124,7 @@ class TextAttributeTest {
         TextRestriction<String> restriction = testAttribute.notStartsWith("testValue");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.field()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
             soft.assertThat(restriction.value()).isEqualTo("testValue%");
             soft.assertThat(restriction.comparison()).isEqualTo(Operator.NOT_LIKE);
         });
@@ -135,7 +135,7 @@ class TextAttributeTest {
         TextRestriction<String> restriction = testAttribute.notEndsWith("testValue");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.field()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
             soft.assertThat(restriction.value()).isEqualTo("%testValue");
             soft.assertThat(restriction.comparison()).isEqualTo(Operator.NOT_LIKE);
         });


### PR DESCRIPTION
Update the restrictions API to align with the decision made under #906 to use the term "attribute" for entity attributes/fields/properties.

This PR does not cover updating the rest of the spec or javadoc that was already written prior to v1.1.