### PR TITLE
Case insensitive Constraints via ignoreCase method per Constraint subtype that can support it

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/TextRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/TextRestrictionRecord.java
@@ -17,7 +17,17 @@
  */
 package jakarta.data.metamodel;
 
+import jakarta.data.metamodel.constraint.Between;
 import jakarta.data.metamodel.constraint.Constraint;
+import jakarta.data.metamodel.constraint.EqualTo;
+import jakarta.data.metamodel.constraint.GreaterThan;
+import jakarta.data.metamodel.constraint.GreaterThanOrEqual;
+import jakarta.data.metamodel.constraint.LessThan;
+import jakarta.data.metamodel.constraint.LessThanOrEqual;
+import jakarta.data.metamodel.constraint.Like;
+import jakarta.data.metamodel.constraint.NotBetween;
+import jakarta.data.metamodel.constraint.NotEqualTo;
+import jakarta.data.metamodel.constraint.NotLike;
 import jakarta.data.metamodel.restrict.TextRestriction;
 
 import java.util.Objects;
@@ -31,7 +41,40 @@ record TextRestrictionRecord<T>(String attribute, Constraint<String> constraint)
     }
 
     @Override
-    public TextRestrictionRecord<T> negate() {
+    public TextRestriction<T> ignoreCase() {
+        // TODO: Use a switch statement after we move up to Java 21 minimum
+        Constraint<String> caseIgnoringConstraint;
+        if (constraint instanceof Like) {
+            caseIgnoringConstraint = ((Like) constraint).ignoreCase();
+        } else if (constraint instanceof NotLike) {
+            caseIgnoringConstraint = ((NotLike) constraint).ignoreCase();
+        } else if (constraint instanceof EqualTo) {
+            caseIgnoringConstraint = ((EqualTo<String>) constraint).ignoreCase();
+        } else if (constraint instanceof NotEqualTo) {
+            caseIgnoringConstraint = ((NotEqualTo<String>) constraint).ignoreCase();
+        } else if (constraint instanceof Between) {
+            caseIgnoringConstraint = ((Between<String>) constraint).ignoreCase();
+        } else if (constraint instanceof NotBetween) {
+            caseIgnoringConstraint = ((NotBetween<String>) constraint).ignoreCase();
+        } else if (constraint instanceof GreaterThan) {
+            caseIgnoringConstraint = ((GreaterThan<String>) constraint).ignoreCase();
+        } else if (constraint instanceof GreaterThanOrEqual) {
+            caseIgnoringConstraint = ((GreaterThanOrEqual<String>) constraint).ignoreCase();
+        } else if (constraint instanceof LessThan) {
+            caseIgnoringConstraint = ((LessThan<String>) constraint).ignoreCase();
+        } else if (constraint instanceof LessThanOrEqual) {
+            caseIgnoringConstraint = ((LessThanOrEqual<String>) constraint).ignoreCase();
+        } else {
+            throw new UnsupportedOperationException(
+                    "Cannot ignore case of a " +
+                    constraint.getClass().getInterfaces()[0].getName() + " constraint");
+        }
+
+        return new TextRestrictionRecord<>(attribute, caseIgnoringConstraint);
+    }
+
+    @Override
+    public TextRestriction<T> negate() {
         return new TextRestrictionRecord<>(attribute, constraint.negate());
     }
 

--- a/api/src/main/java/jakarta/data/metamodel/constraint/Between.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/Between.java
@@ -23,6 +23,10 @@ public interface Between<T extends Comparable<T>> extends Constraint<T> {
         return new BetweenRecord<>(lower, upper);
     }
 
+    Between<T> ignoreCase();
+
+    boolean isCaseSensitive();
+
     T lowerBound();
     T upperBound();
 }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/Constraint.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/Constraint.java
@@ -22,7 +22,7 @@ import java.util.Set;
 public interface Constraint<T> {
 
     static <T> Constraint<T> equalTo(T value) {
-        return new EqualToRecord<>(value);
+        return EqualTo.value(value);
     }
 
     @SafeVarargs
@@ -38,24 +38,24 @@ public interface Constraint<T> {
         return new NullRecord<>();
     }
 
-    static <T extends Comparable<T>> Constraint<T> greaterThan(T bound) {
-        return new GreaterThanRecord<>(bound);
+    static <T extends Comparable<T>> GreaterThan<T> greaterThan(T bound) {
+        return GreaterThan.bound(bound);
     }
 
-    static <T extends Comparable<T>> Constraint<T> lessThan(T bound) {
-        return new LessThanRecord<>(bound);
+    static <T extends Comparable<T>> LessThan<T> lessThan(T bound) {
+        return LessThan.bound(bound);
     }
 
-    static <T extends Comparable<T>> Constraint<T> greaterThanOrEqual(T bound) {
-        return new GreaterThanOrEqualRecord<>(bound);
+    static <T extends Comparable<T>> GreaterThanOrEqual<T> greaterThanOrEqual(T bound) {
+        return GreaterThanOrEqual.min(bound);
     }
 
-    static <T extends Comparable<T>> Constraint<T> lessThanOrEqual(T bound) {
-        return new LessThanOrEqualRecord<>(bound);
+    static <T extends Comparable<T>> LessThanOrEqual<T> lessThanOrEqual(T bound) {
+        return LessThanOrEqual.max(bound);
     }
 
-    static <T extends Comparable<T>> Constraint<T> between(T lowerBound, T upperBound) {
-        return new BetweenRecord<>(lowerBound, upperBound);
+    static <T extends Comparable<T>> Between<T> between(T lowerBound, T upperBound) {
+        return Between.bounds(lowerBound, upperBound);
     }
 
     Constraint<T> negate();

--- a/api/src/main/java/jakarta/data/metamodel/constraint/EqualTo.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/EqualTo.java
@@ -23,5 +23,9 @@ public interface EqualTo<T> extends Constraint<T> {
         return new EqualToRecord<>(value);
     }
 
+    EqualTo<T> ignoreCase();
+
+    boolean isCaseSensitive();
+
     T value();
 }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/EqualToRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/EqualToRecord.java
@@ -19,29 +19,34 @@ package jakarta.data.metamodel.constraint;
 
 import java.util.Objects;
 
-record EqualToRecord<T>(T value) implements EqualTo<T> {
+record EqualToRecord<T>(T value, boolean isCaseSensitive) implements EqualTo<T> {
     public EqualToRecord {
         Objects.requireNonNull(value, "Value must not be null");
     }
 
+    EqualToRecord(T value) {
+        this(value, value instanceof String);
+    }
+
+    @Override
+    public EqualTo<T> ignoreCase() {
+        if (!(value instanceof String)) {
+            throw new UnsupportedOperationException(
+                   "Cannot ignore case of a " + value.getClass().getName() +
+                    " typed attribute");
+        }
+        return new EqualToRecord<>(value, false);
+    }
+
     @Override
     public NotEqualTo<T> negate() {
-        return NotEqualTo.value(value);
+        return new NotEqualToRecord<>(value, isCaseSensitive);
     }
 
     @Override
     public String toString() {
-        return value instanceof String ? "= '" + value + "'" : "= " + value.toString();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        return obj instanceof EqualToRecord<?> that
-            && value.equals(that.value);
-    }
-
-    @Override
-    public int hashCode() {
-        return value.hashCode();
+        return value instanceof String
+                ? "= '" + value + (isCaseSensitive ? "'" : "' IGNORE CASE")
+                : "= " + value.toString();
     }
 }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/GreaterThan.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/GreaterThan.java
@@ -23,5 +23,9 @@ public interface GreaterThan<T extends Comparable<T>> extends Constraint<T> {
         return new GreaterThanRecord<>(lowerBound);
     }
 
+    GreaterThan<T> ignoreCase();
+
     T bound();
+
+    boolean isCaseSensitive();
 }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/GreaterThanOrEqual.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/GreaterThanOrEqual.java
@@ -23,5 +23,9 @@ public interface GreaterThanOrEqual<T extends Comparable<T>> extends Constraint<
         return new GreaterThanOrEqualRecord<>(minimum);
     }
 
+    GreaterThanOrEqual<T> ignoreCase();
+
     T bound();
+
+    boolean isCaseSensitive();
 }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/GreaterThanOrEqualRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/GreaterThanOrEqualRecord.java
@@ -19,30 +19,34 @@ package jakarta.data.metamodel.constraint;
 
 import java.util.Objects;
 
-record GreaterThanOrEqualRecord<T extends Comparable<T>>(T bound)
+record GreaterThanOrEqualRecord<T extends Comparable<T>>(T bound, boolean isCaseSensitive)
         implements GreaterThanOrEqual<T> {
     public GreaterThanOrEqualRecord {
         Objects.requireNonNull(bound, "Lower bound must not be null");
     }
 
+    GreaterThanOrEqualRecord(T bound) {
+        this(bound, bound instanceof String);
+    }
+
+    @Override
+    public GreaterThanOrEqual<T> ignoreCase() {
+        if (!(bound instanceof String)) {
+            throw new UnsupportedOperationException(
+                    "Cannot ignore case of a " + bound.getClass().getName() +
+                    " typed attribute");
+        }
+        return new GreaterThanOrEqualRecord<>(bound, false);
+    }
+
     @Override
     public LessThan<T> negate() {
-        return LessThan.bound(bound);
+        return new LessThanRecord<>(bound, isCaseSensitive);
     }
 
     @Override
     public String toString() {
-        return ">= " + bound.toString();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        return obj instanceof GreaterThanOrEqualRecord<?> that
-            && bound.equals(that.bound);
-    }
-
-    @Override
-    public int hashCode() {
-        return bound.hashCode();
-    }
+        return bound instanceof String
+                ? ">= '" + bound + (isCaseSensitive ? "'" : "' IGNORE CASE")
+                : ">= " + bound;    }
 }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/GreaterThanRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/GreaterThanRecord.java
@@ -19,30 +19,35 @@ package jakarta.data.metamodel.constraint;
 
 import java.util.Objects;
 
-record GreaterThanRecord<T extends Comparable<T>>(T bound)
+record GreaterThanRecord<T extends Comparable<T>>(T bound, boolean isCaseSensitive)
         implements GreaterThan<T> {
     public GreaterThanRecord {
         Objects.requireNonNull(bound, "Lower bound must not be null");
     }
 
+    GreaterThanRecord(T bound) {
+        this(bound, bound instanceof String);
+    }
+
+    @Override
+    public GreaterThan<T> ignoreCase() {
+        if (!(bound instanceof String)) {
+            throw new UnsupportedOperationException(
+                    "Cannot ignore case of a " + bound.getClass().getName() +
+                    " typed attribute");
+        }
+        return new GreaterThanRecord<>(bound, false);
+    }
+
     @Override
     public LessThanOrEqual<T> negate() {
-        return LessThanOrEqual.max(bound);
+        return new LessThanOrEqualRecord<>(bound, isCaseSensitive);
     }
 
     @Override
     public String toString() {
-        return "> " + bound.toString();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        return obj instanceof GreaterThanRecord<?> that
-            && bound.equals(that.bound);
-    }
-
-    @Override
-    public int hashCode() {
-        return bound.hashCode();
+        return bound instanceof String
+                ? "> '" + bound + (isCaseSensitive ? "'" : "' IGNORE CASE")
+                : "> " + bound;
     }
 }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/LessThan.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/LessThan.java
@@ -23,5 +23,9 @@ public interface LessThan<T extends Comparable<T>> extends Constraint<T> {
         return new LessThanRecord<>(upperBound);
     }
 
+    LessThan<T> ignoreCase();
+
     T bound();
+
+    boolean isCaseSensitive();
 }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/LessThanOrEqual.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/LessThanOrEqual.java
@@ -23,5 +23,9 @@ public interface LessThanOrEqual<T extends Comparable<T>> extends Constraint<T> 
         return new LessThanOrEqualRecord<>(maximum);
     }
 
+    LessThanOrEqual<T> ignoreCase();
+
     T bound();
+
+    boolean isCaseSensitive();
 }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/LessThanOrEqualRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/LessThanOrEqualRecord.java
@@ -19,30 +19,35 @@ package jakarta.data.metamodel.constraint;
 
 import java.util.Objects;
 
-record LessThanOrEqualRecord<T extends Comparable<T>>(T bound)
+record LessThanOrEqualRecord<T extends Comparable<T>>(T bound, boolean isCaseSensitive)
         implements LessThanOrEqual<T> {
     public LessThanOrEqualRecord {
         Objects.requireNonNull(bound, "Upper bound must not be null");
     }
 
+    LessThanOrEqualRecord(T bound) {
+        this(bound, bound instanceof String);
+    }
+
+    @Override
+    public LessThanOrEqual<T> ignoreCase() {
+        if (!(bound instanceof String)) {
+            throw new UnsupportedOperationException(
+                    "Cannot ignore case of a " + bound.getClass().getName() +
+                    " typed attribute");
+        }
+        return new LessThanOrEqualRecord<>(bound, false);
+    }
+
     @Override
     public GreaterThan<T> negate() {
-        return GreaterThan.bound(bound);
+        return new GreaterThanRecord<>(bound, isCaseSensitive);
     }
 
     @Override
     public String toString() {
-        return "<= " + bound.toString();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        return obj instanceof LessThanOrEqualRecord<?> that
-            && bound.equals(that.bound);
-    }
-
-    @Override
-    public int hashCode() {
-        return bound.hashCode();
+        return bound instanceof String
+                ? "<= '" + bound + (isCaseSensitive ? "'" : "' IGNORE CASE")
+                : "<= " + bound;
     }
 }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/LessThanRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/LessThanRecord.java
@@ -19,30 +19,35 @@ package jakarta.data.metamodel.constraint;
 
 import java.util.Objects;
 
-record LessThanRecord<T extends Comparable<T>>(T bound)
+record LessThanRecord<T extends Comparable<T>>(T bound, boolean isCaseSensitive)
         implements LessThan<T> {
     public LessThanRecord {
         Objects.requireNonNull(bound, "Upper bound must not be null");
     }
 
+    LessThanRecord(T bound) {
+        this(bound, bound instanceof String);
+    }
+
+    @Override
+    public LessThan<T> ignoreCase() {
+        if (!(bound instanceof String)) {
+            throw new UnsupportedOperationException(
+                    "Cannot ignore case of a " + bound.getClass().getName() +
+                    " typed attribute");
+        }
+        return new LessThanRecord<>(bound, false);
+    }
+
     @Override
     public GreaterThanOrEqual<T> negate() {
-        return GreaterThanOrEqual.min(bound);
+        return new GreaterThanOrEqualRecord<>(bound, isCaseSensitive);
     }
 
     @Override
     public String toString() {
-        return "< " + bound.toString();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        return obj instanceof LessThanRecord<?> that
-            && bound.equals(that.bound);
-    }
-
-    @Override
-    public int hashCode() {
-        return bound.hashCode();
+        return bound instanceof String
+                ? "< '" + bound + (isCaseSensitive ? "'" : "' IGNORE CASE")
+                : "< " + bound;
     }
 }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/Like.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/Like.java
@@ -18,11 +18,17 @@
 package jakarta.data.metamodel.constraint;
 
 public interface Like extends Constraint<String> {
+
+    Like ignoreCase();
+
+    boolean isCaseSensitive();
+
     String pattern();
+
     Character escape();
 
     static Like pattern(String pattern) {
-        return new LikeRecord(pattern);
+        return new LikeRecord(pattern, null);
     }
 
     static Like pattern(String pattern, char charWildcard, char stringWildcard) {

--- a/api/src/main/java/jakarta/data/metamodel/constraint/LikeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/LikeRecord.java
@@ -19,7 +19,7 @@ package jakarta.data.metamodel.constraint;
 
 import java.util.Objects;
 
-record LikeRecord(String pattern, Character escape)
+record LikeRecord(String pattern, Character escape, boolean isCaseSensitive)
         implements Like {
 
     public static final char CHAR_WILDCARD = '_';
@@ -30,8 +30,8 @@ record LikeRecord(String pattern, Character escape)
         Objects.requireNonNull(pattern, "Pattern must not be null");
     }
 
-    public LikeRecord(String pattern) {
-        this(pattern, null);
+    LikeRecord(String pattern, Character escape) {
+        this(pattern, escape, true);
     }
 
     public LikeRecord(String pattern, char charWildcard, char stringWildcard) {
@@ -43,14 +43,20 @@ record LikeRecord(String pattern, Character escape)
     }
 
     @Override
+    public Like ignoreCase() {
+        return new LikeRecord(pattern, escape, false);
+    }
+
+    @Override
     public NotLike negate() {
-        return new NotLikeRecord(pattern, escape);
+        return new NotLikeRecord(pattern, escape, isCaseSensitive);
     }
 
     @Override
     public String toString() {
-        return "LIKE '" + pattern + "'"
-                + (escape == null ? "" : " ESCAPE '\\'");
+        return "LIKE '" + pattern + "'" +
+               (escape == null ? "" : " ESCAPE '\\'" +
+               (isCaseSensitive ? "" : " IGNORE CASE"));
     }
 
     public static LikeRecord prefix(String prefix) {

--- a/api/src/main/java/jakarta/data/metamodel/constraint/NotBetween.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/NotBetween.java
@@ -23,6 +23,10 @@ public interface NotBetween<T extends Comparable<T>> extends Constraint<T> {
         return new NotBetweenRecord<>(lower, upper);
     }
 
+    NotBetween<T> ignoreCase();
+
+    boolean isCaseSensitive();
+
     T lowerBound();
 
     T upperBound();

--- a/api/src/main/java/jakarta/data/metamodel/constraint/NotBetweenRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/NotBetweenRecord.java
@@ -19,7 +19,10 @@ package jakarta.data.metamodel.constraint;
 
 import java.util.Objects;
 
-record NotBetweenRecord<T extends Comparable<T>>(T lowerBound, T upperBound)
+record NotBetweenRecord<T extends Comparable<T>>(
+        T lowerBound,
+        T upperBound,
+        boolean isCaseSensitive)
     implements NotBetween<T> {
 
     NotBetweenRecord {
@@ -27,15 +30,30 @@ record NotBetweenRecord<T extends Comparable<T>>(T lowerBound, T upperBound)
         Objects.requireNonNull(upperBound, "upperBound must not be null");
     }
 
+    NotBetweenRecord(T lowerBound, T upperBound) {
+        this(lowerBound, upperBound, lowerBound instanceof String);
+    }
+
+    @Override
+    public NotBetween<T> ignoreCase() {
+        if (!(lowerBound instanceof String)) {
+            throw new UnsupportedOperationException(
+                   "Cannot ignore case of a " + lowerBound.getClass().getName() +
+                    " typed attribute");
+        }
+        return new NotBetweenRecord<>(lowerBound, upperBound, false);
+    }
+
     @Override
     public Between<T> negate() {
-        return Between.bounds(lowerBound, upperBound);
+        return new BetweenRecord<>(lowerBound, upperBound, isCaseSensitive);
     }
 
     @Override
     public String toString() {
         return lowerBound instanceof String
-                ? "NOT BETWEEN '" + lowerBound + "' AND '" + upperBound + "'"
+                ? "NOT BETWEEN '" + lowerBound + "' AND '" + upperBound + "'" +
+                        (isCaseSensitive ? "" : " IGNORE CASE")
                 : "NOT BETWEEN " + lowerBound + " AND " + upperBound;
     }
 }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/NotEqualTo.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/NotEqualTo.java
@@ -23,5 +23,9 @@ public interface NotEqualTo<T> extends Constraint<T> {
         return new NotEqualToRecord<>(value);
     }
 
+    NotEqualTo<T> ignoreCase();
+
+    boolean isCaseSensitive();
+
     T value();
 }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/NotEqualToRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/NotEqualToRecord.java
@@ -19,19 +19,35 @@ package jakarta.data.metamodel.constraint;
 
 import java.util.Objects;
 
-record NotEqualToRecord<T>(T value) implements NotEqualTo<T> {
+record NotEqualToRecord<T>(T value, boolean isCaseSensitive) implements NotEqualTo<T> {
 
     NotEqualToRecord {
         Objects.requireNonNull(value, "value must not be null");
     }
 
+    NotEqualToRecord(T value) {
+        this(value, value instanceof String);
+    }
+
+    @Override
+    public NotEqualTo<T> ignoreCase() {
+        if (!(value instanceof String)) {
+            throw new UnsupportedOperationException(
+                   "Cannot ignore case of a " + value.getClass().getName() +
+                    " typed attribute");
+        }
+        return new NotEqualToRecord<>(value, false);
+    }
+
     @Override
     public EqualTo<T> negate() {
-        return EqualTo.value(value);
+        return new EqualToRecord<>(value, isCaseSensitive);
     }
 
     @Override
     public String toString() {
-        return value instanceof String ? "<> '" + value + "'" : "<> " + value;
+        return value instanceof String
+                ? "<> '" + value + (isCaseSensitive ? "'" : "' IGNORE CASE")
+                : "<> " + value;
     }
 }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/NotLike.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/NotLike.java
@@ -52,7 +52,11 @@ public interface NotLike extends Constraint<String> {
                                  ESCAPE);
     }
 
+    NotLike ignoreCase();
+
     Character escape();
+
+    boolean isCaseSensitive();
 
     String pattern();
 }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/NotLikeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/NotLikeRecord.java
@@ -19,20 +19,31 @@ package jakarta.data.metamodel.constraint;
 
 import java.util.Objects;
 
-record NotLikeRecord(String pattern, Character escape) implements NotLike {
+record NotLikeRecord(String pattern, Character escape, boolean isCaseSensitive)
+        implements NotLike {
 
     NotLikeRecord {
         Objects.requireNonNull(pattern, "pattern must not be null");
     }
 
+    NotLikeRecord(String pattern, Character escape) {
+        this(pattern, escape, true);
+    }
+
+    @Override
+    public NotLike ignoreCase() {
+        return new NotLikeRecord(pattern, escape, false);
+    }
+
     @Override
     public Like negate() {
-        return new LikeRecord(pattern, escape);
+        return new LikeRecord(pattern, escape, isCaseSensitive);
     }
 
     @Override
     public String toString() {
         return "NOT LIKE '" + pattern + "'" +
-               (escape == null ? "" : " ESCAPE '\\'");
+               (escape == null ? "" : " ESCAPE '\\'") +
+               (isCaseSensitive ? "" : " IGNORE CASE");
     }
 }

--- a/api/src/main/java/jakarta/data/metamodel/restrict/TextRestriction.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/TextRestriction.java
@@ -20,8 +20,12 @@ package jakarta.data.metamodel.restrict;
 import jakarta.data.metamodel.constraint.Constraint;
 
 public interface TextRestriction<T> extends BasicRestriction<T, String> {
+
+    TextRestriction<T> ignoreCase();
+
     @Override
     TextRestriction<T> negate();
+
     @Override
     Constraint<String> constraint();
 }

--- a/api/src/test/java/jakarta/data/metamodel/restrict/RestrictTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/RestrictTest.java
@@ -239,14 +239,14 @@ class RestrictTest {
 
     @Test
     void shouldIgnoreCase() {
-        // TODO TextRestriction.ignoreCase vs TextAttribute.upper/lowercased
-        TextRestriction<Employee> restriction = _Employee.position.contains("SOFTWARE");
-        //        .ignoreCase();
+        TextRestriction<Employee> restriction = _Employee.position.contains("SOFTWARE")
+                .ignoreCase();
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.attribute()).isEqualTo(_Employee.POSITION);
-            //soft.assertThat(restriction.isCaseSensitive()).isFalse();
-            soft.assertThat(restriction.constraint()).isEqualTo(Like.substring("SOFTWARE"));
+            soft.assertThat(((Like) restriction.constraint()).isCaseSensitive()).isFalse();
+            soft.assertThat(restriction.constraint()).isEqualTo(
+                    Like.substring("SOFTWARE").ignoreCase());
         });
     }
 

--- a/api/src/test/java/jakarta/data/metamodel/restrict/TextRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/TextRestrictionRecordTest.java
@@ -58,8 +58,7 @@ class TextRestrictionRecordTest {
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.attribute()).isEqualTo("title");
-            // TODO TextRestriction.ignoreCase vs TextAttribute.upper/lowercased
-            //soft.assertThat(restriction.isCaseSensitive()).isTrue();
+            soft.assertThat(((Like) restriction.constraint()).isCaseSensitive()).isTrue();
             soft.assertThat(constraint.pattern()).isEqualTo("%Java%");
             soft.assertThat(constraint.escape()).isNull();
         });
@@ -73,8 +72,7 @@ class TextRestrictionRecordTest {
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.attribute()).isEqualTo("title");
-            // TODO TextRestriction.ignoreCase vs TextAttribute.upper/lowercased
-            //soft.assertThat(restriction.isCaseSensitive()).isTrue();
+            soft.assertThat(((NotLike) restriction.constraint()).isCaseSensitive()).isTrue();
             soft.assertThat(constraint.pattern()).isEqualTo("%Java%");
             soft.assertThat(constraint.escape()).isNull();
         });
@@ -84,13 +82,12 @@ class TextRestrictionRecordTest {
     void shouldIgnoreCaseForTextRestriction() {
         TextRestriction<Book> restriction = _Book.title.like("%Java%");
 
-        // TODO TextRestriction.ignoreCase vs TextAttribute.upper/lowercased
-        //TextRestriction<String> caseInsensitiveRestriction = restriction.ignoreCase();
+        TextRestriction<Book> caseInsensitiveRestriction = restriction.ignoreCase();
         Like constraint = (Like) restriction.constraint();
 
         SoftAssertions.assertSoftly(soft -> {
-        //    soft.assertThat(caseInsensitiveRestriction.attribute()).isEqualTo("title");
-        //    soft.assertThat(caseInsensitiveRestriction.isCaseSensitive()).isFalse();
+            soft.assertThat(caseInsensitiveRestriction.attribute()).isEqualTo("title");
+            soft.assertThat(((Like) caseInsensitiveRestriction.constraint()).isCaseSensitive()).isFalse();
             soft.assertThat(constraint.pattern()).isEqualTo("%Java%");
             soft.assertThat(constraint.escape()).isNull();
         });
@@ -104,8 +101,7 @@ class TextRestrictionRecordTest {
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.attribute()).isEqualTo("title");
-            // TODO TextRestriction.ignoreCase vs TextAttribute.upper/lowercased
-            //soft.assertThat(restriction.isCaseSensitive()).isTrue();
+            soft.assertThat(((Like) restriction.constraint()).isCaseSensitive()).isTrue();
             soft.assertThat(constraint.pattern()).isEqualTo("%Java%");
             soft.assertThat(constraint.escape()).isNull();
         });
@@ -119,8 +115,7 @@ class TextRestrictionRecordTest {
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.attribute()).isEqualTo("title");
-            // TODO TextRestriction.ignoreCase vs TextAttribute.upper/lowercased
-            //soft.assertThat(restriction.isCaseSensitive()).isTrue();
+            soft.assertThat(((Like) restriction.constraint()).isCaseSensitive()).isTrue();
             soft.assertThat(constraint.pattern()).isEqualTo("%Java__");
             soft.assertThat(constraint.escape()).isEqualTo('$');
         });
@@ -130,16 +125,15 @@ class TextRestrictionRecordTest {
     void shouldNegateLikeRestriction() {
         TextRestriction<Book> likeJakartaEE = _Book.title.endsWith("Jakarta EE");
         TextRestriction<Book> notLikeJakartaEE = likeJakartaEE.negate();
-        // TODO TextRestriction.ignoreCase vs TextAttribute.upper/lowercased
-        //TextRestriction<Book> anyCaseNotLikeJakartaEE = likeJakartaEE.ignoreCase().negate();
-        //TextRestriction<Book> notLikeJakartaEEAnyCase = likeJakartaEE.negate().ignoreCase();
+        TextRestriction<Book> anyCaseNotLikeJakartaEE = likeJakartaEE.ignoreCase().negate();
+        TextRestriction<Book> notLikeJakartaEEAnyCase = likeJakartaEE.negate().ignoreCase();
 
-        //SoftAssertions.assertSoftly(soft -> {
-        //    soft.assertThat(likeJakartaEE.isCaseSensitive()).isTrue();
-        //    soft.assertThat(notLikeJakartaEE.isCaseSensitive()).isTrue();
-        //    soft.assertThat(anyCaseNotLikeJakartaEE.isCaseSensitive()).isFalse();
-        //    soft.assertThat(notLikeJakartaEEAnyCase.isCaseSensitive()).isFalse();
-        //});
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(((Like) likeJakartaEE.constraint()).isCaseSensitive()).isTrue();
+            soft.assertThat(((NotLike) notLikeJakartaEE.constraint()).isCaseSensitive()).isTrue();
+            soft.assertThat(((NotLike) anyCaseNotLikeJakartaEE.constraint()).isCaseSensitive()).isFalse();
+            soft.assertThat(((NotLike) notLikeJakartaEEAnyCase.constraint()).isCaseSensitive()).isFalse();
+        });
     }
 
     @Test
@@ -167,8 +161,7 @@ class TextRestrictionRecordTest {
     void shouldOutputToString() {
         TextRestriction<Book> titleRestriction = _Book.title.contains("Jakarta Data");
         TextRestriction<Book> authorRestriction = _Book.author.equalTo("Myself")
-                // TODO TextRestriction.ignoreCase vs TextAttribute.upper/lowercased
-                //        .ignoreCase()
+                        .ignoreCase()
                         .negate();
 
         SoftAssertions.assertSoftly(soft -> {
@@ -176,7 +169,7 @@ class TextRestrictionRecordTest {
                     title LIKE '%Jakarta Data%' ESCAPE '\\'\
                     """);
             soft.assertThat(authorRestriction.toString()).isEqualTo("""
-                    author <> 'Myself'\
+                    author <> 'Myself' IGNORE CASE\
                     """);
         });
     }
@@ -189,8 +182,7 @@ class TextRestrictionRecordTest {
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.attribute()).isEqualTo("author");
-            // TODO TextRestriction.ignoreCase vs TextAttribute.upper/lowercased
-            //soft.assertThat(restriction.isCaseSensitive()).isTrue();
+            soft.assertThat(constraint.isCaseSensitive()).isTrue();
             soft.assertThat(constraint.value()).isEqualTo("John Doe");
         });
     }


### PR DESCRIPTION
Option 2 for case insensitive Constraints:
Add `.ignoreCase()` to specific subtypes of `Constraint` that are capable of case insensitive comparisons when operating on `String` values.  This includes `Like`, `NotLike`, `EqualTo`, `NotEqualTo`, `Between`, `NotBetween`, and the various GT/LT/GTE/LTE constraints.  If a user ever invokes `ignoreCase()` on a constraint that has a non-String value, it will raise UnsupportedOperationException.
Provide an `isCaseSensitive()` method for each of these same subtypes to determine if a `Constraint` performs case insensitive comparisons, defaulting it based on whether the value is a `String` (`true` for `String` and `false` for others). When it starts as `true`, an instance with `false` can be obtained by invoking `ignoreCase()`.

Example usage:

```
List<Book> booksTitled(Constraint<String> title);

found = library.booksTitled(Constraint.equalTo("Developing with Jakarta Data").ignoreCase());
```

We should choose between this PR or #1005 (or if someone thinks of another way) for case-insensitive constraints