### PR TITLE
address review comment to format Restriction toString more like JDQL

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/restrict/BasicRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/BasicRestrictionRecord.java
@@ -43,20 +43,21 @@ record BasicRestrictionRecord<T>(
     /**
      * Textual representation of a basic restriction.
      * For example,
-     * <pre>price LESS_THAN 50.0</pre>
+     * <pre>price < 50.0</pre>
      *
      * @return textual representation of a basic restriction.
      */
     @Override
     public String toString() {
+        String comparisonString = comparison.asQueryLanguage();
         String valueString = value == null ? "null" : value.toString();
         StringBuilder builder = new StringBuilder(
                 attribute.length() +
-                comparison.name().length() +
+                comparisonString.length() +
                 valueString.length() +
                 4); // number of additional characters that might be appended
         builder.append(attribute).append(' ')
-         .append(comparison.name()).append(' ');
+               .append(comparisonString).append(' ');
         if (value instanceof CharSequence) {
             builder.append('"').append(valueString).append('"');
         } else {

--- a/api/src/main/java/jakarta/data/metamodel/restrict/CompositeRestriction.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/CompositeRestriction.java
@@ -30,17 +30,8 @@ public interface CompositeRestriction<T> extends Restriction<T> {
     Type type();
 
     enum Type {
-        ALL("AND"),
-        ANY("OR");
-
-        /**
-         * Representation of the corresponding logical operator in query language.
-         */
-        private final String qlLogicalOperator;
-
-        private Type(String qlLogicalOperator) {
-            this.qlLogicalOperator = qlLogicalOperator;
-        }
+        ALL,
+        ANY;
 
         /**
          * Representation of the composite restriction type as a query language
@@ -50,7 +41,10 @@ public interface CompositeRestriction<T> extends Restriction<T> {
          * @return the representation as a logical operator in query language.
          */
         String asQueryLanguage() {
-            return qlLogicalOperator;
+            return switch (this) {
+                case ALL -> "AND";
+                case ANY -> "OR";
+            };
         }
     }
 }

--- a/api/src/main/java/jakarta/data/metamodel/restrict/CompositeRestriction.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/CompositeRestriction.java
@@ -30,7 +30,27 @@ public interface CompositeRestriction<T> extends Restriction<T> {
     Type type();
 
     enum Type {
-        ALL,
-        ANY
+        ALL("AND"),
+        ANY("OR");
+
+        /**
+         * Representation of the corresponding logical operator in query language.
+         */
+        private final String qlLogicalOperator;
+
+        private Type(String qlLogicalOperator) {
+            this.qlLogicalOperator = qlLogicalOperator;
+        }
+
+        /**
+         * Representation of the composite restriction type as a query language
+         * logical operator.
+         * For example, {@link #ALL} is represented as {@code AND} in query language.
+         *
+         * @return the representation as a logical operator in query language.
+         */
+        String asQueryLanguage() {
+            return qlLogicalOperator;
+        }
     }
 }

--- a/api/src/main/java/jakarta/data/metamodel/restrict/CompositeRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/CompositeRestrictionRecord.java
@@ -52,29 +52,33 @@ record CompositeRestrictionRecord<T>(
     /**
      * Textual representation of a composite restriction.
      * For example,
-     * <pre>ALL (price LESS_THAN 50.0, name LIKE "%Jakarta EE%")</pre>
+     * <pre>(price < 50.0) AND (name LIKE "%Jakarta EE%")</pre>
      *
      * @return textual representation of a composite restriction.
      */
     @Override
     public String toString() {
+        String logicalOperator = type.asQueryLanguage();
         StringBuilder builder = new StringBuilder(
                 restrictions.size() * SINGLE_RESTRICTION_LENGTH_ESTIMATE +
-                7); // number of additional characters that might be appended
+                6); // number of additional characters that might be appended
         if (isNegated) {
-            builder.append("NOT ");
+            builder.append("NOT (");
         }
-        builder.append(type.name()).append(" (");
+
         boolean first = true;
         for (Restriction<T> restriction : restrictions) {
             if (first) {
                 first = false;
             } else {
-                builder.append(", ");
+                builder.append(' ').append(logicalOperator).append(' ');
             }
-            builder.append(restriction);
+            builder.append('(').append(restriction).append(')');
         }
-        builder.append(')');
+
+        if (isNegated) {
+            builder.append(')');
+        }
         return builder.toString();
     }
 }

--- a/api/src/main/java/jakarta/data/metamodel/restrict/Operator.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/Operator.java
@@ -18,16 +18,16 @@
 package jakarta.data.metamodel.restrict;
 
 public enum Operator {
-    EQUAL("="),
-    GREATER_THAN(">"),
-    GREATER_THAN_EQUAL(">="),
-    IN("IN"),
-    LESS_THAN("<"),
-    LESS_THAN_EQUAL("<="),
-    LIKE("LIKE"),
-    NOT_EQUAL("<>"),
-    NOT_IN("NOT IN"),
-    NOT_LIKE("NOT LIKE");
+    EQUAL,
+    GREATER_THAN,
+    GREATER_THAN_EQUAL,
+    IN,
+    LESS_THAN,
+    LESS_THAN_EQUAL,
+    LIKE,
+    NOT_EQUAL,
+    NOT_IN,
+    NOT_LIKE;
 
     /**
      * Representation of the operator in query language.

--- a/api/src/main/java/jakarta/data/metamodel/restrict/Operator.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/Operator.java
@@ -18,16 +18,36 @@
 package jakarta.data.metamodel.restrict;
 
 public enum Operator {
-    EQUAL,
-    GREATER_THAN,
-    GREATER_THAN_EQUAL,
-    IN,
-    LESS_THAN,
-    LESS_THAN_EQUAL,
-    LIKE,
-    NOT_EQUAL,
-    NOT_IN,
-    NOT_LIKE;
+    EQUAL("="),
+    GREATER_THAN(">"),
+    GREATER_THAN_EQUAL(">="),
+    IN("IN"),
+    LESS_THAN("<"),
+    LESS_THAN_EQUAL("<="),
+    LIKE("LIKE"),
+    NOT_EQUAL("<>"),
+    NOT_IN("NOT IN"),
+    NOT_LIKE("NOT LIKE");
+
+    /**
+     * Representation of the operator in query language.
+     */
+    private final String qlRepresentation;
+
+    private Operator(String qlRepresentation) {
+        this.qlRepresentation = qlRepresentation;
+    }
+
+    /**
+     * Representation of the operator as it appears in query language.
+     * For example, {@link #GREATER_THAN} is represented as {@code >}
+     * in query langugae.
+     *
+     * @return the representation of the operator in query language.
+     */
+    String asQueryLanguage() {
+        return qlRepresentation;
+    }
 
     /**
      * Returns the operator that is the negation of this operator.

--- a/api/src/main/java/jakarta/data/metamodel/restrict/Operator.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/Operator.java
@@ -30,15 +30,6 @@ public enum Operator {
     NOT_LIKE;
 
     /**
-     * Representation of the operator in query language.
-     */
-    private final String qlRepresentation;
-
-    private Operator(String qlRepresentation) {
-        this.qlRepresentation = qlRepresentation;
-    }
-
-    /**
      * Representation of the operator as it appears in query language.
      * For example, {@link #GREATER_THAN} is represented as {@code >}
      * in query langugae.
@@ -46,7 +37,18 @@ public enum Operator {
      * @return the representation of the operator in query language.
      */
     String asQueryLanguage() {
-        return qlRepresentation;
+        return switch (this) {
+            case EQUAL -> "=";
+            case GREATER_THAN -> ">";
+            case GREATER_THAN_EQUAL -> ">=";
+            case IN -> "IN";
+            case LESS_THAN -> "<";
+            case LESS_THAN_EQUAL -> "<=";
+            case LIKE -> "LIKE";
+            case NOT_EQUAL -> "<>";
+            case NOT_IN -> "NOT IN";
+            case NOT_LIKE -> "NOT LIKE";
+        };
     }
 
     /**

--- a/api/src/main/java/jakarta/data/metamodel/restrict/TextRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/TextRestrictionRecord.java
@@ -61,24 +61,21 @@ record TextRestrictionRecord<T>(
     /**
      * Textual representation of a text restriction.
      * For example,
-     * <pre>name LIKE_IGNORE_CASE "Jakarta EE %"</pre>
+     * <pre>name LIKE "Jakarta EE %" IGNORE_CASE</pre>
      *
      * @return textual representation of a text restriction.
      */
     @Override
     public String toString() {
+        String comparisonString = comparison.asQueryLanguage();
         String valueString = value == null ? "null" : value;
         StringBuilder builder = new StringBuilder(
                 attribute.length() +
-                comparison.name().length() +
+                comparisonString.length() +
                 valueString.length() +
                 24); // number of additional characters that might be appended
         builder.append(attribute).append(' ')
-               .append(comparison.name());
-        if (!isCaseSensitive) {
-            builder.append("_IGNORE_CASE");
-        }
-        builder.append(' ');
+               .append(comparisonString).append(' ');
         if (value == null) {
             builder.append(valueString);
         } else {
@@ -86,6 +83,9 @@ record TextRestrictionRecord<T>(
         }
         if (isEscaped) {
             builder.append(" ESCAPED");
+        }
+        if (!isCaseSensitive) {
+            builder.append(" IGNORE_CASE");
         }
         return builder.toString();
     }

--- a/api/src/main/resources/rules.xml
+++ b/api/src/main/resources/rules.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2024 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
   ~
   ~ SPDX-License-Identifier: Apache-2.0
   -->
-<ruleset name="Jakrata Data"
+<ruleset name="Jakarta Data"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">

--- a/api/src/main/resources/rules.xml
+++ b/api/src/main/resources/rules.xml
@@ -27,6 +27,12 @@
         <exclude name="AbstractClassWithoutAbstractMethod"/>
     </rule>
     <rule ref="category/java/security.xml"/>
-    <rule ref="category/java/performance.xml"/>
+    <rule ref="category/java/performance.xml">
+        <!-- Sure, a switch with only 2 options might be inefficient, but that
+             isn't the point. I want switch instead of if/else to enforce that if
+             someone ever adds another enum constant, the switch will cause a
+             compile error, forcing them to implement the needed handling of it. -->
+        <exclude name="TooFewBranchesForSwitch"/>
+    </rule>
 
 </ruleset>

--- a/api/src/test/java/jakarta/data/metamodel/restrict/BasicRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/BasicRestrictionRecordTest.java
@@ -114,7 +114,7 @@ class BasicRestrictionRecordTest {
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.toString())
-                .isEqualTo("numPages GREATER_THAN 100");
+                .isEqualTo("numPages > 100");
         });
     }
 

--- a/api/src/test/java/jakarta/data/metamodel/restrict/CompositeRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/CompositeRestrictionRecordTest.java
@@ -126,10 +126,10 @@ class CompositeRestrictionRecordTest {
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(namedJackKarta.toString()).isEqualTo("""
-                    ALL (firstName EQUAL "Jack", lastName EQUAL "Karta")\
+                    (firstName = "Jack") AND (lastName = "Karta")\
                     """);
             soft.assertThat(notMinorOrMissingName.toString()).isEqualTo("""
-                    NOT ANY (age LESS_THAN 18, name EQUAL null)\
+                    NOT ((age < 18) OR (name = null))\
                     """);
         });
     }

--- a/api/src/test/java/jakarta/data/metamodel/restrict/TextRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/TextRestrictionRecordTest.java
@@ -152,7 +152,7 @@ class TextRestrictionRecordTest {
                     title LIKE "%Jakarta Data%" ESCAPED\
                     """);
             soft.assertThat(authorRestriction.toString()).isEqualTo("""
-                    author NOT_EQUAL_IGNORE_CASE "Myself"\
+                    author <> "Myself" IGNORE_CASE\
                     """);
         });
     }


### PR DESCRIPTION
Address this review comment from #962

              > `ALL (price GREATER_THAN_EQUAL 50, price LESS_THAN 100)`

Why not align the `toString()`s with the equivalent JDQL, so:

```hql
(price >= 50 AND price < 100)
```

_Originally posted by @gavinking in https://github.com/jakartaee/data/issues/962#issuecomment-2640902362_
