### PR TITLE
fix: add junit-platform-launcher

### DIFF
--- a/tck-dist/src/main/starter/ee-pom.xml
+++ b/tck-dist/src/main/starter/ee-pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- ~ Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ ~ Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  ~
  ~ This program and the accompanying materials are made available under the
  ~ terms of the Eclipse Public License v. 2.0, which is available at
@@ -134,6 +134,10 @@
   <dependency>
    <groupId>org.junit.jupiter</groupId>
    <artifactId>junit-jupiter</artifactId>
+  </dependency>
+  <dependency>
+   <groupId>org.junit.platform</groupId>
+   <artifactId>junit-platform-launcher</artifactId>
   </dependency>
   <!-- Signature Test Plugin -->
   <dependency>

--- a/tck-dist/src/main/starter/se-pom.xml
+++ b/tck-dist/src/main/starter/se-pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- ~ Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ ~ Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  ~
  ~ This program and the accompanying materials are made available under the
  ~ terms of the Eclipse Public License v. 2.0, which is available at
@@ -95,6 +95,10 @@
   <dependency>
    <groupId>org.junit.jupiter</groupId>
    <artifactId>junit-jupiter</artifactId>
+  </dependency>
+  <dependency>
+   <groupId>org.junit.platform</groupId>
+   <artifactId>junit-platform-launcher</artifactId>
   </dependency>
   <!-- Signature Test Plugin -->
   <dependency>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- ~ Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ ~ Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
  ~
  ~ This program and the accompanying materials are made available under the
  ~ terms of the Eclipse Public License v. 2.0, which is available at
@@ -47,6 +47,10 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
     </dependency>
     
     <!-- Data API -->


### PR DESCRIPTION
junit-platform-launcher is no longer a transitive dependency of junit-jupiter and will cause Arquillian to fail to discover tests at runtime when missing. 