### PR TITLE
Add Like.literal() and sync implementations of Like and NotLike

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/constraint/Like.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/Like.java
@@ -17,6 +17,9 @@
  */
 package jakarta.data.metamodel.constraint;
 
+import static jakarta.data.metamodel.constraint.LikeRecord.ESCAPE;
+import static jakarta.data.metamodel.constraint.LikeRecord.STRING_WILDCARD;
+
 public interface Like extends Constraint<String> {
     String pattern();
     Character escape();
@@ -34,18 +37,18 @@ public interface Like extends Constraint<String> {
     }
 
     static Like substring(String substring) {
-        return LikeRecord.substring(substring);
+        return new LikeRecord(STRING_WILDCARD + LikeRecord.escape(substring) + STRING_WILDCARD, ESCAPE);
     }
 
     static Like prefix(String prefix) {
-        return LikeRecord.prefix(prefix);
+        return new LikeRecord(LikeRecord.escape(prefix) + STRING_WILDCARD, ESCAPE);
     }
 
     static Like suffix(String suffix) {
-        return LikeRecord.suffix(suffix);
+        return new LikeRecord(STRING_WILDCARD + LikeRecord.escape(suffix), ESCAPE);
     }
 
     static Like literal(String suffix) {
-        return LikeRecord.literal(suffix);
+        return new LikeRecord(LikeRecord.escape(suffix), ESCAPE);
     }
 }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/Like.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/Like.java
@@ -44,4 +44,8 @@ public interface Like extends Constraint<String> {
     static Like suffix(String suffix) {
         return LikeRecord.suffix(suffix);
     }
+
+    static Like literal(String suffix) {
+        return LikeRecord.literal(suffix);
+    }
 }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/LikeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/LikeRecord.java
@@ -26,19 +26,19 @@ record LikeRecord(String pattern, Character escape)
     public static final char STRING_WILDCARD = '%';
     public static final char ESCAPE = '\\';
 
-    public LikeRecord {
+    LikeRecord {
         Objects.requireNonNull(pattern, "Pattern must not be null");
     }
 
-    public LikeRecord(String pattern) {
+    LikeRecord(String pattern) {
         this(pattern, null);
     }
 
-    public LikeRecord(String pattern, char charWildcard, char stringWildcard) {
+    LikeRecord(String pattern, char charWildcard, char stringWildcard) {
         this(pattern, charWildcard, stringWildcard, ESCAPE);
     }
 
-    public LikeRecord(String pattern, char charWildcard, char stringWildcard, char escape) {
+    LikeRecord(String pattern, char charWildcard, char stringWildcard, char escape) {
         this(translate(pattern, charWildcard, stringWildcard, escape), escape);
     }
 
@@ -51,22 +51,6 @@ record LikeRecord(String pattern, Character escape)
     public String toString() {
         return "LIKE '" + pattern + "'"
                 + (escape == null ? "" : " ESCAPE '\\'");
-    }
-
-    public static LikeRecord prefix(String prefix) {
-        return new LikeRecord(escape(prefix) + STRING_WILDCARD, ESCAPE);
-    }
-
-    public static LikeRecord suffix(String suffix) {
-        return new LikeRecord(STRING_WILDCARD + escape(suffix), ESCAPE);
-    }
-
-    public static LikeRecord literal(String suffix) {
-        return new LikeRecord(escape(suffix), ESCAPE);
-    }
-
-    public static LikeRecord substring(String substring) {
-        return new LikeRecord(STRING_WILDCARD + escape(substring) + STRING_WILDCARD, ESCAPE);
     }
 
     static String escape(String literal) {

--- a/api/src/main/java/jakarta/data/metamodel/constraint/LikeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/LikeRecord.java
@@ -61,6 +61,10 @@ record LikeRecord(String pattern, Character escape)
         return new LikeRecord(STRING_WILDCARD + escape(suffix), ESCAPE);
     }
 
+    public static LikeRecord literal(String suffix) {
+        return new LikeRecord(escape(suffix), ESCAPE);
+    }
+
     public static LikeRecord substring(String substring) {
         return new LikeRecord(STRING_WILDCARD + escape(substring) + STRING_WILDCARD, ESCAPE);
     }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/NotLike.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/NotLike.java
@@ -19,42 +19,35 @@ package jakarta.data.metamodel.constraint;
 
 import static jakarta.data.metamodel.constraint.LikeRecord.ESCAPE;
 import static jakarta.data.metamodel.constraint.LikeRecord.STRING_WILDCARD;
-import static jakarta.data.metamodel.constraint.LikeRecord.translate;
 
 public interface NotLike extends Constraint<String> {
 
     static NotLike pattern(String pattern) {
-        return new NotLikeRecord(pattern, null);
+        return new NotLikeRecord(pattern);
     }
 
     static NotLike pattern(String pattern, char charWildcard, char stringWildcard) {
-        return new NotLikeRecord(translate(pattern, charWildcard, stringWildcard, ESCAPE),
-                                 ESCAPE);
+        return new NotLikeRecord(pattern, charWildcard, stringWildcard);
     }
 
     static NotLike pattern(String pattern, char charWildcard, char stringWildcard, char escape) {
-        return new NotLikeRecord(translate(pattern, charWildcard, stringWildcard, escape),
-                                 escape);
+        return new NotLikeRecord(pattern, charWildcard, stringWildcard, escape);
     }
 
     static NotLike prefix(String prefix) {
-        return new NotLikeRecord(LikeRecord.escape(prefix) + STRING_WILDCARD,
-                                 ESCAPE);
+        return new NotLikeRecord(LikeRecord.escape(prefix) + STRING_WILDCARD, ESCAPE);
     }
 
     static NotLike substring(String substring) {
-        return new NotLikeRecord(STRING_WILDCARD + LikeRecord.escape(substring) + STRING_WILDCARD,
-                                 ESCAPE);
+        return new NotLikeRecord(STRING_WILDCARD + LikeRecord.escape(substring) + STRING_WILDCARD, ESCAPE);
     }
 
     static NotLike suffix(String suffix) {
-        return new NotLikeRecord(STRING_WILDCARD + LikeRecord.escape(suffix),
-                                 ESCAPE);
+        return new NotLikeRecord(STRING_WILDCARD + LikeRecord.escape(suffix), ESCAPE);
     }
 
     static NotLike literal(String suffix) {
-        return new NotLikeRecord(LikeRecord.escape(suffix),
-                                 ESCAPE);
+        return new NotLikeRecord(LikeRecord.escape(suffix), ESCAPE);
     }
 
     Character escape();

--- a/api/src/main/java/jakarta/data/metamodel/constraint/NotLike.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/NotLike.java
@@ -52,6 +52,11 @@ public interface NotLike extends Constraint<String> {
                                  ESCAPE);
     }
 
+    static NotLike literal(String suffix) {
+        return new NotLikeRecord(LikeRecord.escape(suffix),
+                                 ESCAPE);
+    }
+
     Character escape();
 
     String pattern();

--- a/api/src/main/java/jakarta/data/metamodel/constraint/NotLikeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/NotLikeRecord.java
@@ -19,10 +19,25 @@ package jakarta.data.metamodel.constraint;
 
 import java.util.Objects;
 
+import static jakarta.data.metamodel.constraint.LikeRecord.ESCAPE;
+import static jakarta.data.metamodel.constraint.LikeRecord.translate;
+
 record NotLikeRecord(String pattern, Character escape) implements NotLike {
 
     NotLikeRecord {
         Objects.requireNonNull(pattern, "pattern must not be null");
+    }
+
+    NotLikeRecord(String pattern) {
+        this(pattern, null);
+    }
+
+    NotLikeRecord(String pattern, char charWildcard, char stringWildcard) {
+        this(pattern, charWildcard, stringWildcard, ESCAPE);
+    }
+
+    NotLikeRecord(String pattern, char charWildcard, char stringWildcard, char escape) {
+        this(translate(pattern, charWildcard, stringWildcard, escape), escape);
     }
 
     @Override


### PR DESCRIPTION
I had decided that `Like.literal()` was unnecessary, but now I've realized there are still cases for it, for example if I have a repo method declared like this:

```java
@Find List<Books> books(Like title);
```

It's useful to be able to call it with:

```java
var books = library.books(Like.literal("Hibernate in Action"));
```

Incidentally, I noticed that `Like` and `NotLike` had superficially divergent implementations.