### PR TITLE
Wide column databases might not be capable of AND

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -1205,8 +1205,8 @@ public class EntityTests {
                 // Column and Key-Value databases might not be capable of And.
                 // Key-Value databases might not be capable of Between.
                 // Column and Key-Value databases might not be capable of In
-                // Column and Key-Value databases might not be capable of sorting.
                 // when used with entity attributes other than the Id.
+                // Column and Key-Value databases might not be capable of sorting.
                 return;
             } else {
                 throw x;


### PR DESCRIPTION
See the [comment from](https://github.com/jakartaee/data/pull/943#discussion_r1924300502) @otaviojava in #943 which points out that some Wide Column databases are not capable of AND.  The TCK needs to be updated to allow for this.
