### PR TITLE
add PageRequest.page(long)

### DIFF
--- a/api/src/main/java/jakarta/data/page/PageRequest.java
+++ b/api/src/main/java/jakarta/data/page/PageRequest.java
@@ -241,6 +241,17 @@ public interface PageRequest {
 
     /**
      * <p>Creates a new page request with the same pagination information,
+     * but with the specified page number.</p>
+     *
+     * @param pageNumber the page number.
+     * @return a new instance of {@code PageRequest}.
+     *         This method never returns {@code null}.
+     * @since 1.1
+     */
+    PageRequest page(long pageNumber);
+
+    /**
+     * <p>Creates a new page request with the same pagination information,
      * but with the specified maximum page size. When a page is retrieved
      * from the database, the number of elements in the page must be equal
      * to the maximum page size unless there is an insufficient number of

--- a/api/src/main/java/jakarta/data/page/Pagination.java
+++ b/api/src/main/java/jakarta/data/page/Pagination.java
@@ -78,4 +78,9 @@ record Pagination(long page, int size, Mode mode, Cursor type, boolean requestTo
         return new Pagination(page, maxPageSize, mode, type, requestTotal);
     }
 
+    @Override
+    public PageRequest page(long pageNumber) {
+        return new Pagination(pageNumber, size, mode, type, requestTotal);
+    }
+
 }


### PR DESCRIPTION
Does anyone remember if there was a good reason that `PageRequest` doesn't offer the ability to mutate the page number?

Because to me it feels much more natural to write `Page.ofSize(PAGE_SIZE).page(pageNumber)` than `Page.ofPage(pageNumber).size(PAGE_SIZE)`.