### PR TITLE
Allow NoSQL to defer request for totals and raise UnsupportedOperationException later

### DIFF
--- a/api/src/main/java/jakarta/data/page/PageRequest.java
+++ b/api/src/main/java/jakarta/data/page/PageRequest.java
@@ -219,11 +219,18 @@ public interface PageRequest {
     int size();
 
     /**
-     * Indicates that a query method which returns a {@link Page}
+     * <p>Indicates that a query method which returns a {@link Page}
      * should retrieve the {@linkplain Page#totalElements() total
      * number of elements} available across all pages. This behavior
      * is enabled by default. To obtain a page request with total
-     * retrieval disabled, call {@link #withoutTotal()}.
+     * retrieval disabled, call {@link #withoutTotal()}.</p>
+     *
+     * <p>The total can be requested from the database before returning
+     * the page, or the request for the total can be deferred until the
+     * {@link Page#totalElements()} or {@link Page#totalPages()} method
+     * is invoked, which can result in an exception being raised if the
+     * request fails or the database is incapable of it.</p>
+     *
      * @return {@code true} if the total number of elements should
      *         be retrieved from the database.
      */

--- a/api/src/main/java/jakarta/data/page/PageRequest.java
+++ b/api/src/main/java/jakarta/data/page/PageRequest.java
@@ -225,11 +225,14 @@ public interface PageRequest {
      * is enabled by default. To obtain a page request with total
      * retrieval disabled, call {@link #withoutTotal()}.</p>
      *
-     * <p>The total can be requested from the database before returning
-     * the page, or the request for the total can be deferred until the
-     * {@link Page#totalElements()} or {@link Page#totalPages()} method
-     * is invoked, which can result in an exception being raised if the
-     * request fails or the database is incapable of it.</p>
+     * <p>A repository implementation might obtain a total from the 
+     * database before returning the page of results, or might defer 
+     * fetching the total until {@link Page#totalElements()} or 
+     * {@link Page#totalPages()} method is invoked. In the case of
+     * deferred fetching, the call to {@code totalElements()} or
+     * {@code totalPages()} raises an exception if the database
+     * request fails or if the database is incapable of computing
+     * totals.</p>
      *
      * @return {@code true} if the total number of elements should
      *         be retrieved from the database.


### PR DESCRIPTION
Accommodate NoSQL databases that are incapable of page totals by clarifying that the request for totals can be deferred until they are asked for, and prepare the user for the possibility of an exception to be raised at that time rather than immediately upon supplying the PageRequest with requestTotals to a repository method.

This goes along with Otavio's #963 where we are trying to figure out a compatible way for NoSQL databases that aren't capable of retrieving totals to be usable for PageRequest instances that by default do not set withoutTotals.