### PR TITLE
Pagination examples should encourage use of Page rather than array

### DIFF
--- a/api/src/main/java/jakarta/data/page/PageRequest.java
+++ b/api/src/main/java/jakarta/data/page/PageRequest.java
@@ -39,19 +39,19 @@ import java.util.Optional;
  * <pre>
  * &#64;OrderBy("age")
  * &#64;OrderBy("ssn")
- * Person[] findByAgeBetween(int minAge, int maxAge, PageRequest pageRequest);
+ * Page&lt;Person&gt; findByAgeBetween(int minAge, int maxAge, PageRequest pageRequest);
  * </pre>
  *
  * <p>This method might be called as follows:</p>
  *
  * <pre>
- * var page = people.findByAgeBetween(35, 59,
- *                PageRequest.ofSize(100));
- * var results = page.content();
+ * Page&lt;Person&gt; page = people.findByAgeBetween(35, 59,
+ *                     PageRequest.ofSize(100));
+ * List&lt;Person&gt; results = page.content();
  * ...
  * while (page.hasNext()) {
  *     page = people.findByAgeBetween(35, 59,
- *                page.nextPageRequest().withoutTotal());
+ *                     page.nextPageRequest().withoutTotal());
  *     results = page.content();
  *   ...
  * }

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -786,7 +786,7 @@ import java.util.Set;
  * allows its results to be split and retrieved in pages. For example,</p>
  *
  * <pre>
- * Product[] findByNameLikeOrderByAmountSoldDescIdAsc(
+ * Page&lt;Product&gt; findByNameLikeOrderByAmountSoldDescIdAsc(
  *                 String pattern, PageRequest pageRequest);
  * ...
  * page1 = products.findByNameLikeOrderByAmountSoldDescIdAsc(
@@ -804,11 +804,11 @@ import java.util.Set;
  * For example,</p>
  *
  * <pre>
- * Product[] findByNameLikeAndPriceBetween(String pattern,
- *                                         float minPrice,
- *                                         float maxPrice,
- *                                         PageRequest pageRequest,
- *                                         Order&lt;Product&gt; order);
+ * Page&lt;Product&gt; findByNameLikeAndPriceBetween(String pattern,
+ *                                             float minPrice,
+ *                                             float maxPrice,
+ *                                             PageRequest pageRequest,
+ *                                             Order&lt;Product&gt; order);
  *
  * ...
  * PageRequest page1Request = PageRequest.ofSize(25);


### PR DESCRIPTION
While looking up some information on pagination, I noticed that our main examples to users on how to use pagination have repository methods returning an array rather than a `Page`.  It is valid to return an array, except not for the example, which won't compile because it shows `Page.content()` being subsequently invoked on the array return value, and then again later on.  This needs to be corrected, preferably by returning `Page` instead.