### PR TITLE
First unit tests to experiment with expressions

### DIFF
--- a/api/src/test/java/jakarta/data/metamodel/expression/ExpressionTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/expression/ExpressionTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data.metamodel.expression;
+
+import jakarta.data.metamodel.Expression;
+import jakarta.data.metamodel.constraint.*;
+import jakarta.data.metamodel.restrict.BasicRestriction;
+import jakarta.data.metamodel.restrict.Restriction;
+import jakarta.data.mock.entity.Book;
+import jakarta.data.mock.entity._Book;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+
+class ExpressionTest {
+
+    @Test
+    void shouldRestrictLast2ofFirst10Chars() {
+
+        Restriction<Book> titleWithEE =
+            _Book.title.left(10).right(2).upper().equalTo("EE");
+
+        @SuppressWarnings("unchecked")
+        BasicRestriction<Book, String> restriction =
+            (BasicRestriction<Book, String>) titleWithEE;
+
+        Constraint<String> constraint = restriction.constraint();
+
+        TextFunctionExpression<Book> upperExpression =
+            (TextFunctionExpression<Book>) restriction.expression();
+
+        List<? extends Expression<Book, ?>> upperArgs = upperExpression.arguments();
+        assertEquals(1, upperArgs.size());
+
+        @SuppressWarnings("unchecked")
+        TextFunctionExpression<Book> rightExpression =
+            (TextFunctionExpression<Book>) upperArgs.get(0);
+
+        List<? extends Expression<Book, ?>> rightArgs = rightExpression.arguments();
+        assertEquals(2, rightArgs.size());
+
+        assertEquals(true, rightArgs.get(1) instanceof NumericLiteral);
+
+        @SuppressWarnings("unchecked")
+        NumericLiteral<Book, Integer> rightArg1 =
+            (NumericLiteral<Book, Integer>) rightArgs.get(1);
+
+        @SuppressWarnings("unchecked")
+        TextFunctionExpression<Book> leftExpression =
+            (TextFunctionExpression<Book>) rightArgs.get(0);
+
+        List<? extends Expression<Book, ?>> leftArgs = leftExpression.arguments();
+        assertEquals(2, leftArgs.size());
+
+        assertEquals(true, leftArgs.get(1) instanceof NumericLiteral);
+
+        @SuppressWarnings("unchecked")
+        NumericLiteral<Book, Integer> leftArg1 =
+            (NumericLiteral<Book, Integer>) leftArgs.get(1);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(restriction.attribute())
+                .isNull(); // restriction on an expression that is not an attribute
+
+            soft.assertThat(leftExpression.name())
+                .isEqualTo(TextFunctionExpression.LEFT);
+
+            soft.assertThat(leftArgs.get(0))
+                .isEqualTo(_Book.title);
+
+            soft.assertThat(leftArg1.value())
+                .isEqualTo(10);
+
+            soft.assertThat(rightExpression.name())
+                .isEqualTo(TextFunctionExpression.RIGHT);
+
+            soft.assertThat(rightArg1.value())
+                .isEqualTo(2);
+
+            soft.assertThat(upperExpression.name())
+                .isEqualTo(TextFunctionExpression.UPPER);
+
+            soft.assertThat(constraint)
+                .isInstanceOf(EqualTo.class);
+
+            soft.assertThat(((EqualTo<String>) constraint).value())
+                .isEqualTo("EE");
+        });
+    }
+
+    @Test
+    void shouldRestrictLengthOfText() {
+
+        Restriction<Book> titleUpTo50Chars = _Book.title.length().lessThanEqual(50);
+
+        @SuppressWarnings("unchecked")
+        BasicRestriction<Book, Integer> restriction =
+            (BasicRestriction<Book, Integer>) titleUpTo50Chars;
+
+        Constraint<Integer> constraint = restriction.constraint();
+
+        NumericFunctionExpression<Book, Integer> lengthExpression =
+            (NumericFunctionExpression<Book, Integer>) restriction.expression();
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(restriction.attribute())
+                .isNull(); // restriction on an expression that is not an attribute
+
+            soft.assertThat(lengthExpression.name())
+                .isEqualTo(NumericFunctionExpression.LENGTH);
+
+            soft.assertThat(lengthExpression.arguments().size())
+                .isEqualTo(1);
+
+            soft.assertThat(lengthExpression.arguments().get(0))
+                .isEqualTo(_Book.title);
+
+            soft.assertThat(constraint)
+                .isInstanceOf(LessThanOrEqual.class);
+
+            soft.assertThat(((LessThanOrEqual<Integer>) constraint).bound())
+                .isEqualTo(50);
+        });
+    }
+}

--- a/api/src/test/java/jakarta/data/metamodel/restrict/BasicRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/BasicRestrictionRecordTest.java
@@ -18,9 +18,9 @@
 package jakarta.data.metamodel.restrict;
 
 import jakarta.data.metamodel.BasicAttribute;
-import jakarta.data.metamodel.ComparableAttribute;
-import jakarta.data.metamodel.TextAttribute;
 import jakarta.data.metamodel.constraint.*;
+import jakarta.data.mock.entity.Book;
+import jakarta.data.mock.entity._Book;
 
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
@@ -29,34 +29,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 
 class BasicRestrictionRecordTest {
-    // A mock static metamodel class for tests
-    interface _Book {
-        String AUTHOR = "author";
-        String ID = "id";
-        String NUMCHAPTERS = "numChapters";
-        String NUMPAGES = "numPages";
-        String TITLE = "title";
-
-        BasicAttribute<Book, String> author = BasicAttribute.of(
-                Book.class, AUTHOR, String.class);
-        TextAttribute<Book> id = TextAttribute.of(
-                Book.class, ID);
-        ComparableAttribute<Book, Integer> numChapters = ComparableAttribute.of(
-                Book.class, NUMCHAPTERS, int.class);
-        ComparableAttribute<Book, Integer> numPages = ComparableAttribute.of(
-                Book.class, NUMPAGES, int.class);
-        BasicAttribute<Book, String> title = BasicAttribute.of(
-                Book.class, TITLE, String.class);
-    }
-
-    // A mock entity class for tests
-    static class Book {
-        String author;
-        String id;
-        int numChapters;
-        int numPages;
-        String title;
-    }
 
     @Test
     void shouldCreateBasicRestrictionWithDefaultNegation() {

--- a/api/src/test/java/jakarta/data/metamodel/restrict/TextRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/TextRestrictionRecordTest.java
@@ -21,6 +21,8 @@ import jakarta.data.metamodel.TextAttribute;
 import jakarta.data.metamodel.constraint.Like;
 import jakarta.data.metamodel.constraint.NotEqualTo;
 import jakarta.data.metamodel.constraint.NotLike;
+import jakarta.data.mock.entity.Book;
+import jakarta.data.mock.entity._Book;
 
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
@@ -29,26 +31,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 
 class TextRestrictionRecordTest {
-    // A mock static metamodel class for tests
-    interface _Book {
-        String AUTHOR = "author";
-        String ID = "id";
-        String TITLE = "title";
-
-        TextAttribute<Book> author = TextAttribute.of(
-                Book.class, AUTHOR);
-        TextAttribute<Book> id = TextAttribute.of(
-                Book.class, ID);
-        TextAttribute<Book> title = TextAttribute.of(
-                Book.class, TITLE);
-    }
-
-    // A mock entity class for tests
-    static class Book {
-        String author;
-        String id;
-        String title;
-    }
 
     @Test
     void shouldCreateTextRestrictionWithDefaultValues() {

--- a/api/src/test/java/jakarta/data/mock/entity/Book.java
+++ b/api/src/test/java/jakarta/data/mock/entity/Book.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data.mock.entity;
+
+/**
+ * A mock entity class for tests
+ */
+public class Book {
+    String author;
+    String id;
+    int numChapters;
+    int numPages;
+    String title;
+}

--- a/api/src/test/java/jakarta/data/mock/entity/_Book.java
+++ b/api/src/test/java/jakarta/data/mock/entity/_Book.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data.mock.entity;
+
+import jakarta.data.metamodel.BasicAttribute;
+import jakarta.data.metamodel.ComparableAttribute;
+import jakarta.data.metamodel.TextAttribute;
+
+/**
+ * A mock static metamodel class for tests
+ */
+public interface _Book {
+    String AUTHOR = "author";
+    String ID = "id";
+    String NUMCHAPTERS = "numChapters";
+    String NUMPAGES = "numPages";
+    String TITLE = "title";
+
+    BasicAttribute<Book, String> author = BasicAttribute.of(
+            Book.class, AUTHOR, String.class);
+    TextAttribute<Book> id = TextAttribute.of(
+            Book.class, ID);
+    ComparableAttribute<Book, Integer> numChapters = ComparableAttribute.of(
+            Book.class, NUMCHAPTERS, int.class);
+    ComparableAttribute<Book, Integer> numPages = ComparableAttribute.of(
+            Book.class, NUMPAGES, int.class);
+    TextAttribute<Book> title = TextAttribute.of(
+            Book.class, TITLE);
+}


### PR DESCRIPTION
This PR moves the Book entity and static metamodel class to a common location where unit tests can share it (first commit) and then adds the first two unit tests to try out Expressions and ensure they are capturing the information that will be needed to construct a query.