### PR TITLE
Need a way to indicate no additional restrictions

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/restrict/EmptyRestriction.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/EmptyRestriction.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data.metamodel.restrict;
+
+import java.util.List;
+
+class EmptyRestriction<T> implements CompositeRestriction<T> {
+    static final EmptyRestriction<?> INSTANCE = new EmptyRestriction<>();
+
+    // prevent instantiation by others
+    private EmptyRestriction() {
+    }
+
+    @Override
+    public boolean isNegated() {
+        return false;
+    }
+
+    @Override
+    public CompositeRestriction<T> negate() {
+        throw new UnsupportedOperationException("Empty restriction cannot be negated.");
+    }
+
+    @Override
+    public List<Restriction<T>> restrictions() {
+        return List.of();
+    }
+
+    @Override
+    public Type type() {
+        return Type.ALL;
+    }
+}

--- a/api/src/main/java/jakarta/data/metamodel/restrict/Restrict.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/Restrict.java
@@ -132,6 +132,11 @@ public class Restrict {
         return new TextRestrictionRecord<>(attribute, Operator.LIKE, ESCAPED, p);
     }
 
+    @SuppressWarnings("unchecked")
+    public static final <T> Restriction<T> none() {
+        return (Restriction<T>) EmptyRestriction.INSTANCE;
+    }
+
     // convenience method for those who would prefer to avoid .negate()
     public static <T> Restriction<T> not(Restriction<T> restriction) {
         Objects.requireNonNull(restriction, "Restriction must not be null");

--- a/api/src/main/java/jakarta/data/metamodel/restrict/Restrict.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/Restrict.java
@@ -132,11 +132,6 @@ public class Restrict {
         return new TextRestrictionRecord<>(attribute, Operator.LIKE, ESCAPED, p);
     }
 
-    @SuppressWarnings("unchecked")
-    public static final <T> Restriction<T> none() {
-        return (Restriction<T>) EmptyRestriction.INSTANCE;
-    }
-
     // convenience method for those who would prefer to avoid .negate()
     public static <T> Restriction<T> not(Restriction<T> restriction) {
         Objects.requireNonNull(restriction, "Restriction must not be null");
@@ -238,5 +233,10 @@ public class Restrict {
             s.append(STRING_WILDCARD);
         }
         return s.toString();
+    }
+
+    @SuppressWarnings("unchecked")
+    public static final <T> Restriction<T> unrestricted() {
+        return (Restriction<T>) Unrestricted.INSTANCE;
     }
 }

--- a/api/src/main/java/jakarta/data/metamodel/restrict/Unmatchable.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/Unmatchable.java
@@ -19,11 +19,11 @@ package jakarta.data.metamodel.restrict;
 
 import java.util.List;
 
-class Unrestricted<T> implements CompositeRestriction<T> {
-    static final Unrestricted<?> INSTANCE = new Unrestricted<>();
+class Unmatchable<T> implements CompositeRestriction<T> {
+    static final Unmatchable<?> INSTANCE = new Unmatchable<>();
 
     // prevent instantiation by others
-    private Unrestricted() {
+    private Unmatchable() {
     }
 
     @Override
@@ -34,7 +34,7 @@ class Unrestricted<T> implements CompositeRestriction<T> {
     @Override
     @SuppressWarnings("unchecked")
     public CompositeRestriction<T> negate() {
-        return (CompositeRestriction<T>) Unmatchable.INSTANCE;
+        return (CompositeRestriction<T>) Unrestricted.INSTANCE;
     }
 
     @Override
@@ -44,6 +44,6 @@ class Unrestricted<T> implements CompositeRestriction<T> {
 
     @Override
     public Type type() {
-        return Type.ALL;
+        return Type.ANY;
     }
 }

--- a/api/src/main/java/jakarta/data/metamodel/restrict/Unrestricted.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/Unrestricted.java
@@ -19,11 +19,11 @@ package jakarta.data.metamodel.restrict;
 
 import java.util.List;
 
-class EmptyRestriction<T> implements CompositeRestriction<T> {
-    static final EmptyRestriction<?> INSTANCE = new EmptyRestriction<>();
+class Unrestricted<T> implements CompositeRestriction<T> {
+    static final Unrestricted<?> INSTANCE = new Unrestricted<>();
 
     // prevent instantiation by others
-    private EmptyRestriction() {
+    private Unrestricted() {
     }
 
     @Override
@@ -33,7 +33,8 @@ class EmptyRestriction<T> implements CompositeRestriction<T> {
 
     @Override
     public CompositeRestriction<T> negate() {
-        throw new UnsupportedOperationException("Empty restriction cannot be negated.");
+        throw new UnsupportedOperationException(
+                "The absence of restrictions cannot be negated.");
     }
 
     @Override

--- a/api/src/test/java/jakarta/data/metamodel/restrict/RestrictTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/RestrictTest.java
@@ -61,22 +61,6 @@ class RestrictTest {
     }
 
     @Test
-    void shouldCreateEmptyRestriction() {
-        Restriction<Employee> unrestricted = Restrict.none();
-
-        assertThat(unrestricted).isInstanceOf(EmptyRestriction.class);
-
-        EmptyRestriction<Employee> emptyRestriction =
-                (EmptyRestriction<Employee>) unrestricted;
-
-        SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(emptyRestriction.isNegated()).isEqualTo(false);
-            soft.assertThat(emptyRestriction.restrictions()).isEmpty();
-            soft.assertThat(emptyRestriction.type()).isEqualTo(CompositeRestriction.Type.ALL);
-        });
-    }
-
-    @Test
     void shouldCreateEqualToRestriction() {
         Restriction<Employee> restriction = Restrict.equalTo("value", "attributeName");
 
@@ -188,6 +172,22 @@ class RestrictTest {
     }
 
     @Test
+    void shouldCreateUnrestricted() {
+        Restriction<Employee> restriction = Restrict.unrestricted();
+
+        assertThat(restriction).isInstanceOf(Unrestricted.class);
+
+        Unrestricted<Employee> unrestricted =
+                (Unrestricted<Employee>) restriction;
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(unrestricted.isNegated()).isEqualTo(false);
+            soft.assertThat(unrestricted.restrictions()).isEmpty();
+            soft.assertThat(unrestricted.type()).isEqualTo(CompositeRestriction.Type.ALL);
+        });
+    }
+
+    @Test
     void shouldEscapeToLikePatternCorrectly() {
         String result = Restrict.endsWith("test_value", "attributeName").value();
 
@@ -195,8 +195,8 @@ class RestrictTest {
     }
 
     @Test
-    void shouldSupplyEmptyRestrictionToRepositoryMethod() {
-        this.findByPosition("Software Engineer", Restrict.none());
+    void shouldSupplyUnrestrictedToRepositoryMethod() {
+        this.findByPosition("Software Engineer", Restrict.unrestricted());
     }
 
     @Test
@@ -207,10 +207,10 @@ class RestrictTest {
     }
 
     @Test
-    void shouldThrowExceptionForNegatingEmptyRestriction() {
-        Restriction<Employee> unrestricted = Restrict.none();
+    void shouldThrowExceptionForNegatingUnrestrictedRestriction() {
+        Restriction<Employee> unrestricted = Restrict.unrestricted();
         assertThatThrownBy(() -> unrestricted.negate())
                 .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessage("Empty restriction cannot be negated.");
+                .hasMessage("The absence of restrictions cannot be negated.");
     }
 }

--- a/api/src/test/java/jakarta/data/metamodel/restrict/RestrictTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/RestrictTest.java
@@ -20,19 +20,69 @@ package jakarta.data.metamodel.restrict;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 
+import jakarta.data.metamodel.SortableAttribute;
+import jakarta.data.metamodel.TextAttribute;
+import jakarta.data.metamodel.impl.SortableAttributeRecord;
+import jakarta.data.metamodel.impl.TextAttributeRecord;
+
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
-class RestrictTest {
+import java.util.List;
 
+class RestrictTest {
+    // Mock static metamodel class for tests
+    interface _Employee {
+        String BADGENUM = "badgeNum";
+        String NAME = "name";
+        String POSITION = "position";
+        String YEARHIRED = "yearHired";
+
+        SortableAttribute<Employee> badgeNum = new SortableAttributeRecord<>(BADGENUM);
+        TextAttribute<Employee> name = new TextAttributeRecord<>(NAME);
+        TextAttribute<Employee> position = new TextAttributeRecord<>(POSITION);
+        SortableAttribute<Employee> yearHired = new SortableAttributeRecord<>(YEARHIRED);
+    }
+
+    // Mock entity class for tests
+    class Employee {
+        int badgeNum;
+        String name;
+        String position;
+        int yearHired;
+    }
+
+    /**
+     * Mock repository method for tests.
+     */
+    List<Employee> findByPosition(String position,
+                                  Restriction<Employee> restriction) {
+        return List.of();
+    }
+
+    @Test
+    void shouldCreateEmptyRestriction() {
+        Restriction<Employee> unrestricted = Restrict.none();
+
+        assertThat(unrestricted).isInstanceOf(EmptyRestriction.class);
+
+        EmptyRestriction<Employee> emptyRestriction =
+                (EmptyRestriction<Employee>) unrestricted;
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(emptyRestriction.isNegated()).isEqualTo(false);
+            soft.assertThat(emptyRestriction.restrictions()).isEmpty();
+            soft.assertThat(emptyRestriction.type()).isEqualTo(CompositeRestriction.Type.ALL);
+        });
+    }
 
     @Test
     void shouldCreateEqualToRestriction() {
-        Restriction<String> restriction = Restrict.equalTo("value", "attributeName");
+        Restriction<Employee> restriction = Restrict.equalTo("value", "attributeName");
 
         assertThat(restriction).isInstanceOf(TextRestrictionRecord.class);
 
-        TextRestrictionRecord<String> basic = (TextRestrictionRecord<String>) restriction;
+        TextRestrictionRecord<Employee> basic = (TextRestrictionRecord<Employee>) restriction;
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(basic.attribute()).isEqualTo("attributeName");
             soft.assertThat(basic.comparison()).isEqualTo(Operator.EQUAL);
@@ -42,11 +92,11 @@ class RestrictTest {
 
     @Test
     void shouldCreateNotEqualToRestriction() {
-        Restriction<String> restriction = Restrict.notEqualTo("value", "attributeName");
+        Restriction<Employee> restriction = Restrict.notEqualTo("value", "attributeName");
 
         assertThat(restriction).isInstanceOf(TextRestrictionRecord.class);
 
-        TextRestrictionRecord<String> basic = (TextRestrictionRecord<String>) restriction;
+        TextRestrictionRecord<Employee> basic = (TextRestrictionRecord<Employee>) restriction;
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(basic.attribute()).isEqualTo("attributeName");
             soft.assertThat(basic.comparison()).isEqualTo(Operator.NOT_EQUAL);
@@ -56,14 +106,14 @@ class RestrictTest {
 
     @Test
     void shouldCombineAllRestrictionsWithNegation() {
-        Restriction<String> r1 = Restrict.notEqualTo("value1", "attributeName1");
-        Restriction<String> r2 = Restrict.greaterThan(100, "attributeName2");
+        Restriction<Employee> r1 = Restrict.notEqualTo("value1", "attributeName1");
+        Restriction<Employee> r2 = Restrict.greaterThan(100, "attributeName2");
 
-        Restriction<String> combined = Restrict.all(r1, r2);
+        Restriction<Employee> combined = Restrict.all(r1, r2);
 
         assertThat(combined).isInstanceOf(CompositeRestrictionRecord.class);
 
-        CompositeRestrictionRecord<String> composite = (CompositeRestrictionRecord<String>) combined;
+        CompositeRestrictionRecord<Employee> composite = (CompositeRestrictionRecord<Employee>) combined;
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(composite.type()).isEqualTo(CompositeRestriction.Type.ALL);
             soft.assertThat(composite.restrictions()).containsExactly(r1, r2);
@@ -73,7 +123,7 @@ class RestrictTest {
 
     @Test
     void shouldCreateContainsRestriction() {
-        TextRestriction<String> restriction = Restrict.contains("substring", "attributeName");
+        TextRestriction<Employee> restriction = Restrict.contains("substring", "attributeName");
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.attribute()).isEqualTo("attributeName");
@@ -84,7 +134,7 @@ class RestrictTest {
 
     @Test
     void shouldCreateNegatedContainsRestriction() {
-        TextRestriction<String> restriction = Restrict.notContains("substring", "attributeName");
+        TextRestriction<Employee> restriction = Restrict.notContains("substring", "attributeName");
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.attribute()).isEqualTo("attributeName");
@@ -95,7 +145,7 @@ class RestrictTest {
 
     @Test
     void shouldCreateStartsWithRestriction() {
-        TextRestriction<String> restriction = Restrict.startsWith("prefix", "attributeName");
+        TextRestriction<Employee> restriction = Restrict.startsWith("prefix", "attributeName");
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.attribute()).isEqualTo("attributeName");
@@ -106,7 +156,7 @@ class RestrictTest {
 
     @Test
     void shouldCreateNegatedStartsWithRestriction() {
-        TextRestriction<String> restriction = Restrict.notStartsWith("prefix", "attributeName");
+        TextRestriction<Employee> restriction = Restrict.notStartsWith("prefix", "attributeName");
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.attribute()).isEqualTo("attributeName");
@@ -117,7 +167,7 @@ class RestrictTest {
 
     @Test
     void shouldCreateEndsWithRestriction() {
-        TextRestriction<String> restriction = Restrict.endsWith("suffix", "attributeName");
+        TextRestriction<Employee> restriction = Restrict.endsWith("suffix", "attributeName");
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.attribute()).isEqualTo("attributeName");
@@ -128,7 +178,7 @@ class RestrictTest {
 
     @Test
     void shouldCreateNegatedEndsWithRestriction() {
-        TextRestriction<String> restriction = Restrict.notEndsWith("suffix", "attributeName");
+        TextRestriction<Employee> restriction = Restrict.notEndsWith("suffix", "attributeName");
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.attribute()).isEqualTo("attributeName");
@@ -145,9 +195,22 @@ class RestrictTest {
     }
 
     @Test
+    void shouldSupplyEmptyRestrictionToRepositoryMethod() {
+        this.findByPosition("Software Engineer", Restrict.none());
+    }
+
+    @Test
     void shouldThrowExceptionForInvalidWildcard() {
         assertThatThrownBy(() -> Restrict.like("pattern_value", '_', '_', "attributeName"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Cannot use the same character (_) for both types of wildcards.");
+    }
+
+    @Test
+    void shouldThrowExceptionForNegatingEmptyRestriction() {
+        Restriction<Employee> unrestricted = Restrict.none();
+        assertThatThrownBy(() -> unrestricted.negate())
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage("Empty restriction cannot be negated.");
     }
 }

--- a/api/src/test/java/jakarta/data/metamodel/restrict/RestrictTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/RestrictTest.java
@@ -172,6 +172,23 @@ class RestrictTest {
     }
 
     @Test
+    void shouldCreateUnmatchableRestrictionWhenNegatingUnrestricted() {
+        Restriction<Employee> restriction = Restrict.unrestricted();
+        Restriction<Employee> negated = restriction.negate();
+
+        assertThat(negated).isInstanceOf(Unmatchable.class);
+
+        Unmatchable<Employee> unmatchable = (Unmatchable<Employee>) negated;
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(unmatchable.isNegated()).isEqualTo(false);
+            soft.assertThat(unmatchable.negate()).isEqualTo(restriction);
+            soft.assertThat(unmatchable.restrictions()).isEmpty();
+            soft.assertThat(unmatchable.type()).isEqualTo(CompositeRestriction.Type.ANY);
+        });
+    }
+
+    @Test
     void shouldCreateUnrestricted() {
         Restriction<Employee> restriction = Restrict.unrestricted();
 
@@ -204,13 +221,5 @@ class RestrictTest {
         assertThatThrownBy(() -> Restrict.like("pattern_value", '_', '_', "attributeName"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Cannot use the same character (_) for both types of wildcards.");
-    }
-
-    @Test
-    void shouldThrowExceptionForNegatingUnrestrictedRestriction() {
-        Restriction<Employee> unrestricted = Restrict.unrestricted();
-        assertThatThrownBy(() -> unrestricted.negate())
-                .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessage("The absence of restrictions cannot be negated.");
     }
 }


### PR DESCRIPTION
This came up during discussion of one of the other issues.
Given a repository method that allows Restrictions to be supplied at run time, such as,

```
@Find
List<Person> bornIn(int year, Restriction<Person> restrictions, Order<Person> order);
```

There is currently no way for a repository user to use the method when a case arises where they don't need to make any additional restrictions.

Currently, allowing for that possibility would require the repository to duplicate the method and omit the Restriction parameter,

```
@Find
List<Person> bornIn(int year, Order<Person> order);
```

One idea to avoid the need to duplicate repository methods is to allow an empty Restriction instance that indicates the decision to not apply any additional restrictions,

```
everyoneBornIn2000 = people.bornIn(2000, Restrict.none(), Order.by(_Person.ssn.asc()));
```

I'm not sure what a good name for it is. This PR calls it `Restrict.none()`, but open to better ideas for names.