### PR TITLE
Let Java record provide the equals and hashCode implementation

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/constraint/BetweenRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/BetweenRecord.java
@@ -32,18 +32,6 @@ record BetweenRecord<T extends Comparable<?>>(T lowerBound, T upperBound)
     }
 
     @Override
-    public boolean equals(Object obj) {
-        return obj instanceof BetweenRecord<?> that
-            && lowerBound.equals(that.lowerBound)
-            && upperBound.equals(that.upperBound);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(lowerBound, upperBound);
-    }
-
-    @Override
     public NotBetween<T> negate() {
         return NotBetween.bounds(lowerBound, upperBound);
     }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/EqualToRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/EqualToRecord.java
@@ -33,15 +33,4 @@ record EqualToRecord<T>(T value) implements EqualTo<T> {
     public String toString() {
         return value instanceof String ? "= '" + value + "'" : "= " + value.toString();
     }
-
-    @Override
-    public boolean equals(Object obj) {
-        return obj instanceof EqualToRecord<?> that
-            && value.equals(that.value);
-    }
-
-    @Override
-    public int hashCode() {
-        return value.hashCode();
-    }
 }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/GreaterThanOrEqualRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/GreaterThanOrEqualRecord.java
@@ -34,15 +34,4 @@ record GreaterThanOrEqualRecord<T extends Comparable<?>>(T bound)
     public String toString() {
         return ">= " + bound.toString();
     }
-
-    @Override
-    public boolean equals(Object obj) {
-        return obj instanceof GreaterThanOrEqualRecord<?> that
-            && bound.equals(that.bound);
-    }
-
-    @Override
-    public int hashCode() {
-        return bound.hashCode();
-    }
 }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/GreaterThanRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/GreaterThanRecord.java
@@ -34,15 +34,4 @@ record GreaterThanRecord<T extends Comparable<?>>(T bound)
     public String toString() {
         return "> " + bound.toString();
     }
-
-    @Override
-    public boolean equals(Object obj) {
-        return obj instanceof GreaterThanRecord<?> that
-            && bound.equals(that.bound);
-    }
-
-    @Override
-    public int hashCode() {
-        return bound.hashCode();
-    }
 }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/InRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/InRecord.java
@@ -30,17 +30,6 @@ record InRecord<T>(Set<T> values) implements In<T> {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        return obj instanceof InRecord<?> that
-            && values.equals(that.values);
-    }
-
-    @Override
-    public int hashCode() {
-        return values.hashCode();
-    }
-
-    @Override
     public NotIn<T> negate() {
         return NotIn.values(values);
     }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/LessThanOrEqualRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/LessThanOrEqualRecord.java
@@ -34,15 +34,4 @@ record LessThanOrEqualRecord<T extends Comparable<?>>(T bound)
     public String toString() {
         return "<= " + bound.toString();
     }
-
-    @Override
-    public boolean equals(Object obj) {
-        return obj instanceof LessThanOrEqualRecord<?> that
-            && bound.equals(that.bound);
-    }
-
-    @Override
-    public int hashCode() {
-        return bound.hashCode();
-    }
 }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/LessThanRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/LessThanRecord.java
@@ -34,15 +34,4 @@ record LessThanRecord<T extends Comparable<?>>(T bound)
     public String toString() {
         return "< " + bound.toString();
     }
-
-    @Override
-    public boolean equals(Object obj) {
-        return obj instanceof LessThanRecord<?> that
-            && bound.equals(that.bound);
-    }
-
-    @Override
-    public int hashCode() {
-        return bound.hashCode();
-    }
 }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/LikeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/LikeRecord.java
@@ -100,16 +100,4 @@ record LikeRecord(String pattern, Character escape)
         }
         return result.toString();
     }
-
-    @Override
-    public boolean equals(Object obj) {
-        return obj instanceof LikeRecord that
-            && pattern.equals(that.pattern)
-            && Objects.equals(escape, that.escape);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(pattern, escape);
-    }
 }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/NullRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/NullRecord.java
@@ -21,16 +21,6 @@ record NullRecord<T>() implements Null<T> {
     static final NullRecord<?> INSTANCE = new NullRecord<>();
 
     @Override
-    public boolean equals(Object obj) {
-        return obj instanceof NullRecord;
-    }
-
-    @Override
-    public int hashCode() {
-        return 0;
-    }
-
-    @Override
     public NotNull<T> negate() {
         return NotNull.instance();
     }


### PR DESCRIPTION
Some of our Constraint records implement .equals and hashCode methods while others are letting it default to what you get automatically for Java records.  These should all be consistent, and I don't see an reasons why we need to override it, so the approach I took in this PR is to remove it where we had it implemented.  If anyone does know of a reason why we need to override it or why an implementation we provide is better, we could go the other direction and add it where currently missing instead.