### PR TITLE
message for unsupported exception on declaringType

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/Attribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/Attribute.java
@@ -57,6 +57,11 @@ public interface Attribute<T> {
      * @since 1.1
      */
     default Class<T> declaringType() {
-        throw new UnsupportedOperationException();
+        throw new UnsupportedOperationException(getClass().getName() + """
+                 was obtained in a way that does not identify the entity class\
+                 that declares the attribute. Static metamodel classes should\
+                 use the .of method that is defined on the Attribute subtype\
+                 to provide the entity class.\
+                """);
     }
 }


### PR DESCRIPTION
Address review comment from @otaviojava to include a message on the UnsupportedOperationException that is raised by Attribute.declaringType()