### PR TITLE
Case insensitive Constraints via IgnoreCase annotation

### DIFF
--- a/api/src/main/java/jakarta/data/Limit.java
+++ b/api/src/main/java/jakarta/data/Limit.java
@@ -34,7 +34,7 @@ import jakarta.data.page.PageRequest;
  *
  * <pre>
  * &#64;Find
- * Product[] namedLike(&#64;By(_Product.NAME) &#64;Is(Like.class) String namePattern,
+ * Product[] namedLike(&#64;By(_Product.NAME) &#64;IgnoreCase &#64;Is(Like.class) String namePattern,
  *                     Limit limit,
  *                     Sort&lt;?&gt;... sorts);
  *

--- a/api/src/main/java/jakarta/data/constraint/Constraint.java
+++ b/api/src/main/java/jakarta/data/constraint/Constraint.java
@@ -44,8 +44,8 @@ import jakarta.data.restrict.Restriction;
  * <pre>
  * &#64;Find
  * List&lt;Car&gt; withinYears(&#64;By(_Car.YEAR) Between&lt;Integer&gt; year,
- *                       &#64;By(_Car.MAKE) Like makePattern,
- *                       &#64;By(_Car.MODEL) Like modelPattern,
+ *                       &#64;By(_Car.MAKE) &#64;IgnoreCase Like makePattern,
+ *                       &#64;By(_Car.MODEL) &#64;IgnoreCase Like modelPattern,
  *                       Order&lt;Car&gt; sorts);
  *
  * ...
@@ -68,8 +68,8 @@ import jakarta.data.restrict.Restriction;
  * <pre>
  * &#64;Find
  * List&lt;Car&gt; pricedAtMost(&#64;By(_Car.PRICE) &#64;Is(AtMost.class) int maxPrice,
- *                        &#64;By(_Car.MAKE) &#64;Is(Like.class) String makePattern,
- *                        &#64;By(_Car.MODEL) &#64;Is(Like.class) Sting modelPattern,
+ *                        &#64;By(_Car.MAKE) &#64;IgnoreCase &#64;Is(Like.class) String makePattern,
+ *                        &#64;By(_Car.MODEL) &#64;IgnoreCase &#64;Is(Like.class) Sting modelPattern,
  *                        Order&lt;Car&gt; sorts);
  *
  * ...

--- a/api/src/main/java/jakarta/data/constraint/EqualTo.java
+++ b/api/src/main/java/jakarta/data/constraint/EqualTo.java
@@ -36,16 +36,16 @@ import jakarta.data.spi.expression.literal.Literal;
  *
  * <pre>
  * &#64;Find
- * List&lt;Car&gt; fromManufacturer(&#64;By(_Car.MAKE) EqualTo&lt;String&gt; manufacturer);
+ * List&lt;Car&gt; fromManufacturer(&#64;By(_Car.MAKE) &#64;IgnoreCase EqualTo&lt;String&gt; manufacturer);
  *
  * &#64;Find
- * List&lt;Car&gt; ofMakeAndModel(&#64;By(_Car.MAKE) &#64;Is(EqualTo.class) String manufacturer,
- *                          &#64;By(_Car.MODEL) &#64;Is(EqualTo.class) String model,
+ * List&lt;Car&gt; ofMakeAndModel(&#64;By(_Car.MAKE) &#64;IgnoreCase &#64;Is(EqualTo.class) String manufacturer,
+ *                          &#64;By(_Car.MODEL) &#64;IgnoreCase &#64;Is(EqualTo.class) String model,
  *                          Order&lt;Car&gt; sorts);
  *
  * &#64;Find
- * List&lt;Car&gt; ofMakeAndModelAndYear(&#64;By(_Car.MAKE) String manufacturer,
- *                                 &#64;By(_Car.MODEL) String model,
+ * List&lt;Car&gt; ofMakeAndModelAndYear(&#64;By(_Car.MAKE) &#64;IgnoreCase String manufacturer,
+ *                                 &#64;By(_Car.MODEL) &#64;IgnoreCase String model,
  *                                 &#64;By(_Car.YEAR) int modelYear,
  *                                 Order&lt;Car&gt; sorts);
  * ...

--- a/api/src/main/java/jakarta/data/constraint/Like.java
+++ b/api/src/main/java/jakarta/data/constraint/Like.java
@@ -41,11 +41,12 @@ import jakarta.data.spi.expression.literal.StringLiteral;
  * List&lt;Car&gt; matchVIN(&#64;By(_Car.VIN) Like vinPattern);
  *
  * &#64;Find // requires the -parameters compiler option to preserve parameter names
- * List&lt;Car&gt; makeAndModel(Like make, Like model);
+ * List&lt;Car&gt; makeAndModel(&#64;IgnoreCase Like make,
+ *                        &#64;IgnoreCase Like model);
  *
  * &#64;Find
- * List&lt;Car&gt; search(&#64;By(_Car.MAKE) &#64;Is(Like.class) String makePattern,
- *                  &#64;By(_Car.MODEL) &#64;Is(Like.class) String modelPattern,
+ * List&lt;Car&gt; search(&#64;By(_Car.MAKE) &#64;IgnoreCase &#64;Is(Like.class) String makePattern,
+ *                  &#64;By(_Car.MODEL) &#64;IgnoreCase &#64;Is(Like.class) String modelPattern,
  *                  Order&lt;Car&gt; sorts);
  *
  * ...

--- a/api/src/main/java/jakarta/data/constraint/NotEqualTo.java
+++ b/api/src/main/java/jakarta/data/constraint/NotEqualTo.java
@@ -37,8 +37,8 @@ import jakarta.data.spi.expression.literal.Literal;
  * List&lt;Car&gt; excludingManufacturer(&#64;By(_Car.MAKE) NotEqualTo&lt;String&gt; excludedManufacturer);
  *
  * &#64;Find
- * List&lt;Car&gt; ofMakeNotModel(&#64;By(_Car.MAKE) &#64;Is(EqualTo.class) String manufacturer,
- *                          &#64;By(_Car.MODEL) &#64;Is(NotEqualTo.class) String excludedModel,
+ * List&lt;Car&gt; ofMakeNotModel(&#64;By(_Car.MAKE) &#64;IgnoreCase &#64;Is(EqualTo.class) String manufacturer,
+ *                          &#64;By(_Car.MODEL) &#64;IgnoreCase &#64;Is(NotEqualTo.class) String excludedModel,
  *                          Order&lt;Car&gt; sorts);
  * ...
  *

--- a/api/src/main/java/jakarta/data/constraint/NotLike.java
+++ b/api/src/main/java/jakarta/data/constraint/NotLike.java
@@ -38,11 +38,11 @@ import jakarta.data.spi.expression.literal.StringLiteral;
  *
  * <pre>
  * &#64;Find
- * List&lt;Car&gt; matchVIN(&#64;By(_Car.VIN) NotLike pattern);
+ * List&lt;Car&gt; matchVIN(&#64;By(_Car.VIN) &#64;IgnoreCase NotLike pattern);
  *
  * &#64;Find
- * List&lt;Car&gt; ofMakeNotModel(&#64;By(_Car.MAKE) String manufacturer,
- *                          &#64;By(_Car.MODEL) &#64;Is(NotLike.class) String excludePattern,
+ * List&lt;Car&gt; ofMakeNotModel(&#64;By(_Car.MAKE) &#64;IgnoreCase String manufacturer,
+ *                          &#64;By(_Car.MODEL) &#64;IgnoreCase &#64;Is(NotLike.class) String excludePattern,
  *                          Order&lt;Car&gt; sorts);
  *
  * ...

--- a/api/src/main/java/jakarta/data/page/Page.java
+++ b/api/src/main/java/jakarta/data/page/Page.java
@@ -30,8 +30,8 @@ import java.util.stream.StreamSupport;
  *
  * <pre>
  * &#64;Find
- * Page&lt;Vehicle&gt; search(&#64;By("make") String make,
- *                      &#64;By("model") String model,
+ * Page&lt;Vehicle&gt; search(&#64;By("make") &#64;IgnoreCase String make,
+ *                      &#64;By("model") &#64;IgnoreCase String model,
  *                      &#64;By("year") int designYear,
  *                      PageRequest pageRequest,
  *                      Order&lt;Vehicle&gt; order);

--- a/api/src/main/java/jakarta/data/repository/By.java
+++ b/api/src/main/java/jakarta/data/repository/By.java
@@ -52,11 +52,11 @@ import jakarta.data.constraint.EqualTo;
  *     Person findById(&#64;By(ID) String id); // maps to Person.ssn
  *
  *     &#64;Find
- *     List&lt;Person&gt; findNamed(&#64;By("firstName") String first,
- *                            &#64;By("lastName") String last);
+ *     List&lt;Person&gt; findNamed(&#64;By("firstName") &#64;IgnoreCase String first,
+ *                            &#64;By("lastName") &#64;IgnoreCase String last);
  *
  *     &#64;Find
- *     List&lt;Person&gt; findByCity(&#64;By("address.city") String city);
+ *     List&lt;Person&gt; findByCity(&#64;By("address.city") &#64;IgnoreCase String city);
  * }
  * </pre>
  *
@@ -76,11 +76,11 @@ import jakarta.data.constraint.EqualTo;
  *     Person findById(String ssn);
  *
  *     &#64;Find
- *     List&lt;Person&gt; findNamed(String firstName,
- *                            String lastname);
+ *     List&lt;Person&gt; findNamed(&#64;IgnoreCase String firstName,
+ *                            &#64;IgnoreCase String lastname);
  *
  *     &#64;Find
- *     List&lt;Person&gt; findByCity(String address_city);
+ *     List&lt;Person&gt; findByCity(&#64;IgnoreCase String address_city);
  * }
  * </pre>
  */

--- a/api/src/main/java/jakarta/data/repository/Find.java
+++ b/api/src/main/java/jakarta/data/repository/Find.java
@@ -79,7 +79,7 @@ import java.lang.annotation.Target;
  * &#64;Repository
  * interface Garage {
  *     &#64;Find
- *     List&lt;Car&gt; getCarsWithModel(@By("model") String model);
+ *     List&lt;Car&gt; getCarsWithModel(@By("model") &#64;IgnoreCase String model);
  * }
  * </pre>
  * <p>The {@code @Find} annotation indicates that the {@code getCarsWithModel(model)}

--- a/api/src/main/java/jakarta/data/repository/IgnoreCase.java
+++ b/api/src/main/java/jakarta/data/repository/IgnoreCase.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data.repository;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.data.constraint.AtLeast;
+import jakarta.data.constraint.AtMost;
+import jakarta.data.constraint.Between;
+import jakarta.data.constraint.EqualTo;
+import jakarta.data.constraint.GreaterThan;
+import jakarta.data.constraint.LessThan;
+import jakarta.data.constraint.Like;
+import jakarta.data.constraint.NotBetween;
+import jakarta.data.constraint.NotEqualTo;
+import jakarta.data.constraint.NotLike;
+
+/**
+ * <p>Annotates a parameter of a repository {@link Find} or {@link Delete}
+ * method, to compare an entity attribute ignoring case.</p>
+ *
+ * <p>The parameter must correspond to a {@link String}-typed entity attribute
+ * and must either be an implicit equality constraint or one of the following
+ * constraints, indicated by the method parameter's type or its {@link Is @Is}
+ * annotation.
+ *
+ * <ul>
+ * <li>{@link AtLeast}</li>
+ * <li>{@link AtMost}</li>
+ * <li>{@link Between} (not available for {@code @Is})</li>
+ * <li>{@link EqualTo}</li>
+ * <li>{@link GreaterThan}</li>
+ * <li>{@link LessThan}</li>
+ * <li>{@link Like}</li>
+ * <li>{@link NotBetween} (not available for {@code @Is})</li>
+ * <li>{@link NotEqualTo}</li>
+ * <li>{@link NotLike}</li>
+ * </ul>
+ *
+ * <p>For example,</p>
+ *
+ * <pre>
+ * &#64;Repository
+ * public interface People extends BasicRepository&lt;Person, Long&gt; {
+ *
+ *     // List of Person entities where the lastName attribute matches a
+ *     // literal value, ignoring case.
+ *     // Requires the -parameters compile option.
+ *     &#64;Find
+ *     List&lt;Person&gt; ofSurname(&#64;IgnoreCase String lastName);
+ *
+ *     // List of Person entities where the lastName attribute matches a
+ *     // pattern, ignoring case.
+ *     &#64;Find
+ *     &#64;OrderBy(_Person.LASTNAME)
+ *     &#64;OrderBy(_Person.FIRSTNAME)
+ *     List&lt;Person&gt; surnamed(&#64;By(_Person.LASTNAME) &#64;IgnoreCase Like pattern);
+ *
+ *     // List of Person entities where the lastName attribute, is alphabetized
+ *     // within the first parameter up to but not including the second
+ *     // parameter, ignoring case.
+ *     &#64;Find
+ *     &#64;OrderBy(_Person.LASTNAME)
+ *     &#64;OrderBy(_Person.FIRSTNAME)
+ *     List&lt;Person&gt; withinSurnameRange(
+ *         &#64;By(_Person.LASTNAME) &#64;IgnoreCase &#64;Is(AtLeast.class) String beginAt,
+ *         &#64;By(_Person.LASTNAME) &#64;IgnoreCase &#64;Is(LessThan.class) String endBefore);
+ * }
+ *
+ * ...
+ *
+ * smiths = people.ofSurname("smith");
+ * aNames = people.surnamed(Like.pattern("A%"));
+ * surnamesAToE = people.withinSurnameRange("A", "F");
+ * </pre>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface IgnoreCase {
+}

--- a/api/src/main/java/jakarta/data/repository/Is.java
+++ b/api/src/main/java/jakarta/data/repository/Is.java
@@ -59,7 +59,7 @@ import jakarta.data.constraint.NotLike;
  *
  *     // Find a page of Product entities where the name field matches a pattern.
  *     &#64;Find
- *     Page&lt;Product&gt; search(&#64;By(_Product.NAME) &#64;Is(Like.class) String pattern,
+ *     Page&lt;Product&gt; search(&#64;By(_Product.NAME) &#64;IgnoreCase &#64;Is(Like.class) String pattern,
  *                          PageRequest pagination,
  *                          Order&lt;Product&gt; order);
  *

--- a/api/src/main/java/jakarta/data/repository/OrderBy.java
+++ b/api/src/main/java/jakarta/data/repository/OrderBy.java
@@ -119,7 +119,7 @@ public @interface OrderBy {
      * <pre>
      * &#64;Find
      * &#64;OrderBy("age")
-     * Stream&lt;Person&gt; withLastName(&#64;By("lastName") String surname);
+     * Stream&lt;Person&gt; withLastName(&#64;By("lastName") &#64;IgnoreCase String surname);
      * </pre>
      *
      * @return entity attribute name.

--- a/api/src/main/java/jakarta/data/repository/Repository.java
+++ b/api/src/main/java/jakarta/data/repository/Repository.java
@@ -40,7 +40,7 @@ import java.lang.annotation.Target;
  *
  *     &#64;Find
  *     &#64;OrderBy("price")
- *     List&lt;Product&gt; namedLike(&#64;By("name") &#64;Is(Like.class) String namePattern);
+ *     List&lt;Product&gt; namedLike(&#64;By("name") &#64;IgnoreCase &#64;Is(Like.class) String namePattern);
  *
  *     &#64;Query("UPDATE Product SET price = price - (price * ?1) WHERE price * ?1 &lt;= ?2")
  *     int putOnSale(float rateOfDiscount, float maxDiscount);

--- a/api/src/main/java/jakarta/data/restrict/Restriction.java
+++ b/api/src/main/java/jakarta/data/restrict/Restriction.java
@@ -46,8 +46,8 @@ import jakarta.data.repository.Find;
  * public interface Cars extends CrudRepository&lt;Car, String&gt; {
  *
  *     &#64;Find
- *     List&lt;Car&gt; search(&#64;By(_Car.MAKE) String manufacturer,
- *                      &#64;By(_Car.MODEL) String model,
+ *     List&lt;Car&gt; search(&#64;By(_Car.MAKE) &#64;IgnoreCase String manufacturer,
+ *                      &#64;By(_Car.MODEL) &#64;IgnoreCase String model,
  *                      Restriction&lt;Car&gt; restriction,
  *                      Order&lt;Car&gt;... sort);
  * }

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -86,7 +86,7 @@ import java.util.Set;
  *
  *     &#64;Find
  *     List&lt;Product&gt; search(
- *             &#64;By(_Product.NAME) &#64;Is(Like.class) String namePattern,
+ *             &#64;By(_Product.NAME) &#64;IgnoreCase &#64;Is(Like.class) String namePattern,
  *             Restriction&lt;Product&gt; restriction,
  *             Order&lt;Product&gt; sortBy);
  *
@@ -383,7 +383,7 @@ import java.util.Set;
  *
  *     &#64;Find
  *     &#64;OrderBy("price")
- *     Product[] named(String name);
+ *     Product[] named(&#64;IgnoreCase String name);
  *     </pre>
  * </li>
  * <li>The parameter is a {@link Constraint} or a
@@ -448,7 +448,7 @@ import java.util.Set;
  *
  * <pre>
  * &#64;Find
- * Stream&lt;Person&gt; livingInCity(String address_city);
+ * Stream&lt;Person&gt; livingInCity(&#64;IgnoreCase String address_city);
  * </pre>
  *
  * <h2>JDQL query methods</h2>
@@ -893,7 +893,7 @@ import java.util.Set;
  *
  * <pre>
  * &#64;Find
- * Page&lt;Product&gt; pricedWithin(&#64;By("name") &#64;Is(Like.class) String pattern,
+ * Page&lt;Product&gt; pricedWithin(&#64;By("name") &#64;IgnoreCase &#64;Is(Like.class) String pattern,
  *                            &#64;By("price") &#64;Is(AtLeast.class) float minPrice,
  *                            &#64;By("price") &#64;Is(AtMost.class) float maxPrice,
  *                            PageRequest pageRequest,
@@ -917,7 +917,7 @@ import java.util.Set;
  *
  * <pre>
  * &#64;Find
- * Product[] named(&#64;By("name") &#64;Is(Like.class) String pattern,
+ * Product[] named(&#64;By("name") &#64;IgnoreCase &#64;Is(Like.class) String pattern,
  *                 Limit max,
  *                 Order&lt;Product&gt; sortBy);
  *
@@ -935,7 +935,7 @@ import java.util.Set;
  *
  * <pre>
  * &#64;Find
- * Product[] namedLike(&#64;By("name") &#64;Is(Like.class) String pattern,
+ * Product[] namedLike(&#64;By("name") &#64;IgnoreCase &#64;Is(Like.class) String pattern,
  *                     Limit max,
  *                     {@code Sort<?>...} sortBy);
  *
@@ -957,7 +957,7 @@ import java.util.Set;
  *
  * <pre>
  *     &#64;Find
- *     List&lt;Product&gt; namedLike(&#64;By(_Product.NAME) Like pattern,
+ *     List&lt;Product&gt; namedLike(&#64;By(_Product.NAME) &#64;IgnoreCase Like pattern,
  *                             Restriction&lt;Product&gt; restrict,
  *                             Order&lt;Product&gt; sorts);
  * </pre>

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -412,7 +412,7 @@ For example:
 @Repository
 public interface ProductRepository {
    @Find
-   List<Product> search(@By(_Product.DESCRIPTION) @Is(Like.class) description,
+   List<Product> search(@By(_Product.DESCRIPTION) @IgnoreCase @Is(Like.class) description,
                         Restriction<Product> restriction);
 }
 ----
@@ -760,8 +760,8 @@ In this example, the application uses `OrderBy` to define a subset of the sort c
 public interface Products extends CrudRepository<Product, Long> {
     @Find
     @OrderBy(_Car.VEHICLE_CONDITION)
-    CursoredPage<Car> find(@By(_Car.MAKE) String manufacturer,
-                           @By(_Car.MODEL) String model,
+    CursoredPage<Car> find(@By(_Car.MAKE) @IgnoreCase String manufacturer,
+                           @By(_Car.MODEL) @IgnoreCase String model,
                            PageRequest pageRequest,
                            Order<Car> sorts);
 }


### PR DESCRIPTION
Option 1 for case insensitive Constraints:
Give the repository method author an `@IgnoreCase` annotation with which to indicate when a Constraint should be applied independent of case.  Typically it will be known upfront that the database contains a mixture of case, and it will be more convenient to specify this information in a single place on the repository method signature rather than everywhere it is used (where there is also the risk of forgetting to do it in one place).

Example usage:

```
List<Book> booksTitled(@IgnoreCase Like title);

found = library.booksTitled(Like.pattern("Developing applications with Jakarta Data"));
```
