### PR TITLE
TCK tests of Select annotation on record component to identify the entity attribute

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
@@ -47,6 +47,12 @@ public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long>, I
     @Query("ORDER BY id ASC")
     Stream<AsciiCharacter> alphabetic(Limit limit);
 
+    @Find(NaturalNumber.class)
+    CardinalNumber cardinalNumberOf(@By(_NaturalNumber.ID) long value);
+
+    @Find(NaturalNumber.class)
+    Stream<CardinalNumber> cardinalNumberStream(long floorOfSquareRoot);
+
     long countByHexadecimalNotNull();
 
     boolean existsByThisCharacter(char ch);

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/CardinalNumber.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/CardinalNumber.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.framework.read.only;
+
+import ee.jakarta.tck.data.framework.read.only.NaturalNumber.NumberType;
+import jakarta.data.repository.Select;
+
+/**
+ * A record that contains a subset of the attributes of the NaturalNumber entity.
+ * where the Select annotation is used to identify entity attribute names that do
+ * not match the record component names.
+ */
+public record CardinalNumber(
+        // Select annotation is not needed when the name matches
+        Short numBitsRequired,
+        @Select(_NaturalNumber.NUMTYPEORDINAL)
+        int numType,
+        @Select(_NaturalNumber.ID)
+        long value) {
+
+    @Override
+    public String toString() {
+        return value + " " +
+                NumberType.values()[numType] + " (" +
+                numBitsRequired + " bits)";
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers.java
@@ -45,6 +45,20 @@ import ee.jakarta.tck.data.framework.read.only.NaturalNumber.NumberType;
 @Repository
 public interface NaturalNumbers extends BasicRepository<NaturalNumber, Long>, IdOperations {
 
+    @Find
+    Optional<CardinalNumber> cardinalNumberOptional(int id);
+
+    @Find
+    @OrderBy(_NaturalNumber.NUMTYPEORDINAL)
+    @OrderBy(_NaturalNumber.NUMBITSREQUIRED)
+    @OrderBy(_NaturalNumber.ID)
+    Page<CardinalNumber> cardinalNumberPage(
+            @By(_NaturalNumber.FLOOROFSQUAREROOT) long sqrtFloor,
+            PageRequest pageReq);
+
+    @Find
+    CardinalNumber[] cardinalNumbers(@By(_NaturalNumber.NUMBITSREQUIRED) Short bits);
+
     long countAll();
 
     CursoredPage<NaturalNumber> findByFloorOfSquareRootOrderByIdAsc(long sqrtFloor,

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -2423,6 +2423,46 @@ public class EntityTests {
     }
 
     @Assertion(id = "539", strategy = """
+            Use a repository method that returns a record type, where the record
+            components are annotated to select a subset of entity attributes.
+            The Find annotation value is needed to identify the entity.
+            """)
+    public void testReturnRecordThatSelectsAttributesFindEntity() {
+
+        CardinalNumber found = characters.cardinalNumberOf(59L);
+
+        assertEquals(59L, found.value());
+        assertEquals(Short.valueOf((short) 6), found.numBitsRequired());
+        assertEquals(NumberType.PRIME.ordinal(), found.numType());
+
+        try {
+            found = characters.cardinalNumberOf(0); // database only has 1 to 100
+        } catch (EmptyResultException x) {
+            // expected
+        }
+    }
+
+    @Assertion(id = "539", strategy = """
+            Use a repository method that returns a Stream of record type,
+            where the record components are annotated to select a subset of entity
+            attributes. The Find annotation value is needed to identify the entity.
+            """)
+    public void testReturnStreamOfRecordThatSelectsAttributesFindEntity() {
+
+        Stream<CardinalNumber> stream = characters.cardinalNumberStream(3L);
+
+        assertEquals(List.of("4 COMPOSITE (3 bits)",
+                             "5 PRIME (3 bits)",
+                             "6 COMPOSITE (3 bits)",
+                             "7 PRIME (3 bits)",
+                             "8 COMPOSITE (4 bits)"),
+                     stream
+                         .map(CardinalNumber::toString)
+                         .sorted()
+                         .collect(Collectors.toList()));
+    }
+
+    @Assertion(id = "539", strategy = """
             Use a repository method that selects a single entity attribute as
             an array of long.
             """)
@@ -2529,7 +2569,6 @@ public class EntityTests {
         assertEquals(List.of(41L, 43L, 45L, 47L, 49L),
                      page5.content());
     }
-
 
     @Assertion(id = "539", strategy = """
             Use a repository method that selects a single entity attribute as

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -54,6 +54,7 @@ import ee.jakarta.tck.data.framework.read.only._NaturalNumber;
 import ee.jakarta.tck.data.framework.read.only.AsciiCharacter;
 import ee.jakarta.tck.data.framework.read.only.AsciiCharacters;
 import ee.jakarta.tck.data.framework.read.only.AsciiCharactersPopulator;
+import ee.jakarta.tck.data.framework.read.only.CardinalNumber;
 import ee.jakarta.tck.data.framework.read.only.CustomRepository;
 import ee.jakarta.tck.data.framework.read.only.HexInfo;
 import ee.jakarta.tck.data.framework.read.only.NaturalNumber;
@@ -2309,6 +2310,119 @@ public class EntityTests {
     }
 
     @Assertion(id = "539", strategy = """
+            Use a repository method that returns an array of a record type,
+            where record components are annotated to select a subset of entity
+            attributes.
+            """)
+    public void testReturnArrayOfRecordThatSelectsAttributes() {
+        CardinalNumber[] found;
+
+        found = numbers.cardinalNumbers(Short.valueOf((short) 5));
+
+        assertEquals(List.of("16 COMPOSITE (5 bits)",
+                             "17 PRIME (5 bits)",
+                             "18 COMPOSITE (5 bits)",
+                             "19 PRIME (5 bits)",
+                             "20 COMPOSITE (5 bits)",
+                             "21 COMPOSITE (5 bits)",
+                             "22 COMPOSITE (5 bits)",
+                             "23 PRIME (5 bits)",
+                             "24 COMPOSITE (5 bits)",
+                             "25 COMPOSITE (5 bits)",
+                             "26 COMPOSITE (5 bits)",
+                             "27 COMPOSITE (5 bits)",
+                             "28 COMPOSITE (5 bits)",
+                             "29 PRIME (5 bits)",
+                             "30 COMPOSITE (5 bits)",
+                             "31 PRIME (5 bits)"),
+                     Arrays.stream(found)
+                             .map(CardinalNumber::toString)
+                             .sorted()
+                             .collect(Collectors.toList()));
+
+        found = numbers.cardinalNumbers(Short.valueOf((short) 0));
+
+        assertEquals(0, found.length);
+    }
+
+    @Assertion(id = "539", strategy = """
+            Use a repository method that returns an Optional of a record type,
+            where record components are annotated to select a subset of entity
+            attributes.
+            """)
+    public void testReturnOptionalOfRecordThatSelectsAttributes() {
+        Optional<CardinalNumber> found;
+
+        found = numbers.cardinalNumberOptional(79);
+
+        assertEquals(true, found.isPresent());
+        assertEquals(79L, found.get().value());
+        assertEquals(Short.valueOf((short) 7), found.get().numBitsRequired());
+        assertEquals(NumberType.PRIME.ordinal(), found.get().numType());
+
+        found = numbers.cardinalNumberOptional(0); // database only has 1 to 100
+
+        assertEquals(false, found.isPresent());
+    }
+
+    @Assertion(id = "539", strategy = """
+            Use a repository method that returns a Page of a record type,
+            where record components are annotated to select a subset of entity
+            attributes.
+            """)
+    public void testReturnPageOfRecordThatSelectsAttributes() {
+        Page<CardinalNumber> page1;
+
+        try {
+            page1 = numbers.cardinalNumberPage(9L, PageRequest.ofSize(7));
+        } catch (UnsupportedOperationException x) {
+            if (type.isKeywordSupportAtOrBelow(DatabaseType.COLUMN)) {
+                // Column and Key-Value databases might not be capable of sorting.
+                return;
+            } else {
+                throw x;
+            }
+        }
+
+        assertEquals(List.of("83 PRIME (7 bits)",
+                             "89 PRIME (7 bits)",
+                             "97 PRIME (7 bits)",
+                             "81 COMPOSITE (7 bits)",
+                             "82 COMPOSITE (7 bits)",
+                             "84 COMPOSITE (7 bits)",
+                             "85 COMPOSITE (7 bits)"),
+                     page1.stream()
+                             .map(CardinalNumber::toString)
+                             .collect(Collectors.toList()));
+
+        Page<CardinalNumber> page2 = numbers
+                .cardinalNumberPage(9L, page1.nextPageRequest());
+
+        assertEquals(List.of("86 COMPOSITE (7 bits)",
+                             "87 COMPOSITE (7 bits)",
+                             "88 COMPOSITE (7 bits)",
+                             "90 COMPOSITE (7 bits)",
+                             "91 COMPOSITE (7 bits)",
+                             "92 COMPOSITE (7 bits)",
+                             "93 COMPOSITE (7 bits)"),
+                     page2.stream()
+                             .map(CardinalNumber::toString)
+                             .collect(Collectors.toList()));
+
+        Page<CardinalNumber> page3 = numbers
+                .cardinalNumberPage(9L, page2.nextPageRequest());
+
+        assertEquals(List.of("94 COMPOSITE (7 bits)",
+                             "95 COMPOSITE (7 bits)",
+                             "96 COMPOSITE (7 bits)",
+                             "98 COMPOSITE (7 bits)",
+                             "99 COMPOSITE (7 bits)"),
+                     page3.stream()
+                             .map(CardinalNumber::toString)
+                             .collect(Collectors.toList()));
+    }
+
+    @Assertion(id = "539", strategy = """
             Use a repository method that selects a single entity attribute as
             an array of long.
             """)
@@ -2403,18 +2517,19 @@ public class EntityTests {
         Page<Long> page3 = positives.withParity(odd, page4.previousPageRequest());
 
         assertEquals(List.of(21L, 23L, 25L, 27L, 29L),
-                page3.content());
+                     page3.content());
 
         Page<Long> page2 = positives.withParity(odd, page3.previousPageRequest());
 
         assertEquals(List.of(11L, 13L, 15L, 17L, 19L),
-                page2.content());
+                     page2.content());
 
         Page<Long> page5 = positives.withParity(odd, page4.nextPageRequest());
 
         assertEquals(List.of(41L, 43L, 45L, 47L, 49L),
-                page5.content());
+                     page5.content());
     }
+
 
     @Assertion(id = "539", strategy = """
             Use a repository method that selects a single entity attribute as


### PR DESCRIPTION
TCK tests that of repository methods that return a subset of entity attributes as a Java record, where the record component uses the Select annotation to identify a corresponding entity attribute.  Some of the tests also include specifying the Find annotation value to identify the entity.  Others assume the primary entity type.