### PR TITLE
Fix documentation about NoSQL database behavior.

### DIFF
--- a/api/src/main/java/jakarta/data/page/Page.java
+++ b/api/src/main/java/jakarta/data/page/Page.java
@@ -163,8 +163,16 @@ public interface Page<T> extends Iterable<T> {
      * Returns the total number of pages of query results, if the {@link #pageRequest()}
      * specified that {@linkplain PageRequest#requestTotal the total should be retrieved
      * from the database}.
+     *
+     * <p><strong>Note for NoSQL databases:</strong> The ability to determine the total number of pages
+     * is dependent on support for total element queries in the database. Key-Value and Wide-Column
+     * databases generally do not support this feature. For Graph and Document databases, support may vary
+     * by provider. If the total page count cannot be determined, calling this method will result in an
+     * {@link UnsupportedOperationException}.</p>
+     *
      * @return the total number of pages.
      * @throws IllegalStateException if the total was not retrieved from the database.
+     * @throws UnsupportedOperationException if the database does not support total page count queries.
      */
     long totalPages();
 }

--- a/api/src/main/java/jakarta/data/page/Page.java
+++ b/api/src/main/java/jakarta/data/page/Page.java
@@ -146,8 +146,16 @@ public interface Page<T> extends Iterable<T> {
      * Returns the total number of elements across all pages of query results, if the
      * {@link #pageRequest()} specified that {@linkplain PageRequest#requestTotal the
      * total should be retrieved from the database}.
+     *
+     * <p><strong>Note for NoSQL databases:</strong> Not all NoSQL databases support counting the total
+     * number of elements. This operation is <strong>not supported</strong> for Key-Value and Wide-Column databases.
+     * For Graph and Document databases, support for this operation may vary depending on the provider.
+     * If the database does not support retrieving the total number of elements, calling this method will
+     * result in an {@link UnsupportedOperationException}.</p>
+     *
      * @return the total number of elements across all pages.
      * @throws IllegalStateException if the total was not retrieved from the database.
+     * @throws UnsupportedOperationException if the database does not support total element queries.
      */
     long totalElements();
 

--- a/api/src/main/java/jakarta/data/repository/Query.java
+++ b/api/src/main/java/jakarta/data/repository/Query.java
@@ -44,6 +44,17 @@ import java.lang.annotation.Target;
  *     The value might not be precise on databases that provide eventual consistency.</li>
  * </ul>
  *
+ * <p><strong>Note on NoSQL Databases:</strong></p>
+ * <p>Update and delete operations in NoSQL databases may not support returning {@code int} or {@code long}
+ * due to their eventual consistency model. Unlike traditional ACID-compliant relational databases,
+ * many NoSQL databases do not guarantee immediate consistency across distributed nodes. As a result,
+ * the number of affected entities might not be accurately reported.</p>
+ *
+ * <p>This limitation is not tied to a specific type of NoSQL database but applies across Key-Value,
+ * Wide-Column, Document, and Graph databases. When a NoSQL provider does not support returning
+ * {@code int} or {@code long} for these operations, invoking such a method will result in an
+ * {@link UnsupportedOperationException}.</p>
+ *
  * <p>Compared to SQL, JDQL allows an abbreviated syntax for {@code select} statements:</p>
  * <ul>
  * <li>The {@code from} clause is optional in JDQL. When it is missing, the queried entity is determined by the return


### PR DESCRIPTION
It fixes: [NoSQL databases need to be allowed to raise errors for function that the database type is not capable o](https://github.com/jakartaee/data/issues/782)


## Changes

Fixes:


- [ ] [TCK cannot require totalElements and totalPages of some NoSQL databases](https://github.com/jakartaee/data/pull/804) - Otavio needs to clarify which types of NoSQL databases can support counts and which cannot.
- [ ] Per #828 document that UnsupportedOperationException can be raised on Delete methods that return an update count when a non-relational database relies on eventual consistency and is incapable of knowing the count of deleted entities.