### PR TITLE
remove duplicated 'implements' from PathRecords

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/path/ComparablePathRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/path/ComparablePathRecord.java
@@ -18,10 +18,9 @@
 package jakarta.data.metamodel.path;
 
 import jakarta.data.metamodel.ComparableAttribute;
-import jakarta.data.metamodel.ComparableExpression;
 import jakarta.data.metamodel.NavigableExpression;
 
 record ComparablePathRecord<T,U,C extends Comparable<?>>
         (NavigableExpression<T,U> expression, ComparableAttribute<U, C> attribute)
-        implements ComparableExpression<T,C>, ComparablePath<T,U,C> {
+        implements ComparablePath<T,U,C> {
 }

--- a/api/src/main/java/jakarta/data/metamodel/path/NavigablePathRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/path/NavigablePathRecord.java
@@ -22,6 +22,6 @@ import jakarta.data.metamodel.NavigableExpression;
 
 record NavigablePathRecord<T,U,V>
         (NavigableExpression<T,U> expression, NavigableAttribute<U,V> attribute)
-        implements NavigableExpression<T,V>, NavigablePath<T,U,V> {
+        implements NavigablePath<T,U,V> {
 
 }

--- a/api/src/main/java/jakarta/data/metamodel/path/NumericPathRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/path/NumericPathRecord.java
@@ -19,9 +19,8 @@ package jakarta.data.metamodel.path;
 
 import jakarta.data.metamodel.NavigableExpression;
 import jakarta.data.metamodel.NumericAttribute;
-import jakarta.data.metamodel.NumericExpression;
 
 record NumericPathRecord<T,U,N extends Number & Comparable<N>>
         (NavigableExpression<T,U> expression, NumericAttribute<U,N> attribute)
-        implements NumericExpression<T,N>, NumericPath<T,U,N> {
+        implements NumericPath<T,U,N> {
 }

--- a/api/src/main/java/jakarta/data/metamodel/path/TextPathRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/path/TextPathRecord.java
@@ -19,9 +19,8 @@ package jakarta.data.metamodel.path;
 
 import jakarta.data.metamodel.NavigableExpression;
 import jakarta.data.metamodel.TextAttribute;
-import jakarta.data.metamodel.TextExpression;
 
 record TextPathRecord<T,U>
         (NavigableExpression<T,U> expression, TextAttribute<U> attribute)
-        implements TextExpression<T>, TextPath<T,U> {
+        implements TextPath<T,U> {
 }


### PR DESCRIPTION
The `XxxxPathRecord` doesn't need to directly implement `XxxxExpression`, because `XxxxPath` already does.