### PR TITLE
Javadoc should indicate how boolean is sorted

### DIFF
--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -237,7 +237,7 @@ import java.util.Set;
  * <br>{@code int} and {@link Integer}
  * <br>{@code long} and {@link Long}
  * <br>{@code short} and {@link Short}</td>
- * <td></td></tr>
+ * <td>Boolean values are sorted such that {@code false} &lt; {@code true}.</td></tr>
  *
  * <tr style="vertical-align: top"><td>Binary data</td>
  * <td>{@code byte[]}</td>


### PR DESCRIPTION
While writing a test, I checked the Javadoc table of basic types to see whether `true` or `false` is ordered first.  Although this table has information on how some other types are sorted, it does not mention anything for boolean.  I did find the answer elsewhere in the specification document.  This PR adds the information to the table in the JavaDoc.