### PR TITLE
TCK tests of record result types where record component names match the entity attributes

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023,2025 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -15,6 +15,8 @@
  */
 package ee.jakarta.tck.data.framework.read.only;
 
+import static jakarta.data.repository.By.ID;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -26,9 +28,11 @@ import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import jakarta.data.repository.BasicRepository;
+import jakarta.data.repository.By;
+import jakarta.data.repository.Find;
+import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
-
 import ee.jakarta.tck.data.framework.read.only.NaturalNumber.NumberType;
 
 /**
@@ -72,6 +76,26 @@ public interface NaturalNumbers extends BasicRepository<NaturalNumber, Long>, Id
                                                                        long maxSqrtFloor,
                                                                        PageRequest pagination,
                                                                        Sort<NaturalNumber> sort);
+
+    @Find
+    NumberInfo infoByIdentifier(@By(_NaturalNumber.ID) long id);
+
+    @Find
+    NumberInfo[] infoByNumBitsNeeded(@By(_NaturalNumber.NUMBITSREQUIRED) Short bits);
+
+    @Find
+    Stream<NumberInfo> infoByOddness(@By(_NaturalNumber.IS_ODD) boolean isOdd);
+
+    @Find
+    List<NumberInfo> infoByParity(@By(_NaturalNumber.IS_ODD) boolean isOdd);
+
+    @Find
+    Optional<NumberInfo> infoIfFound(@By(ID) long id);
+
+    @Find
+    @OrderBy(ID)
+    Page<NumberInfo> infoPaginated(@By(_NaturalNumber.IS_ODD) boolean isOdd,
+                                   PageRequest pageReq);
 
     @Query("SELECT id WHERE isOdd = true AND id BETWEEN 21 AND ?1 ORDER BY id ASC")
     Page<Long> oddsFrom21To(long max, PageRequest pageRequest);

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NumberInfo.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NumberInfo.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.framework.read.only;
+
+import ee.jakarta.tck.data.framework.read.only.NaturalNumber.NumberType;
+
+/**
+ * A record that contains a subset of the attributes of the NaturalNumber entity.
+ * where the record component names are an exact match of the entity attribute names.
+ */
+public record NumberInfo(
+        long id,
+        boolean isOdd,
+        Short numBitsRequired,
+        NumberType numType) {
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/_NaturalNumber.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/_NaturalNumber.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.framework.read.only;
+
+import jakarta.data.metamodel.Attribute;
+import jakarta.data.metamodel.SortableAttribute;
+import jakarta.data.metamodel.StaticMetamodel;
+import jakarta.data.metamodel.impl.AttributeRecord;
+import jakarta.data.metamodel.impl.SortableAttributeRecord;
+
+/**
+ * Static metamodel class for the NaturalNumber entity.
+ */
+@StaticMetamodel(NaturalNumber.class)
+public interface _NaturalNumber {
+    String FLOOROFSQUAREROOT = "floorOfSquareRoot";
+    String ID = "id";
+    String IS_ODD = "isOdd";
+    String NUMBITSREQUIRED = "numBitsRequired";
+    String NUMTYPE = "numType";
+    String NUMTYPEORDINAL = "numTypeOrdinal";
+
+    SortableAttribute<NaturalNumber> floorOfSquareRoot = new SortableAttributeRecord<>(FLOOROFSQUAREROOT);
+    SortableAttribute<NaturalNumber> id = new SortableAttributeRecord<>(ID);
+    SortableAttribute<NaturalNumber> isOdd = new SortableAttributeRecord<>(IS_ODD);
+    SortableAttribute<NaturalNumber> numBitsRequired = new SortableAttributeRecord<>(NUMBITSREQUIRED);
+    Attribute<NaturalNumber> numType = new AttributeRecord<>(NUMTYPE);
+    SortableAttribute<NaturalNumber> numTypeOrdinal = new SortableAttributeRecord<>(NUMTYPEORDINAL);
+}


### PR DESCRIPTION
Add test scenarios for various return types with a Java record where the record component names match entity attribute names and are used to request the retrieval of a subset of entity attributes.

This does not cover any scenarios that require the annotation to identify the entity attribute name(s). Separate PRs will be needed for those scenarios.