### PR TITLE
TCK tests Find(entityclass) to disambiguate which entity to select values from when returning a record

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
@@ -31,6 +31,7 @@ import jakarta.data.repository.Find;
 import jakarta.data.repository.Query;
 import jakarta.data.repository.Repository;
 import jakarta.data.repository.Save;
+import jakarta.data.repository.Select;
 
 /**
  * This is a read only repository that represents the set of AsciiCharacters from 0-256.
@@ -106,4 +107,10 @@ public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long>, I
 
     @Query("SELECT COUNT(THIS) WHERE numericValue <= 97 AND numericValue >= 74")
     long twentyFour();
+
+    @Find(NaturalNumber.class) // this is not the primary entity type
+    @Select({ _NaturalNumber.NUMTYPEORDINAL,
+              _NaturalNumber.FLOOROFSQUAREROOT,
+              _NaturalNumber.ID })
+    List<WholeNumber> wholeNumbers(Short numBitsRequired);
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/HexInfo.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/HexInfo.java
@@ -15,26 +15,20 @@
  */
 package ee.jakarta.tck.data.framework.read.only;
 
-import ee.jakarta.tck.data.framework.read.only.NaturalNumber.NumberType;
-
 /**
- * A record that contains a subset of the attributes of the NaturalNumber entity.
- * where the record component names do not match the corresponding entity attribute
- * names.
+ * A record that contains a subset of the attributes of the AsciiCharacter entity.
+ * where the record component names are an exact match of the entity attribute names.
  */
-public record WholeNumber(
-        int numType,
-        long sqrtFloor,        
-        long value) implements Comparable<WholeNumber> {
+public record HexInfo (
+        String hexadecimal,
+        int numericValue) implements Comparable<HexInfo> {
 
     @Override
-    public int compareTo(WholeNumber other) {
-        return Long.compare(value, other.value);
+    public int compareTo(HexInfo other) {
+        return numericValue - other.numericValue;
     }
 
     public String toString() {
-        return value +
-                " " + NumberType.values()[numType] +
-                " √" + value + " >= " + sqrtFloor;
+        return hexadecimal + '(' + numericValue + ')';
     }
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers.java
@@ -78,6 +78,17 @@ public interface NaturalNumbers extends BasicRepository<NaturalNumber, Long>, Id
                                                                        PageRequest pagination,
                                                                        Sort<NaturalNumber> sort);
 
+    @Find(AsciiCharacter.class) // this is not the primary entity type
+    Optional<HexInfo> hexadecimalInfo(int numericValue);
+
+    @Find(AsciiCharacter.class) // this is not the primary entity type
+    HexInfo[] hexadecimalOfControlChars(@By("isControl") boolean isControlChar);
+
+    @Find(AsciiCharacter.class) // this is not the primary entity type
+    @SuppressWarnings("unchecked")
+    Page<HexInfo> hexadecimalPage(PageRequest pageReq,
+                                  Sort<AsciiCharacter>... sorts);
+
     @Find
     NumberInfo infoByIdentifier(@By(_NaturalNumber.ID) long id);
 


### PR DESCRIPTION
Add TCK tests where a Find method uses the Find.value() to specify the entity class to query for, with results returned as records that are subsets of the entity. In some tests, the record component names match the entity attribute names, and in another test they do not matching, requiring the repository method to use Select to specify the entity attributes.