### PR TITLE
javadoc should point to the First annotation as a solution to NonUniqueResultException

### DIFF
--- a/api/src/main/java/jakarta/data/exceptions/NonUniqueResultException.java
+++ b/api/src/main/java/jakarta/data/exceptions/NonUniqueResultException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,20 @@
  */
 package jakarta.data.exceptions;
 
+import jakarta.data.repository.Find;
+import jakarta.data.repository.First;
+import jakarta.data.repository.Query;
+
 /**
- * This exception is raised when execution of a repository method with a singular
- * return type finds multiple results. This error may be circumvented using the
- * {@code findFirst...} method name pattern or by supplying {@code Limit.of(1)}
- * as a parameter to explicitly request only the first result.
+ * <p>This exception is raised when execution of a repository method with a singular
+ * return type finds multiple results.</p>
+ *
+ * <p>This error can be circumvented by applying the {@link First @First} annotation
+ * to a repository {@link Find} or {@link Query} method to explicitly request that
+ * at most one result be returned.
+ * Alternatively, if using the Query by Method Name pattern, the
+ * {@code findFirst...} method name pattern can be used to explicitly request that
+ * at most one result be returned.</p>
  */
 public class NonUniqueResultException extends DataException {
     private static final long serialVersionUID = 7742411163016495764L;

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import jakarta.data.Limit;
 import jakarta.data.Order;
 import jakarta.data.Sort;
+import jakarta.data.exceptions.NonUniqueResultException;
 import jakarta.data.metamodel.StaticMetamodel;
 import jakarta.data.page.PageRequest;
 import jakarta.data.repository.BasicRepository;
@@ -29,6 +30,7 @@ import jakarta.data.repository.CrudRepository;
 import jakarta.data.repository.DataRepository;
 import jakarta.data.repository.Delete;
 import jakarta.data.repository.Find;
+import jakarta.data.repository.First;
 import jakarta.data.repository.Insert;
 import jakarta.data.repository.OrderBy;
 import jakarta.data.repository.Param;
@@ -745,10 +747,11 @@ import java.util.Set;
  *
  * <pre>
  * // Query by Method Name
- * Vehicle[] findByMakeAndModelAndYear(String makerName, String model, int year, Sort&lt;?&gt;... sorts);
+ * Vehicle[] findFirst50ByMakeAndModelAndYear(String makerName, String model, int year, Sort&lt;?&gt;... sorts);
  *
  * // parameter-based conditions
  * &#64;Find
+ * &#64;First(50)
  * Vehicle[] searchFor(String make, String model, int year, Sort&lt;?&gt;... sorts);
  * </pre>
  *
@@ -845,6 +848,22 @@ import java.util.Set;
  *                                 Sort.desc("price"),
  *                                 Sort.desc("amountSold"),
  *                                 Sort.asc("name"));
+ * </pre>
+ *
+ * <h2>Maximum number of results</h2>
+ *
+ * <p>Apply the {@link First @First} annotation to a repository {@link Find} or
+ * {@link Query} method to establish a maximum number of results across all
+ * usage of the method. The default value of 1 allows you to avoid the
+ * {@link NonUniqueResultException} that would normally occurs when multiple
+ * entities match a query that is performed by a repository method that has a
+ * singular result type. For example,</p>
+ *
+ * <pre>
+ * &#64;Find
+ * &#64;First
+ * &#64;OrderBy("hourlyWage")
+ * Optional&lt;Employee&gt; withLowestWage(String jobRole);
  * </pre>
  *
  * <h2>Returning subsets of entity attributes</h2>


### PR DESCRIPTION
Javadoc should point to the `@First` annotation as a solution to `NonUniqueResultException` rather than `Limit.of(1)`, which relies on the user of the method to always supply a `1` value.

Also, our main Javadoc starting page that highlights available spec function should mention `@First` and include an example of it.  That page also has a side-by-side comparison of a parameter-based find method vs a Query by Method Name find method and it would be nice to include `@First` there as well now that we have an alternative to the Query by Method Name `findFirst#By` name pattern.