### PR TITLE
TCK tests of selecting one attribute of entities, where entity is determined by Find value or primary entity type

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/PositiveIntegers.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/PositiveIntegers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023,2025 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -15,6 +15,8 @@
  */
 package ee.jakarta.tck.data.framework.read.only;
 
+import static jakarta.data.repository.By.ID;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -28,10 +30,13 @@ import jakarta.data.page.CursoredPage;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 import jakarta.data.repository.Find;
+import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Param;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.BasicRepository;
+import jakarta.data.repository.By;
 import jakarta.data.repository.Repository;
+import jakarta.data.repository.Select;
 
 /**
  * This is a read only repository that shares the same data (and entity type)
@@ -70,6 +75,14 @@ public interface PositiveIntegers extends BasicRepository<NaturalNumber, Long> {
     @Query("Select id Where isOdd = true and (id = :id or id < :exclusiveMax) Order by id Desc")
     List<Long> oddAndEqualToOrBelow(long id, long exclusiveMax);
 
+    @Find
+    @Select(_NaturalNumber.ID)
+    long[] requiringBits(Short numBitsRequired);
+
+    @Find
+    @Select(_NaturalNumber.NUMTYPE)
+    Optional<NumberType> typeOfNumber(@By(ID) long num);
+
     // Per the spec: The 'and' operator has higher precedence than 'or'.
     @Query("WHERE numBitsRequired = :bits OR numType = :type AND id < :xmax")
     CursoredPage<NaturalNumber> withBitCountOrOfTypeAndBelow(@Param("bits") short bitsRequired,
@@ -78,4 +91,9 @@ public interface PositiveIntegers extends BasicRepository<NaturalNumber, Long> {
                                                              Sort<NaturalNumber> sort1,
                                                              Sort<NaturalNumber> sort2,
                                                              PageRequest pageRequest);
+
+    @Find
+    @Select(_NaturalNumber.ID)
+    @OrderBy(_NaturalNumber.ID)
+    Page<Long> withParity(boolean isOdd, PageRequest pageReq);
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -2216,6 +2216,42 @@ public class EntityTests {
 
     @Assertion(id = "539", strategy = """
             Use a repository method that selects a single entity attribute as
+            an List of long. The entity type is identified by the Find annotation.
+            """)
+    public void testSelectEntityAttributeAsListOfLong() {
+
+        List<Long> found = shared.withTruncatedSqrt(7);
+
+        assertEquals(List.of(49L, 50L, 51L, 52L, 53L, 54L, 55L, 56L,
+                             57L, 58L, 59L, 60L, 61L, 62L, 63L),
+                     found.stream()
+                                     .sorted()
+                                     .collect(Collectors.toList()));
+
+        assertEquals(List.of(), shared.withTruncatedSqrt(0));
+    }
+
+    @Assertion(id = "539", strategy = """
+            Use a repository method that selects a single entity attribute as
+            an int value. The entity type is identified by the Find annotation.
+            """)
+    public void testSelectEntityAttributeAsOne() {
+
+        assertEquals(30, shared.valueOf("1e"));
+
+        assertEquals(42, shared.valueOf("2a"));
+
+        try {
+            int value = shared.valueOf("-4c");
+            fail("Should not be able to find a value that is not in the database: " +
+                 value);
+        } catch (EmptyResultException x) {
+            // expected
+        }
+    }
+
+    @Assertion(id = "539", strategy = """
+            Use a repository method that selects a single entity attribute as
             an Optional.
             """)
     public void testSelectEntityAttributeAsOptional() {
@@ -2233,12 +2269,12 @@ public class EntityTests {
             Use a repository method that selects a single entity attribute as a Page.
             """)
     public void testSelectEntityAttributeAsPage() {
-        final boolean ODD = true;
+        final boolean odd = true;
 
         PageRequest page4Request = PageRequest.ofPage(4).size(5);
         Page<Long> page4;
         try {
-            page4 = positives.withParity(ODD, page4Request);
+            page4 = positives.withParity(odd, page4Request);
         } catch (UnsupportedOperationException x) {
             if (type.isKeywordSupportAtOrBelow(DatabaseType.COLUMN)) {
                 // Column and Key-Value databases might not be capable of sorting.
@@ -2251,20 +2287,38 @@ public class EntityTests {
         assertEquals(List.of(31L, 33L, 35L, 37L, 39L),
                      page4.content());
 
-        Page<Long> page3 = positives.withParity(ODD, page4.previousPageRequest());
+        Page<Long> page3 = positives.withParity(odd, page4.previousPageRequest());
 
         assertEquals(List.of(21L, 23L, 25L, 27L, 29L),
                 page3.content());
 
-        Page<Long> page2 = positives.withParity(ODD, page3.previousPageRequest());
+        Page<Long> page2 = positives.withParity(odd, page3.previousPageRequest());
 
         assertEquals(List.of(11L, 13L, 15L, 17L, 19L),
                 page2.content());
 
-        Page<Long> page5 = positives.withParity(ODD, page4.nextPageRequest());
+        Page<Long> page5 = positives.withParity(odd, page4.nextPageRequest());
 
         assertEquals(List.of(41L, 43L, 45L, 47L, 49L),
                 page5.content());
+    }
+
+    @Assertion(id = "539", strategy = """
+            Use a repository method that selects a single entity attribute as
+            a Stream of long. The entity type is identified by the Find annotation.
+            """)
+    public void testSelectEntityAttributeAsStreamOfLong() {
+
+        Stream<Long> found = shared.withBitRequirementOf(Short.valueOf((short) 5));
+
+        assertEquals(List.of(16L, 17L, 18L, 19L, 20L, 21L, 22L, 23L,
+                             24L, 25L, 26L, 27L, 28L, 29L, 30L, 31L),
+                     found
+                                     .sorted()
+                                     .collect(Collectors.toList()));
+
+        assertEquals(0L,
+                     shared.withBitRequirementOf(Short.valueOf((short) -1)).count());
     }
 
     @Assertion(id = "539", strategy = """

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -2196,6 +2196,78 @@ public class EntityTests {
     }
 
     @Assertion(id = "539", strategy = """
+            Use a repository method that selects a single entity attribute as
+            an array of long.
+            """)
+    public void testSelectEntityAttributeAsArrayOfLong() {
+
+        long[] found = positives.requiringBits(Short.valueOf((short) 4));
+
+        assertEquals(List.of(8L, 9L, 10L, 11L, 12L, 13L, 14L, 15L),
+                     Arrays.stream(found)
+                                     .sorted()
+                                     .mapToObj(Long::valueOf)
+                                     .collect(Collectors.toList()));
+
+        long[] notFound = positives.requiringBits(Short.valueOf((short) 0));
+
+        assertEquals(0, notFound.length);
+    }
+
+    @Assertion(id = "539", strategy = """
+            Use a repository method that selects a single entity attribute as
+            an Optional.
+            """)
+    public void testSelectEntityAttributeAsOptional() {
+
+        assertEquals(NumberType.COMPOSITE, positives.typeOfNumber(18).orElseThrow());
+
+        assertEquals(NumberType.PRIME, positives.typeOfNumber(19).orElseThrow());
+
+        assertEquals(NumberType.ONE, positives.typeOfNumber(1).orElseThrow());
+
+        assertEquals(false, positives.typeOfNumber(0).isPresent());
+    }
+
+    @Assertion(id = "539", strategy = """
+            Use a repository method that selects a single entity attribute as a Page.
+            """)
+    public void testSelectEntityAttributeAsPage() {
+        final boolean ODD = true;
+
+        PageRequest page4Request = PageRequest.ofPage(4).size(5);
+        Page<Long> page4;
+        try {
+            page4 = positives.withParity(ODD, page4Request);
+        } catch (UnsupportedOperationException x) {
+            if (type.isKeywordSupportAtOrBelow(DatabaseType.COLUMN)) {
+                // Column and Key-Value databases might not be capable of sorting.
+                return;
+            } else {
+                throw x;
+            }
+        }
+
+        assertEquals(List.of(31L, 33L, 35L, 37L, 39L),
+                     page4.content());
+
+        Page<Long> page3 = positives.withParity(ODD, page4.previousPageRequest());
+
+        assertEquals(List.of(21L, 23L, 25L, 27L, 29L),
+                page3.content());
+
+        Page<Long> page2 = positives.withParity(ODD, page3.previousPageRequest());
+
+        assertEquals(List.of(11L, 13L, 15L, 17L, 19L),
+                page2.content());
+
+        Page<Long> page5 = positives.withParity(ODD, page4.nextPageRequest());
+
+        assertEquals(List.of(41L, 43L, 45L, 47L, 49L),
+                page5.content());
+    }
+
+    @Assertion(id = "539", strategy = """
             Use a repository method that selects a named subset of entity attributes
             to retrieve as an array of records.
             """)

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/MultipleEntityRepo.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/MultipleEntityRepo.java
@@ -15,12 +15,21 @@
  */
 package ee.jakarta.tck.data.standalone.entity;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 
+import ee.jakarta.tck.data.framework.read.only.AsciiCharacter;
+import ee.jakarta.tck.data.framework.read.only.NaturalNumber;
+import ee.jakarta.tck.data.framework.read.only._AsciiCharacter;
+import ee.jakarta.tck.data.framework.read.only._NaturalNumber;
+import jakarta.data.repository.By;
+import jakarta.data.repository.Find;
 import jakarta.data.repository.Insert;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
+import jakarta.data.repository.Select;
 
 /**
  * A repository that performs operations on different types of entities.
@@ -52,6 +61,18 @@ public interface MultipleEntityRepo { // Do not add a primary entity type.
 
     @Query("UPDATE Coordinate SET x = :newX, y = y / :yDivisor WHERE id = :id")
     int move(UUID id, double newX, float yDivisor);
+
+    @Find(AsciiCharacter.class)
+    @Select(_AsciiCharacter.NUMERICVALUE)
+    int valueOf(String hexadecimal);
+
+    @Find(NaturalNumber.class)
+    @Select("id")
+    Stream<Long> withBitRequirementOf(Short numBitsRequired);
+
+    @Find(NaturalNumber.class)
+    @Select("id")
+    List<Long> withTruncatedSqrt(@By(_NaturalNumber.FLOOROFSQUAREROOT) long floor);
 
     @Query("WHERE id = ?1")
     Optional<Coordinate> withUUID(UUID id);


### PR DESCRIPTION
This PR has TCK tests for
* selecting a single attribute of entities as `long[]`, `Optional`, and `Page`, where the entity is unspecified and defaults to the primary entity type of the repository.
* selecting a single attribute of entities as `int`, `List`, and `Stream`, where the entity is chosen by the `Find` annotation value.