### PR TITLE
Fix breaking change with declaringType()

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/Attribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/Attribute.java
@@ -48,8 +48,15 @@ public interface Attribute<T> {
 
     /**
      * Obtain the Java class which declares this entity attribute.
+     * This is only guaranteed to be known if a static <code>of</code> method,
+     * such as {@link BasicAttribute#of(Class, String, Class)},
+     * was used to obtain the instance.
+     *
      * @return the declaring class
+     * @throws UnsupportedOperationException if the declaring type is not known.
      * @since 1.1
      */
-    Class<T> declaringType();
+    default Class<T> declaringType() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/api/src/main/java/jakarta/data/metamodel/Attribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/Attribute.java
@@ -48,9 +48,9 @@ public interface Attribute<T> {
 
     /**
      * Obtain the Java class which declares this entity attribute.
-     * This is only guaranteed to be known if a static <code>of</code> method,
-     * such as {@link BasicAttribute#of(Class, String, Class)},
-     * was used to obtain the instance.
+     * @apiNote This is only guaranteed to be known if a static <code>of</code> method,
+     *          such as {@link BasicAttribute#of(Class, String, Class)}, was used to obtain 
+     *          the instance.
      *
      * @return the declaring class
      * @throws UnsupportedOperationException if the declaring type is not known.


### PR DESCRIPTION
Fixes the compile failure in the TCK by fixing the breaking change from Attribute.declaringType