### PR TITLE
Find value should be annotation member, not a constant

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Find.java
+++ b/api/src/main/java/jakarta/data/repository/Find.java
@@ -150,5 +150,5 @@ public @interface Find {
      * }
      * </pre>
      */
-    Class<?> value = void.class;
+    Class<?> value() default void.class;
 }


### PR DESCRIPTION
A typo caused the value member of the Find annotation to be a constant rather than a member of the annotation. This PR corrects it.