### PR TITLE
Remove extra incorrect String from example

### DIFF
--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -920,7 +920,7 @@ import java.util.Set;
  * <pre>
  * public record Name(String firstName,
  *                    String middleName,
- *                    String &#64;Select("lastName") String surname) {}
+ *                    &#64;Select("lastName") String surname) {}
  *
  * &#64;Query("FROM Person WHERE ssn=?1")
  * Optional&lt;Name&gt; getName(long socialSecurityNum);


### PR DESCRIPTION
Fixes the documentation bug found by @luckygc in https://github.com/jakartaee/data/commit/040f0c6010e4f420c50112a2a3cebe77b55f28a0#r153616089