### PR TITLE
implement toString to make Restrictions more readable

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/restrict/BasicRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/BasicRestrictionRecord.java
@@ -49,14 +49,19 @@ record BasicRestrictionRecord<T>(
      */
     @Override
     public String toString() {
-        StringBuilder s = new StringBuilder();
-        s.append(attribute).append(' ')
+        String valueString = value == null ? "null" : value.toString();
+        StringBuilder builder = new StringBuilder(
+                attribute.length() +
+                comparison.name().length() +
+                valueString.length() +
+                4); // number of additional characters that might be appended
+        builder.append(attribute).append(' ')
          .append(comparison.name()).append(' ');
         if (value instanceof CharSequence) {
-            s.append('"').append(value).append('"');
+            builder.append('"').append(valueString).append('"');
         } else {
-            s.append(value);
+            builder.append(valueString);
         }
-        return s.toString();
+        return builder.toString();
     }
 }

--- a/api/src/main/java/jakarta/data/metamodel/restrict/BasicRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/BasicRestrictionRecord.java
@@ -39,4 +39,24 @@ record BasicRestrictionRecord<T>(
                 comparison.negate(),
                 value);
     }
+
+    /**
+     * Textual representation of a basic restriction.
+     * For example,
+     * <pre>price LESS_THAN 50.0</pre>
+     *
+     * @return textual representation of a basic restriction.
+     */
+    @Override
+    public String toString() {
+        StringBuilder s = new StringBuilder();
+        s.append(attribute).append(' ')
+         .append(comparison.name()).append(' ');
+        if (value instanceof CharSequence) {
+            s.append('"').append(value).append('"');
+        } else {
+            s.append(value);
+        }
+        return s.toString();
+    }
 }

--- a/api/src/main/java/jakarta/data/metamodel/restrict/CompositeRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/CompositeRestrictionRecord.java
@@ -43,4 +43,31 @@ record CompositeRestrictionRecord<T>(
     public CompositeRestriction<T> negate() {
         return new CompositeRestrictionRecord<>(type, restrictions, !isNegated);
     }
+
+    /**
+     * Textual representation of a composite restriction.
+     * For example,
+     * <pre>ALL (price LESS_THAN 50.0, name LIKE "%Jakarta EE%")</pre>
+     *
+     * @return textual representation of a composite restriction.
+     */
+    @Override
+    public String toString() {
+        StringBuilder s = new StringBuilder(200);
+        if (isNegated) {
+            s.append("NOT ");
+        }
+        s.append(type.name()).append(" (");
+        boolean first = true;
+        for (Restriction<T> r : restrictions) {
+            if (first) {
+                first = false;
+            } else {
+                s.append(", ");
+            }
+            s.append(r);
+        }
+        s.append(')');
+        return s.toString();
+    }
 }

--- a/api/src/main/java/jakarta/data/metamodel/restrict/CompositeRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/CompositeRestrictionRecord.java
@@ -28,6 +28,11 @@ record CompositeRestrictionRecord<T>(
         List<Restriction<T>> restrictions,
         boolean isNegated) implements CompositeRestriction<T> {
 
+    /**
+     * Initial guess of length per restriction that is being combined.
+     */
+    private static final int SINGLE_RESTRICTION_LENGTH_ESTIMATE = 100;
+
     CompositeRestrictionRecord {
         if (restrictions == null || restrictions.isEmpty()) {
             throw new IllegalArgumentException(
@@ -53,21 +58,23 @@ record CompositeRestrictionRecord<T>(
      */
     @Override
     public String toString() {
-        StringBuilder s = new StringBuilder(200);
+        StringBuilder builder = new StringBuilder(
+                restrictions.size() * SINGLE_RESTRICTION_LENGTH_ESTIMATE +
+                7); // number of additional characters that might be appended
         if (isNegated) {
-            s.append("NOT ");
+            builder.append("NOT ");
         }
-        s.append(type.name()).append(" (");
+        builder.append(type.name()).append(" (");
         boolean first = true;
-        for (Restriction<T> r : restrictions) {
+        for (Restriction<T> restriction : restrictions) {
             if (first) {
                 first = false;
             } else {
-                s.append(", ");
+                builder.append(", ");
             }
-            s.append(r);
+            builder.append(restriction);
         }
-        s.append(')');
-        return s.toString();
+        builder.append(')');
+        return builder.toString();
     }
 }

--- a/api/src/main/java/jakarta/data/metamodel/restrict/TextRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/TextRestrictionRecord.java
@@ -67,21 +67,26 @@ record TextRestrictionRecord<T>(
      */
     @Override
     public String toString() {
-        StringBuilder s = new StringBuilder(50);
-        s.append(attribute).append(' ')
-         .append(comparison.name());
+        String valueString = value == null ? "null" : value;
+        StringBuilder builder = new StringBuilder(
+                attribute.length() +
+                comparison.name().length() +
+                valueString.length() +
+                24); // number of additional characters that might be appended
+        builder.append(attribute).append(' ')
+               .append(comparison.name());
         if (!isCaseSensitive) {
-            s.append("_IGNORE_CASE");
+            builder.append("_IGNORE_CASE");
         }
-        s.append(' ');
-        if (value instanceof CharSequence) {
-            s.append('"').append(value).append('"');
+        builder.append(' ');
+        if (value == null) {
+            builder.append(valueString);
         } else {
-            s.append(value);
+            builder.append('"').append(valueString).append('"');
         }
         if (isEscaped) {
-            s.append(" ESCAPED");
+            builder.append(" ESCAPED");
         }
-        return s.toString();
+        return builder.toString();
     }
 }

--- a/api/src/main/java/jakarta/data/metamodel/restrict/TextRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/TextRestrictionRecord.java
@@ -57,4 +57,31 @@ record TextRestrictionRecord<T>(
                 isEscaped,
                 value);
     }
+
+    /**
+     * Textual representation of a text restriction.
+     * For example,
+     * <pre>name LIKE_IGNORE_CASE "Jakarta EE %"</pre>
+     *
+     * @return textual representation of a text restriction.
+     */
+    @Override
+    public String toString() {
+        StringBuilder s = new StringBuilder(50);
+        s.append(attribute).append(' ')
+         .append(comparison.name());
+        if (!isCaseSensitive) {
+            s.append("_IGNORE_CASE");
+        }
+        s.append(' ');
+        if (value instanceof CharSequence) {
+            s.append('"').append(value).append('"');
+        } else {
+            s.append(value);
+        }
+        if (isEscaped) {
+            s.append(" ESCAPED");
+        }
+        return s.toString();
+    }
 }

--- a/api/src/main/java/jakarta/data/metamodel/restrict/Unmatchable.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/Unmatchable.java
@@ -42,6 +42,16 @@ class Unmatchable<T> implements CompositeRestriction<T> {
         return List.of();
     }
 
+    /**
+     * Textual representation of the unmatchable restriction.
+     *
+     * @return textual representation of the unmatchable restriction.
+     */
+    @Override
+    public String toString() {
+        return "UNMATCHABLE";
+    }
+
     @Override
     public Type type() {
         return Type.ANY;

--- a/api/src/main/java/jakarta/data/metamodel/restrict/Unrestricted.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/Unrestricted.java
@@ -42,6 +42,16 @@ class Unrestricted<T> implements CompositeRestriction<T> {
         return List.of();
     }
 
+    /**
+     * Textual representation of the unrestricted restriction.
+     *
+     * @return textual representation of the unrestricted restriction.
+     */
+    @Override
+    public String toString() {
+        return "UNRESTRICTED";
+    }
+
     @Override
     public Type type() {
         return Type.ALL;

--- a/api/src/test/java/jakarta/data/metamodel/restrict/BasicRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/BasicRestrictionRecordTest.java
@@ -109,6 +109,16 @@ class BasicRestrictionRecordTest {
     }
 
     @Test
+    void shouldOutputToString() {
+        Restriction<Book> restriction = Restrict.greaterThan(100, "numPages");
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(restriction.toString())
+                .isEqualTo("numPages GREATER_THAN 100");
+        });
+    }
+
+    @Test
     void shouldSupportNegatedRestrictionUsingDefaultConstructor() {
         BasicRestriction<Book> negatedRestriction =
                 (BasicRestriction<Book>) Restrict.<Book>notEqualTo((Object) "Unknown", "author");

--- a/api/src/test/java/jakarta/data/metamodel/restrict/CompositeRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/CompositeRestrictionRecordTest.java
@@ -21,6 +21,8 @@ package jakarta.data.metamodel.restrict;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 
+import jakarta.data.metamodel.restrict.BasicRestrictionRecordTest.Book;
+
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import java.util.List;
@@ -108,6 +110,27 @@ class CompositeRestrictionRecordTest {
             soft.assertThat(anyNegated.isNegated()).isEqualTo(true);
 
             soft.assertThat(anyNotNegated.isNegated()).isEqualTo(false);
+        });
+    }
+
+    @Test
+    void shouldOutputToString() {
+        Restriction<Person> namedJackKarta = Restrict
+                .all(Restrict.equalTo("Jack", "firstName"),
+                     Restrict.equalTo("Karta", "lastName"));
+
+        Restriction<Person> minorOrMissingAge = Restrict
+                .any(Restrict.lessThan(18, "age"),
+                     Restrict.equalTo(null, "name"));
+        Restriction<Person> notMinorOrMissingAge = minorOrMissingAge.negate();
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(namedJackKarta.toString()).isEqualTo("""
+                    ALL (firstName EQUAL "Jack", lastName EQUAL "Karta")\
+                    """);
+            soft.assertThat(notMinorOrMissingAge.toString()).isEqualTo("""
+                    NOT ANY (age LESS_THAN 18, name EQUAL null)\
+                    """);
         });
     }
 

--- a/api/src/test/java/jakarta/data/metamodel/restrict/CompositeRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/CompositeRestrictionRecordTest.java
@@ -119,16 +119,16 @@ class CompositeRestrictionRecordTest {
                 .all(Restrict.equalTo("Jack", "firstName"),
                      Restrict.equalTo("Karta", "lastName"));
 
-        Restriction<Person> minorOrMissingAge = Restrict
+        Restriction<Person> minorOrMissingName = Restrict
                 .any(Restrict.lessThan(18, "age"),
                      Restrict.equalTo(null, "name"));
-        Restriction<Person> notMinorOrMissingAge = minorOrMissingAge.negate();
+        Restriction<Person> notMinorOrMissingName = minorOrMissingName.negate();
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(namedJackKarta.toString()).isEqualTo("""
                     ALL (firstName EQUAL "Jack", lastName EQUAL "Karta")\
                     """);
-            soft.assertThat(notMinorOrMissingAge.toString()).isEqualTo("""
+            soft.assertThat(notMinorOrMissingName.toString()).isEqualTo("""
                     NOT ANY (age LESS_THAN 18, name EQUAL null)\
                     """);
         });

--- a/api/src/test/java/jakarta/data/metamodel/restrict/TextRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/TextRestrictionRecordTest.java
@@ -141,6 +141,23 @@ class TextRestrictionRecordTest {
     }
 
     @Test
+    void shouldOutputToString() {
+        TextRestriction<Book> titleRestriction =
+                Restrict.contains("Jakarta Data", "title");
+        TextRestriction<Book> authorRestriction =
+                Restrict.<Book>equalTo("Myself", "author").ignoreCase().negate();
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(titleRestriction.toString()).isEqualTo("""
+                    title LIKE "%Jakarta Data%" ESCAPED\
+                    """);
+            soft.assertThat(authorRestriction.toString()).isEqualTo("""
+                    author NOT_EQUAL_IGNORE_CASE "Myself"\
+                    """);
+        });
+    }
+
+    @Test
     void shouldSupportNegationForTextRestriction() {
         TextRestrictionRecord<String> restriction = new TextRestrictionRecord<>(
                 "author",


### PR DESCRIPTION
Adds implementation of toString on the built-in Restrictions to display in a concise way that is meaningful.

For example,
`name LIKE "Jakarta EE %"`
Or,
`ALL (price GREATER_THAN_EQUAL 50, price LESS_THAN 100)`