### PR TITLE
fix up treatment of null restrictions

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/BasicAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/BasicAttribute.java
@@ -36,8 +36,7 @@ public interface BasicAttribute<T,V> extends Attribute<T> {
     }
 
     default Restriction<T> isNull() {
-        //TODO: fix this "= NULL" is not the same thing as "IS NULL" in JDQL
-        return Restrict.equalTo(null, name());
+        return Restrict.isNull(name());
     }
 
     default Restriction<T> notEqualTo(V value) {
@@ -52,8 +51,7 @@ public interface BasicAttribute<T,V> extends Attribute<T> {
     }
 
     default Restriction<T> notNull() {
-        //TODO: fix this "<> NULL" is not the same thing as "IS NOT NULL" in JDQL
-        return Restrict.notEqualTo(null, name());
+        return Restrict.isNotNull(name());
     }
 
 }

--- a/api/src/main/java/jakarta/data/metamodel/BasicAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/BasicAttribute.java
@@ -51,7 +51,7 @@ public interface BasicAttribute<T,V> extends Attribute<T> {
     }
 
     default Restriction<T> notNull() {
-        return Restrict.isNotNull(name());
+        return Restrict.notNull(name());
     }
 
 }

--- a/api/src/main/java/jakarta/data/metamodel/TextAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/TextAttribute.java
@@ -50,22 +50,27 @@ public interface TextAttribute<T> extends ComparableAttribute<T,String> {
         return Restrict.endsWith(suffix, name());
     }
 
+    @Override
     default TextRestriction<T> equalTo(String value) {
         return Restrict.equalTo(value, name());
     }
 
+    @Override
     default TextRestriction<T> greaterThan(String value) {
         return Restrict.greaterThan(value, name());
     }
 
+    @Override
     default TextRestriction<T> greaterThanEqual(String value) {
         return Restrict.greaterThanEqual(value, name());
     }
 
+    @Override
     default TextRestriction<T> lessThan(String value) {
         return Restrict.lessThan(value, name());
     }
 
+    @Override
     default TextRestriction<T> lessThanEqual(String value) {
         return Restrict.lessThanEqual(value, name());
     }
@@ -93,6 +98,7 @@ public interface TextAttribute<T> extends ComparableAttribute<T,String> {
         return Restrict.notEndsWith(suffix, name());
     }
 
+    @Override
     default TextRestriction<T> notEqualTo(String value) {
         return Restrict.notEqualTo(value, name());
     }

--- a/api/src/main/java/jakarta/data/metamodel/restrict/BasicRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/BasicRestrictionRecord.java
@@ -30,6 +30,7 @@ record BasicRestrictionRecord<T>(
 
     BasicRestrictionRecord {
         Objects.requireNonNull(attribute, "Attribute must not be null");
+        Objects.requireNonNull(value, "Value must not be null");
     }
 
     @Override
@@ -49,7 +50,7 @@ record BasicRestrictionRecord<T>(
      */
     @Override
     public String toString() {
-        String valueString = value == null ? "null" : value.toString();
+        String valueString = value.toString();
         StringBuilder builder = new StringBuilder(
                 attribute.length() +
                 comparison.name().length() +

--- a/api/src/main/java/jakarta/data/metamodel/restrict/Restrict.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/Restrict.java
@@ -79,6 +79,10 @@ public class Restrict {
         return new TextRestrictionRecord<>(attribute, Operator.EQUAL, value);
     }
 
+    public static <T> UnaryRestriction<T> isNull(String attribute) {
+        return new UnaryRestrictionRecord<>(attribute, UnaryOperator.IS_NULL);
+    }
+
     public static <T, V extends Comparable<V>> Restriction<T> greaterThan(V value, String attribute) {
         return new BasicRestrictionRecord<>(attribute, Operator.GREATER_THAN, value);
     }
@@ -144,6 +148,10 @@ public class Restrict {
 
     public static <T> TextRestriction<T> notEqualTo(String value, String attribute) {
         return new TextRestrictionRecord<>(attribute, Operator.NOT_EQUAL, value);
+    }
+
+    public static <T> UnaryRestriction<T> isNotNull(String attribute) {
+        return new UnaryRestrictionRecord<>(attribute, UnaryOperator.IS_NOT_NULL);
     }
 
     public static <T> TextRestriction<T> notContains(String substring, String attribute) {

--- a/api/src/main/java/jakarta/data/metamodel/restrict/Restrict.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/Restrict.java
@@ -150,7 +150,7 @@ public class Restrict {
         return new TextRestrictionRecord<>(attribute, Operator.NOT_EQUAL, value);
     }
 
-    public static <T> UnaryRestriction<T> isNotNull(String attribute) {
+    public static <T> UnaryRestriction<T> notNull(String attribute) {
         return new UnaryRestrictionRecord<>(attribute, UnaryOperator.IS_NOT_NULL);
     }
 

--- a/api/src/main/java/jakarta/data/metamodel/restrict/UnaryOperator.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/UnaryOperator.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2023,2025 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data.metamodel.restrict;
+
+public enum UnaryOperator {
+    IS_NULL, IS_NOT_NULL;
+
+    UnaryOperator negate() {
+        return this == IS_NULL ? IS_NOT_NULL : IS_NULL;
+    }
+}

--- a/api/src/main/java/jakarta/data/metamodel/restrict/UnaryOperator.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/UnaryOperator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023,2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/data/metamodel/restrict/UnaryRestriction.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/UnaryRestriction.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023,2025 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data.metamodel.restrict;
+
+public interface UnaryRestriction<T> extends Restriction<T> {
+    String attribute();
+
+    UnaryOperator operator();
+
+    @Override
+    UnaryRestriction<T> negate();
+}

--- a/api/src/main/java/jakarta/data/metamodel/restrict/UnaryRestriction.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/UnaryRestriction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023,2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/data/metamodel/restrict/UnaryRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/UnaryRestrictionRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023,2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/data/metamodel/restrict/UnaryRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/UnaryRestrictionRecord.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023,2025 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data.metamodel.restrict;
+
+public record UnaryRestrictionRecord<T>(String attribute, UnaryOperator operator)
+        implements UnaryRestriction<T> {
+    @Override
+    public UnaryRestriction<T> negate() {
+        return new UnaryRestrictionRecord<>(attribute, operator.negate());
+    }
+
+    @Override
+    public String toString() {
+        return attribute + " " + operator;
+    }
+}

--- a/api/src/test/java/jakarta/data/metamodel/AttributeTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/AttributeTest.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.Test;
 import jakarta.data.metamodel.restrict.BasicRestriction;
 import jakarta.data.metamodel.restrict.Operator;
 import jakarta.data.metamodel.restrict.Restriction;
+import jakarta.data.metamodel.restrict.UnaryOperator;
+import jakarta.data.metamodel.restrict.UnaryRestriction;
 
 import java.util.Set;
 
@@ -102,11 +104,10 @@ class AttributeTest {
         Restriction<String> restriction = testAttribute.isNull();
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
-            BasicRestriction<String> basic = (BasicRestriction<String>) restriction;
+            soft.assertThat(restriction).isInstanceOf(UnaryRestriction.class);
+            UnaryRestriction<String> basic = (UnaryRestriction<String>) restriction;
             soft.assertThat(basic.attribute()).isEqualTo("testAttribute");
-            soft.assertThat(basic.value()).isNull();
-            soft.assertThat(basic.comparison()).isEqualTo(Operator.EQUAL);
+            soft.assertThat(basic.operator()).isEqualTo(UnaryOperator.IS_NULL);
         });
     }
 
@@ -115,11 +116,10 @@ class AttributeTest {
         Restriction<String> restriction = testAttribute.notNull();
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
-            BasicRestriction<String> basic = (BasicRestriction<String>) restriction;
+            soft.assertThat(restriction).isInstanceOf(UnaryRestriction.class);
+            UnaryRestriction<String> basic = (UnaryRestriction<String>) restriction;
             soft.assertThat(basic.attribute()).isEqualTo("testAttribute");
-            soft.assertThat(basic.value()).isNull();
-            soft.assertThat(basic.comparison()).isEqualTo(Operator.NOT_EQUAL);
+            soft.assertThat(basic.operator()).isEqualTo(UnaryOperator.IS_NOT_NULL);
         });
     }
 }

--- a/api/src/test/java/jakarta/data/metamodel/restrict/BasicRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/BasicRestrictionRecordTest.java
@@ -53,18 +53,6 @@ class BasicRestrictionRecordTest {
     }
 
     @Test
-    void shouldCreateBasicRestrictionWithNullValue() {
-        // Create a restriction with a null value
-        BasicRestrictionRecord<String> restriction = new BasicRestrictionRecord<>("title", Operator.EQUAL, null);
-
-        SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("title");
-            soft.assertThat(restriction.comparison()).isEqualTo(Operator.EQUAL);
-            soft.assertThat(restriction.value()).isNull();
-        });
-    }
-
-    @Test
     void shouldNegateLTERestriction() {
         Restriction<Book> numChaptersLTE10 = Restrict.lessThanEqual(10, "numChapters");
         BasicRestriction<Book> numChaptersLTE10Basic = (BasicRestriction<Book>) numChaptersLTE10;
@@ -135,5 +123,12 @@ class BasicRestrictionRecordTest {
         assertThatThrownBy(() -> new BasicRestrictionRecord<>(null, Operator.EQUAL, "testValue"))
                 .isInstanceOf(NullPointerException.class)
                 .hasMessage("Attribute must not be null");
+    }
+
+    @Test
+    void shouldThrowExceptionWhenValueIsNull() {
+        assertThatThrownBy(() -> new BasicRestrictionRecord<>("title", Operator.EQUAL, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("Value must not be null");
     }
 }


### PR DESCRIPTION
This makes the following changes:

1. Introduces `UnaryRestriction` and `UnaryOperator` to represent `is null` and `is not null`.
2. Disallows `null` as a value in `BasicRestriction`, since the meaning of `= null` and `<> null` varies between datastores.