### PR TITLE
Disallow multiple Select values on a record component

### DIFF
--- a/api/src/main/java/jakarta/data/repository/Select.java
+++ b/api/src/main/java/jakarta/data/repository/Select.java
@@ -19,6 +19,7 @@ package jakarta.data.repository;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -30,13 +31,16 @@ import java.lang.annotation.Target;
  * <p>This annotation can be specified on a repository find method or
  * on a record component.</p>
  *
- * <p>When used on a repository find method, the {@link value} of this annotation
- * must be the name(s) of one or more entity attributes to use as query results
- * when an entity matches the restrictions imposed by the method.</p>
+ * <p>When used on a repository find method that returns an entity attribute
+ * type, at most one {@code Select} annotation can annotate the method.</p>
  *
- * <p>When used on a record component, the {@link value} of this annotation
- * must be the name of the entity attribute to which the record component
- * corresponds. This value is used for all repository methods that lack this
+ * <p>When used on a repository find method that returns a Java record type,
+ * multiple {@code Select} annotations may annotate the method, one for each
+ * record component. The number and order of {@code Select} annotations must
+ * match the number and order of record components.</p>
+ *
+ * <p>When used on a record component, the {@code Select} annotation
+ * value is used for all repository methods that lack this
  * annotation and for which the record is the result type.</p>
  *
  * <p>This annotation must not be used in other locations.</p>
@@ -44,11 +48,12 @@ import java.lang.annotation.Target;
  * @see Find
  */
 @Documented
+@Repeatable(Select.List.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.RECORD_COMPONENT })
 public @interface Select {
     /**
-     * <p>Name or names of an entity attribute(s) that have a single-valued
+     * <p>Name of an entity attribute that has a single-valued
      * basic type. Multiple-valued types such as collections, arrays, and
      * associations cannot be retrieved independently of the entity.</p>
      *
@@ -82,8 +87,8 @@ public @interface Select {
      *
      * <h3>Annotating a Repository Method</h3>
      *
-     * <p>Place the {@code Select} annotation on a repository find method and
-     * assign the annotation value to be the names of multiple entity attributes,
+     * <p>Place one or more {@code Select} annotations on a repository find method
+     * and assign the annotation values to be the names of entity attributes,
      * corresponding to the order and types of the components of the Java record
      * that is used for the result type.</p>
      *
@@ -99,7 +104,9 @@ public @interface Select {
      *                      int designYear) {}
      *
      *     &#64;Find
-     *     &#64;Select({_Car.MODEL, _Car.MAKE, _Car.YEAR})
+     *     &#64;Select(_Car.MODEL)
+     *     &#64;Select(_Car.MAKE)
+     *     &#64;Select(_Car.YEAR)
      *     Optional&lt;ModelInfo&gt; getModelInfo(@By(_Car.VIN) String vehicleIdNum);
      * }
      * </pre>
@@ -131,5 +138,23 @@ public @interface Select {
      * {@linkplain jakarta.data/jakarta.data.metamodel static metamodel},
      * to avoid hard coding String values for the entity attribute names.</p>
      */
-    String[] value();
+    String value();
+
+    /**
+     * Enables multiple {@link Select} annotations on a repository {@link Find}
+     * method that returns a Java record type. Multiple {@code Select} annotations
+     * must not be used on any other types of method.
+     */
+    @Documented
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD) // RECORD_COMPONENT is intentionally omitted
+    @interface List {
+        /**
+         * Returns a list of annotations with the first corresponding to the first
+         * record component, the second to the second record component, and so forth.
+         *
+         * @return list of annotations.
+         */
+        Select[] value();
+    }
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
@@ -115,8 +115,8 @@ public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long>, I
     long twentyFour();
 
     @Find(NaturalNumber.class) // this is not the primary entity type
-    @Select({ _NaturalNumber.NUMTYPEORDINAL,
-              _NaturalNumber.FLOOROFSQUAREROOT,
-              _NaturalNumber.ID })
+    @Select(_NaturalNumber.NUMTYPEORDINAL)
+    @Select(_NaturalNumber.FLOOROFSQUAREROOT)
+    @Select(_NaturalNumber.ID)
     List<WholeNumber> wholeNumbers(Short numBitsRequired);
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers.java
@@ -130,29 +130,29 @@ public interface NaturalNumbers extends BasicRepository<NaturalNumber, Long>, Id
     Optional<NaturalNumber> two();
 
     @Find
-    @Select({ _NaturalNumber.NUMTYPEORDINAL,
-              _NaturalNumber.FLOOROFSQUAREROOT,
-              _NaturalNumber.ID })
+    @Select(_NaturalNumber.NUMTYPEORDINAL)
+    @Select(_NaturalNumber.FLOOROFSQUAREROOT)
+    @Select(_NaturalNumber.ID)
     List<WholeNumber> wholeNumberList(@By(_NaturalNumber.NUMTYPEORDINAL) int numType,
                                       Order<NaturalNumber> order);
 
     @Find
-    @Select({ _NaturalNumber.NUMTYPEORDINAL,
-              _NaturalNumber.FLOOROFSQUAREROOT,
-              _NaturalNumber.ID })
+    @Select(_NaturalNumber.NUMTYPEORDINAL)
+    @Select(_NaturalNumber.FLOOROFSQUAREROOT)
+    @Select(_NaturalNumber.ID)
     Optional<WholeNumber> wholeNumberOf(@By(ID) int id);
 
     @Find
-    @Select({ _NaturalNumber.NUMTYPEORDINAL,
-              _NaturalNumber.FLOOROFSQUAREROOT,
-              _NaturalNumber.ID })
+    @Select(_NaturalNumber.NUMTYPEORDINAL)
+    @Select(_NaturalNumber.FLOOROFSQUAREROOT)
+    @Select(_NaturalNumber.ID)
     WholeNumber[] wholeNumbers(@By(_NaturalNumber.FLOOROFSQUAREROOT) int floorOfSquareRoot,
                                Order<NaturalNumber> order);
 
     @Find
-    @Select({ _NaturalNumber.NUMTYPEORDINAL,
-              _NaturalNumber.FLOOROFSQUAREROOT,
-              _NaturalNumber.ID })
+    @Select(_NaturalNumber.NUMTYPEORDINAL)
+    @Select(_NaturalNumber.FLOOROFSQUAREROOT)
+    @Select(_NaturalNumber.ID)
     Page<WholeNumber> wholeNumberPage(@By(_NaturalNumber.NUMTYPEORDINAL) int numType,
                                       PageRequest pageReq,
                                       Order<NaturalNumber> order);


### PR DESCRIPTION
This is an idea for a possible improvement to `@Select` that will switch its `value` from an array to a single item to prevent the following which do not make sense:

- `@Select({ "attributeName1", "attributeName2", ... })` on a single record component
- `@Select({})`

The only place where we need multiple entity attribute names is on a repository method, and so this PR proposes to make the annotation repeatable (as we have for `OrderBy`) on a method,

```
@Repeatable(Select.List.class)
```

```
    @Target(ElementType.METHOD) // RECORD_COMPONENT is intentionally omitted
    @interface List {
```

See the updated TCK tests for examples of usage.

It's a little bit more to type when specified on a method that returns a record. However, it does format nicely and has consistency with existing usage of `OrderBy`. Also, `@Select` on a repository method is useful when you want to map results to a third-party provided record class that you can't modify to add the `@Select` to or you are sharing the same record class for different purposes and cannot have the `@Select` there or need to override it. These are both less often encountered scenarios outside of core usage, so it could make sense to trade off making it at little bit more verbose here to better enforce valid usage and eliminate the possibility of doing some nonsensical things with it.

What do others think about this?  I'm fine with it either way and this is pretty minor, but I thought it was a potential improvement that deserved to be considered.