### PR TITLE
TCK challenge against boolean result of Query

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Query.java
+++ b/api/src/main/java/jakarta/data/repository/Query.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,8 +34,14 @@ import java.lang.annotation.Target;
  *
  * <p>The required {@link #value} member specifies the JDQL or JPQL query as a string.</p>
  *
- * <p>For {@code select} statements, the return type of the query method must be consistent with the type returned by
- * the query. For {@code update} or {@code delete} statements, it must be {@code void}, {@code int} or {@code long}.</p>
+ * <p>For {@code select} statements, the return type of the query method must be
+ * consistent with the type returned by the query.</p>
+ *
+ * <p>For {@code update} or {@code delete} statements, the return value must be one of:</p>
+ * <ul>
+ * <li>{@code void}</li>
+ * <li>{@code int} or {@code long}, where the value is the count of matching entities</li>
+ * </ul>
  *
  * <p>Compared to SQL, JDQL allows an abbreviated syntax for {@code select} statements:</p>
  * <ul>

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023,2025 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -2462,7 +2462,7 @@ public class EntityTests {
         float c1yExpected;
         double c1xExpected;
         try {
-            assertEquals(true, shared.move(id1, 1.23d, 1.5f));
+            assertEquals(1, shared.move(id1, 1.23d, 1.5f));
             c1yExpected = 3.5f; // 5.25 / 1.5 = 3.5
             c1xExpected = 1.23D;
         } catch (UnsupportedOperationException x) {

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/MultipleEntityRepo.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/MultipleEntityRepo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -51,7 +51,7 @@ public interface MultipleEntityRepo { // Do not add a primary entity type.
     void deleteIfPositiveWithoutReturnRecords();
 
     @Query("UPDATE Coordinate SET x = :newX, y = y / :yDivisor WHERE id = :id")
-    boolean move(UUID id, double newX, float yDivisor);
+    int move(UUID id, double newX, float yDivisor);
 
     @Query("WHERE id = ?1")
     Optional<Coordinate> withUUID(UUID id);


### PR DESCRIPTION
Fixes #923 by switching the TCK test from the invalid `boolean` return value for `@Query("UPDATE ...` to instead have a return type of `int`.  Also, improves documentation of `Query` to clarify what the `int` and `long` return values mean.

A separate PR/issue should be used if we decide that we also want to support a boolean return type.