### PR TITLE
Prefer NumericAttribute over ComparableAttribute and SortableAttribute

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/Attribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/Attribute.java
@@ -34,7 +34,7 @@ package jakarta.data.metamodel;
  *     comparable. Generally this subtype is unused but is applicable for
  *     databases that allow sorting on attributes of type {@code byte[]}.</li>
  * <li>{@link NavigableAttribute} for entity attributes that have attributes
- *     of their own. This is used for embeddables and relation attributes of
+ *     of their own. This is used for embeddables and associations to other
  *     entities.</li>
  * <li>{@link BasicAttribute} for other types of entity attributes, such as
  *     collections, embeddables, and other relation attributes.</li>

--- a/api/src/main/java/jakarta/data/metamodel/Attribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/Attribute.java
@@ -24,12 +24,18 @@ package jakarta.data.metamodel;
  * <ul>
  * <li>{@link TextAttribute} for entity attributes that represent text,
  *     typically of type {@link String}.</li>
+ * <li>{@link NumericAttribute} for entity attributes that represent numeric
+ *     values, such as {@code int}, {@link Long}, and {@link java.math.BigDecimal}.
+ *     </li>
  * <li>{@link ComparableAttribute} for entity attributes that represent other
- *     sortable and comparable values, such as {@code int}, {@link Long},
- *     {@code boolean}, {@link java.time.LocalDateTime}, and enumerations.</li>
+ *     sortable and comparable values, such as {@code boolean},
+ *     {@link java.time.LocalDateTime}, and enumerations.</li>
  * <li>{@link SortableAttribute} for entity types that are sortable, but not
  *     comparable. Generally this subtype is unused but is applicable for
- *     databases that allow sorting on {@code byte[]} attributes. </li>
+ *     databases that allow sorting on {@code byte[]} attributes.</li>
+ * <li>{@link NavigableAttribute} for entity attributes that have attributes
+ *     of their own. This is used for embeddables and relation attributes of
+ *     entities.</li>
  * <li>{@link BasicAttribute} for other types of entity attributes, such as
  *     collections, embeddables, and other relation attributes.</li>
  * </ul>

--- a/api/src/main/java/jakarta/data/metamodel/Attribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/Attribute.java
@@ -32,7 +32,7 @@ package jakarta.data.metamodel;
  *     {@link java.time.LocalDateTime}, and enumerations.</li>
  * <li>{@link SortableAttribute} for entity types that are sortable, but not
  *     comparable. Generally this subtype is unused but is applicable for
- *     databases that allow sorting on {@code byte[]} attributes.</li>
+ *     databases that allow sorting on attributes of type {@code byte[]}.</li>
  * <li>{@link NavigableAttribute} for entity attributes that have attributes
  *     of their own. This is used for embeddables and relation attributes of
  *     entities.</li>

--- a/api/src/main/java/jakarta/data/metamodel/ComparableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/ComparableAttribute.java
@@ -45,7 +45,7 @@ import java.util.Objects;
  * <p>Where possible, {@code ComparableAttribute}, which provides more function,
  * is preferred over {@link SortableAttribute}. Likewise, subtypes of
  * {@code ComparableAttribute}, such as {@link NumericAttribute} and
- * {@link TextAttribute} are preferred over {@code ComparableAttribute}.</p>
+ * {@link TextAttribute}, are preferred over {@code ComparableAttribute}.</p>
  *
  * @param <T> entity class of the static metamodel.
  * @param <V> type of entity attribute (or wrapper type if primitive).

--- a/api/src/main/java/jakarta/data/metamodel/ComparableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/ComparableAttribute.java
@@ -29,8 +29,6 @@ import java.util.Objects;
  * <p>Entity attribute types that are comparable include:</p>
  *
  * <ul>
- * <li>numeric attributes, such as {@code long}, {@link Float}, and
- *     {@link java.math.BigInteger}</li>
  * <li>time attributes, such as {@link java.time.LocalDateTime} and
  *     {@link java.time.Instant}</li>
  * <li>boolean attributes: {@code boolean} and {@link Boolean}</li>
@@ -38,16 +36,16 @@ import java.util.Objects;
  *     based on {@link Enum#ordinal()} or {@link Enum#name()}.
  *     The Jakarta Persistence default of {@code ordinal} can be overridden
  *     with the {@code jakarta.persistence.Enumerated} annotation.</li>
+ * <li>numeric attributes, such as {@code long}, {@link Float}, and
+ *     {@link java.math.BigInteger} - Use the {@link NumericAttribute} subtype
+ *     instead</li>
  * <li>textual attributes - Use the {@link TextAttribute} subtype instead</li>
  * </ul>
  *
- * <p>Primitive types such as {@code int} and {@code float} are considered
- * comparable even though they do not implement the {@link Comparable}
- * interface because the corresponding wrapper types, such as {@link Integer},
- * do implement {@code Comparable}.</p>
- *
  * <p>Where possible, {@code ComparableAttribute}, which provides more function,
- * is preferred over {@link SortableAttribute}.</p>
+ * is preferred over {@link SortableAttribute}. Likewise, subtypes of
+ * {@code ComparableAttribute}, such as {@link NumericAttribute} and
+ * {@link TextAttribute} are preferred over {@code ComparableAttribute}.</p>
  *
  * @param <T> entity class of the static metamodel.
  * @param <V> type of entity attribute (or wrapper type if primitive).

--- a/api/src/main/java/jakarta/data/metamodel/NavigableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/NavigableAttribute.java
@@ -21,8 +21,28 @@ import jakarta.data.metamodel.impl.NavigableAttributeRecord;
 
 import java.util.Objects;
 
+/**
+ * <p>Represents an entity attribute that is an embeddable or relation.
+ * These types of entity attributes have attributes of their own that can
+ * be navigated to.</p>
+ *
+ * @param <T> entity class of the static metamodel.
+ * @param <U> type of entity attribute.
+ */
 public interface NavigableAttribute<T,U>
         extends Attribute<T>, NavigableExpression<T,U> {
+
+    /**
+     * <p>Creates a static metamodel {@code NavigableAttribute} representing the
+     * entity attribute with the specified name.</p>
+     *
+     * @param <T> entity class of the static metamodel.
+     * @param <U> type of entity attribute.
+     * @param entityClass   the entity class.
+     * @param name          the name of the entity attribute.
+     * @param attributeType type of the entity attribute.
+     * @return instance of {@code NavigableAttribute}.
+     */
     static <T,U> NavigableAttribute<T,U> of(Class<T> entityClass,
                                             String name,
                                             Class<U> attributeType) {

--- a/api/src/main/java/jakarta/data/metamodel/NavigableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/NavigableAttribute.java
@@ -22,7 +22,7 @@ import jakarta.data.metamodel.impl.NavigableAttributeRecord;
 import java.util.Objects;
 
 /**
- * <p>Represents an entity attribute that is an embeddable or relation.
+ * <p>Represents an entity attribute that is an embeddable or association to another entity.
  * These types of entity attributes have attributes of their own that can
  * be navigated to.</p>
  *

--- a/api/src/main/java/jakarta/data/metamodel/NumericAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/NumericAttribute.java
@@ -47,7 +47,7 @@ import java.util.Objects;
  */
 
 public interface NumericAttribute<T,N extends Number & Comparable<N>>
-        extends BasicAttribute<T,N>, NumericExpression<T, N> {
+        extends ComparableAttribute<T,N>, NumericExpression<T, N> {
 
     /**
      * <p>Creates a static metamodel {@code NumericAttribute} representing the

--- a/api/src/main/java/jakarta/data/metamodel/NumericAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/NumericAttribute.java
@@ -22,7 +22,7 @@ import jakarta.data.metamodel.impl.NumericAttributeRecord;
 import java.util.Objects;
 
 /**
- * <p>Represents a numeric entity attribute in the {@link StaticMetamodel}.
+ * <p>Represents a {@linkplain Number numeric} entity attribute in the {@link StaticMetamodel}.
  * Numeric entity attributes can be sorted on in query results and can be
  * compared against values in query restrictions. They can also be used as
  * and within numeric expressions involving various arithmetic operations.

--- a/api/src/main/java/jakarta/data/metamodel/NumericAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/NumericAttribute.java
@@ -21,10 +21,47 @@ import jakarta.data.metamodel.impl.NumericAttributeRecord;
 
 import java.util.Objects;
 
+/**
+ * <p>Represents a numeric entity attribute in the {@link StaticMetamodel}.
+ * Numeric entity attributes can be sorted on in query results and can be
+ * compared against values in query restrictions. They can also be used as
+ * and within numeric expressions involving various arithmetic operations.
+ * </p>
+ *
+ * <p>Entity attribute types that are considered numeric include:</p>
+ *
+ * <ul>
+ * <li>numeric primitve types: {@code byte}, {@code double}, {@code float},
+ *     {@code int}, {@code long}, {@code short}</li>
+ * <li>numeric wrapper types: {@link Byte}, {@link Double}, {@link Float},
+ *     {@link Integer}, {@link Long}, {@link Short}</li>
+ * <li>{@link java.math.BigDecimal} and {@link java.math.BigInteger}</li>
+ * </ul>
+ *
+ * <p>Where possible, {@code NumericAttribute}, which provides more function,
+ * is preferred over {@link ComparableAttribute} and {@link SortableAttribute}.
+ * </p>
+ *
+ * @param <T> entity class of the static metamodel.
+ * @param <N> type of entity attribute (or wrapper type if primitive).
+ */
+
 public interface NumericAttribute<T,N extends Number & Comparable<N>>
         extends BasicAttribute<T,N>, NumericExpression<T, N> {
-    static <T,N extends Number & Comparable<N>> NumericAttribute<T,N>
-    of(Class<T> entityClass, String name, Class<N> attributeType) {
+
+    /**
+     * <p>Creates a static metamodel {@code NumericAttribute} representing the
+     * entity attribute with the specified name.</p>
+     *
+     * @param <T> entity class of the static metamodel.
+     * @param <N> type of entity attribute (or wrapper type if primitive).
+     * @param entityClass   the entity class.
+     * @param name          the name of the entity attribute.
+     * @param attributeType type of the entity attribute.
+     * @return instance of {@code NumericAttribute}.
+     */
+    static <T,N extends Number & Comparable<N>> NumericAttribute<T,N> of(
+            Class<T> entityClass, String name, Class<N> attributeType) {
         Objects.requireNonNull(entityClass, "entity class is required");
         Objects.requireNonNull(name, "entity attribute name is required");
         Objects.requireNonNull(attributeType, "entity attribute type is required");

--- a/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java
@@ -29,7 +29,7 @@ import jakarta.data.metamodel.impl.SortableAttributeRecord;
  *<p>A {@code SortableAttribute} may be used to sort query results.
  * When an attribute type is a numeric type, {@link NumericAttribute}
  * is preferred. When an attribute type is {@link String},
- * {@link TextAttribute} is preferred. When an attribute (or if a primitive,
+ * {@link TextAttribute} is preferred. When an attribute type (or, if primitive,
  * its wrapper class) is a subtype of {@link java.lang.Comparable},
  * use of {@link ComparableAttribute} is usually preferred, since a
  * {@code SortableAttribute} cannot be used in order-based query

--- a/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java
@@ -27,8 +27,10 @@ import jakarta.data.metamodel.impl.SortableAttributeRecord;
  * that is sortable, but not comparable.</p>
  *
  *<p>A {@code SortableAttribute} may be used to sort query results.
- * When an attribute type (or if a primitive, its wrapper class)
- * is a subtype of {@link java.lang.Comparable},
+ * When an attribute type is a numeric type, {@link NumericAttribute}
+ * is preferred. When an attribute type is a {@link String},
+ * {@link TextAttribute} is preferred. When an attribute (or if a primitive,
+ * its wrapper class) is a subtype of {@link java.lang.Comparable},
  * use of {@link ComparableAttribute} is usually preferred, since a
  * {@code SortableAttribute} cannot be used in order-based query
  * restrictions. Direct use of {@code SortableAttribute} is appropriate 

--- a/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java
@@ -28,7 +28,7 @@ import jakarta.data.metamodel.impl.SortableAttributeRecord;
  *
  *<p>A {@code SortableAttribute} may be used to sort query results.
  * When an attribute type is a numeric type, {@link NumericAttribute}
- * is preferred. When an attribute type is a {@link String},
+ * is preferred. When an attribute type is {@link String},
  * {@link TextAttribute} is preferred. When an attribute (or if a primitive,
  * its wrapper class) is a subtype of {@link java.lang.Comparable},
  * use of {@link ComparableAttribute} is usually preferred, since a

--- a/api/src/main/java/jakarta/data/metamodel/StaticMetamodel.java
+++ b/api/src/main/java/jakarta/data/metamodel/StaticMetamodel.java
@@ -41,7 +41,7 @@ import jakarta.data.Sort;
  * <li>{@link NumericAttribute} for entity attributes of numeric types, such as
  *     {@code int}, {@link Double}, and {@link java.math.BigInteger}.</li>
  * <li>{@link ComparableAttribute} for entity attributes that represent other
- *     sortable and comparable values, such as ,
+ *     sortable and comparable values, such as
  *     {@code boolean}, {@link java.time.LocalDateTime}, and enumerations.</li>
  * <li>{@link NavigableAttribute} for entity attributes that are embeddables
  *     or relations.</li>

--- a/api/src/main/java/jakarta/data/metamodel/StaticMetamodel.java
+++ b/api/src/main/java/jakarta/data/metamodel/StaticMetamodel.java
@@ -38,11 +38,15 @@ import jakarta.data.Sort;
  * <ul>
  * <li>{@link TextAttribute} for entity attributes that represent text,
  *     typically of type {@link String}.</li>
+ * <li>{@link NumericAttribute} for entity attributes of numeric types, such as
+ *     {@code int}, {@link Double}, and {@link java.math.BigInteger}.</li>
  * <li>{@link ComparableAttribute} for entity attributes that represent other
- *     sortable and comparable values, such as {@code int}, {@link Double},
+ *     sortable and comparable values, such as ,
  *     {@code boolean}, {@link java.time.LocalDateTime}, and enumerations.</li>
+ * <li>{@link NavigableAttribute} for entity attributes that are embeddables
+ *     or relations.</li>
  * <li>{@link BasicAttribute} for other types of entity attributes, such as
- *     collections, embeddables, and other relation attributes.</li>
+ *     collections.</li>
  * </ul>
  *
  * <p>Jakarta Data defines the following conventions for static metamodel classes:</p>
@@ -87,15 +91,15 @@ import jakarta.data.Sort;
  *     String NAME_LAST = "name.last";
  *     String YEAROFBIRTH = "yearOfBirth";
  *
- *     ComparableAttribute&lt;Person,Long&gt; ssn = ComparableAttribute.of(
+ *     NumericAttribute&lt;Person,Long&gt; ssn = NumericAttribute.of(
  *             Person.class, SSN, long.class);
- *     BasicAttribute&lt;Person,Name&gt; name = BasicAttribute.of(
+ *     NavigableAttribute&lt;Person,Name&gt; name = NavigableAttribute.of(
  *             Person.class, NAME, Name.class);
  *     TextAttribute&lt;Person&gt; name_first = TextAttribute.of(
  *             Person.class, NAME_FIRST);
  *     TextAttribute&lt;Person&gt; name_last = TextAttribute.of(
  *             Person.class, NAME_LAST);
- *     ComparableAttribute&lt;Person,Integer&gt; yearOfBirth = ComparableAttribute.of(
+ *     NumericAttribute&lt;Person,Integer&gt; yearOfBirth = NumericAttribute.of(
  *             Person.class, YEAROFBIRTH, int.class);
  * }
  * </pre>
@@ -124,6 +128,9 @@ import jakarta.data.Sort;
  * attempt to initialize the fields of the static metamodel class for that entity.</p>
  *
  */
+// TODO potentially replace  _Person.name_first and _Person.name_last in the above
+//      with usage of NavigableAttribute after the design of it is further along
+//      and we are more certain there won't be changes to it.
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/api/src/main/java/jakarta/data/metamodel/package-info.java
+++ b/api/src/main/java/jakarta/data/metamodel/package-info.java
@@ -39,11 +39,11 @@
  *     String NAME = "name";
  *     String PRICE = "price";
  *
- *     ComparableAttribute&lt;Product,Long&gt; id = ComparableAttribute.of(
+ *     NumericAttribute&lt;Product,Long&gt; id = NumericAttribute.of(
  *             Product.class, ID, long.class);
  *     TextAttribute&lt;Product&gt; name = TextAttribute.of(
  *             Product.class, NAME);
- *     ComparableAttribute&lt;Product,Float&gt; price = ComparableAttribute.of(
+ *     NumericAttribute&lt;Product,Float&gt; price = NumericAttribute.of(
  *             Product.class, PRICE, float.class);
  * }
  *

--- a/spec/src/main/asciidoc/entity.asciidoc
+++ b/spec/src/main/asciidoc/entity.asciidoc
@@ -426,7 +426,9 @@ The following are conventions for static metamodel classes:
 The following subinterfaces of `Attribute` are recommended to obtain the full benefit of the static metamodel:
 
 - `TextAttribute` for entity attributes that represent text, typically of type `String`.
-- `ComparableAttribute` for entity attributes that represent other comparable values, such as `long`, `Integer`, `boolean`, `java.time.Instant`, and enumerations.
+- `NumericAttribute` for entity attributes of numeric types, such as `long`, `Integer`, and `BigDecimal`.
+- `ComparableAttribute` for entity attributes that represent other comparable values, such as `boolean`, `java.time.Instant`, and enumerations.
+- `NavigableAttribute` for entity attributes that are embeddables or relations.
 - `BasicAttribute` for other types of entity attributes, such as collections, embeddables, and other relation attributes.
 
 ==== Example Metamodel Class and Usage
@@ -453,11 +455,11 @@ public interface _Product {
   String NAME = "name";
   String PRICE = "price";
 
-  ComparableAttribute<Product,Long> id = ComparableAttribute.of(
+  NumericAttribute<Product,Long> id = NumericAttribute.of(
           Product.class, ID, long.class);
   TextAttribute<Product> name = TextAttribute.of(
           Product.class, NAME);
-  ComparableAttribute<Product,Float> price = ComparableAttribute.of(
+  NumericAttribute<Product,Float> price = NumericAttribute.of(
           Product.class, PRICE, float.class);
 }
 ----


### PR DESCRIPTION
Similar to how we updated examples and recommended usage to prefer ComparableAttribute over SortableAttribute, we should do likewise for preferring NumericAttribute over either of these, and for NavigableAttribute over BasicAttribute.

This also includes doc updates for these new attribute types as we did when introducing ComparableAttribute.  It does not include any documentation for Expression, Restriction, Constraint, and other completely new classes in the static metamodel which are still being worked with. The reasoning is that Attribute already exists and can be expected to be more stable, but these others are still changing and not certain enough yet to proceed with devoting effort to adding the documentation at this point.