### PR TITLE
Remove .attribute() from BasicRestriction

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/restrict/BasicRestriction.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/BasicRestriction.java
@@ -21,7 +21,6 @@ import jakarta.data.metamodel.Expression;
 import jakarta.data.metamodel.constraint.Constraint;
 
 public interface BasicRestriction<T, V> extends Restriction<T> {
-    String attribute();
 
     @Override
     BasicRestriction<T, V> negate();

--- a/api/src/main/java/jakarta/data/metamodel/restrict/BasicRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/BasicRestrictionRecord.java
@@ -36,11 +36,6 @@ record BasicRestrictionRecord<T, V>(Expression<T,V> expression, Constraint<V> co
     }
 
     @Override
-    public String attribute() {
-        return expression instanceof Attribute<?> att ? att.name() : null;
-    }
-
-    @Override
     public BasicRestriction<T, V> negate() {
         return BasicRestriction.of(expression, constraint.negate());
     }

--- a/api/src/test/java/jakarta/data/metamodel/AttributeTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/AttributeTest.java
@@ -47,12 +47,13 @@ class AttributeTest {
             BasicAttribute.of(Person.class, "testAttribute", String.class);
     @Test
     void shouldCreateEqualToRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Person, String> restriction =
                 (BasicRestriction<Person, String>) testAttribute.equalTo("testValue");
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
-            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.expression()).isEqualTo(testAttribute);
             soft.assertThat(restriction.constraint()).isInstanceOf(EqualTo.class);
             soft.assertThat(restriction.constraint()).isEqualTo(Constraint.equalTo("testValue"));
         });
@@ -60,12 +61,13 @@ class AttributeTest {
 
     @Test
     void shouldCreateNotEqualToRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Person, String> restriction =
                 (BasicRestriction<Person, String>) testAttribute.notEqualTo("testValue");
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
-            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.expression()).isEqualTo(testAttribute);
             soft.assertThat(restriction.constraint()).isInstanceOf(NotEqualTo.class);
             soft.assertThat(restriction.constraint()).isEqualTo(NotEqualTo.value("testValue"));
         });
@@ -73,12 +75,13 @@ class AttributeTest {
 
     @Test
     void shouldCreateInRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Person, String> restriction =
                 (BasicRestriction<Person, String>) testAttribute.in(Set.of("value1", "value2"));
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
-            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.expression()).isEqualTo(testAttribute);
             soft.assertThat(restriction.constraint()).isInstanceOf(In.class);
             soft.assertThat(restriction.constraint()).isEqualTo(Constraint.in("value1", "value2"));
         });
@@ -93,12 +96,13 @@ class AttributeTest {
 
     @Test
     void shouldCreateNotInRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Person, String> restriction =
                 (BasicRestriction<Person, String>) testAttribute.notIn(Set.of("value1", "value2"));
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
-            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.expression()).isEqualTo(testAttribute);
             soft.assertThat(restriction.constraint()).isInstanceOf(NotIn.class);
             soft.assertThat(restriction.constraint()).isEqualTo(NotIn.values("value1", "value2"));
         });
@@ -113,24 +117,26 @@ class AttributeTest {
 
     @Test
     void shouldCreateIsNullRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Person, String> restriction =
                 (BasicRestriction<Person, String>) testAttribute.isNull();
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
-            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.expression()).isEqualTo(testAttribute);
             soft.assertThat(restriction.constraint()).isInstanceOf(Null.class);
         });
     }
 
     @Test
     void shouldCreateNotNullRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Person, String> restriction =
                 (BasicRestriction<Person, String>) testAttribute.notNull();
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
-            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.expression()).isEqualTo(testAttribute);
             soft.assertThat(restriction.constraint()).isInstanceOf(NotNull.class);
         });
     }

--- a/api/src/test/java/jakarta/data/metamodel/ComparableAttributeTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/ComparableAttributeTest.java
@@ -29,7 +29,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 
 
-class SortableAttributeTest {
+class ComparableAttributeTest {
     // Mock entity class for tests
     static class Person {
         String firstName;
@@ -38,7 +38,6 @@ class SortableAttributeTest {
         int testAttribute;
     }
 
-    //it ignores the implementation of the SortableAttribute interface and uses an anonymous class to test the methods
     private final ComparableAttribute<Person, Integer> testAttribute =
             ComparableAttribute.of(Person.class, "testAttribute", Integer.class);
 

--- a/api/src/test/java/jakarta/data/metamodel/SortableAttributeTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/SortableAttributeTest.java
@@ -44,12 +44,13 @@ class SortableAttributeTest {
 
     @Test
     void shouldCreateGreaterThanRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Person, Integer> restriction =
                 (BasicRestriction<Person, Integer>) testAttribute.greaterThan(10);
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
-            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.expression()).isEqualTo(testAttribute);
             soft.assertThat(restriction.constraint()).isInstanceOf(GreaterThan.class);
             soft.assertThat(restriction.constraint()).isEqualTo(Constraint.greaterThan(10));
         });
@@ -57,12 +58,13 @@ class SortableAttributeTest {
 
     @Test
     void shouldCreateGreaterThanEqualRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Person, Integer> restriction =
                 (BasicRestriction<Person, Integer>) testAttribute.greaterThanEqual(10);
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
-            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.expression()).isEqualTo(testAttribute);
             soft.assertThat(restriction.constraint()).isInstanceOf(GreaterThanOrEqual.class);
             soft.assertThat(restriction.constraint()).isEqualTo(Constraint.greaterThanOrEqual(10));
         });
@@ -70,12 +72,13 @@ class SortableAttributeTest {
 
     @Test
     void shouldCreateLessThanRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Person, Integer> restriction =
                 (BasicRestriction<Person, Integer>) testAttribute.lessThan(10);
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
-            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.expression()).isEqualTo(testAttribute);
             soft.assertThat(restriction.constraint()).isInstanceOf(LessThan.class);
             soft.assertThat(restriction.constraint()).isEqualTo(Constraint.lessThan(10));
         });
@@ -83,12 +86,13 @@ class SortableAttributeTest {
 
     @Test
     void shouldCreateLessThanOrEqualRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Person, Integer> restriction =
                 (BasicRestriction<Person, Integer>) testAttribute.lessThanEqual(10);
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
-            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.expression()).isEqualTo(testAttribute);
             soft.assertThat(restriction.constraint()).isInstanceOf(LessThanOrEqual.class);
             soft.assertThat(restriction.constraint()).isEqualTo(Constraint.lessThanOrEqual(10));
         });
@@ -96,12 +100,13 @@ class SortableAttributeTest {
 
     @Test
     void shouldCreateBetweenRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Person, Integer> restriction =
                 (BasicRestriction<Person, Integer>) testAttribute.between(5, 15);
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
-            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.expression()).isEqualTo(testAttribute);
             soft.assertThat(restriction.constraint()).isInstanceOf(Between.class);
             soft.assertThat(restriction.constraint()).isEqualTo(Constraint.between(5,15));
         });

--- a/api/src/test/java/jakarta/data/metamodel/TextAttributeTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/TextAttributeTest.java
@@ -35,11 +35,12 @@ class TextAttributeTest {
 
     @Test
     void shouldCreateContainsRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Author,String> restriction =
                 (BasicRestriction<Author, String>) testAttribute.contains("testValue");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.expression()).isEqualTo(testAttribute);
             soft.assertThat(restriction.constraint()).isInstanceOf(Like.class);
             soft.assertThat(((Like) restriction.constraint()).pattern()).isEqualTo("%testValue%");
         });
@@ -47,11 +48,12 @@ class TextAttributeTest {
 
     @Test
     void shouldCreateStartsWithRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Author,String> restriction =
                 (BasicRestriction<Author, String>) testAttribute.startsWith("testValue");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.expression()).isEqualTo(testAttribute);
             soft.assertThat(restriction.constraint()).isInstanceOf(Like.class);
             soft.assertThat(((Like) restriction.constraint()).pattern()).isEqualTo("testValue%");
         });
@@ -59,11 +61,12 @@ class TextAttributeTest {
 
     @Test
     void shouldCreateEndsWithRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Author,String> restriction =
                 (BasicRestriction<Author,String>) testAttribute.endsWith("testValue");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.expression()).isEqualTo(testAttribute);
             soft.assertThat(restriction.constraint()).isInstanceOf(Like.class);
             soft.assertThat(((Like) restriction.constraint()).pattern()).isEqualTo("%testValue");
         });
@@ -71,11 +74,12 @@ class TextAttributeTest {
 
     @Test
     void shouldCreateLikeRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Author,String> restriction =
                 (BasicRestriction<Author, String>) testAttribute.like("%test%");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.expression()).isEqualTo(testAttribute);
             soft.assertThat(restriction.constraint()).isInstanceOf(Like.class);
             soft.assertThat(((Like) restriction.constraint()).pattern()).isEqualTo("%test%");
         });
@@ -83,11 +87,12 @@ class TextAttributeTest {
 
     @Test
     void shouldCreateNotContainsRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Author,String> restriction =
                 (BasicRestriction<Author, String>) testAttribute.notContains("testValue");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.expression()).isEqualTo(testAttribute);
             soft.assertThat(restriction.constraint()).isInstanceOf(NotLike.class);
             soft.assertThat(((NotLike) restriction.constraint()).pattern()).isEqualTo("%testValue%");
         });
@@ -95,11 +100,12 @@ class TextAttributeTest {
 
     @Test
     void shouldCreateNotLikeRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Author,String> restriction =
                 (BasicRestriction<Author, String>) testAttribute.notLike("%test%");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.expression()).isEqualTo(testAttribute);
             soft.assertThat(restriction.constraint()).isInstanceOf(NotLike.class);
             soft.assertThat(((NotLike) restriction.constraint()).pattern()).isEqualTo("%test%");
         });
@@ -107,11 +113,12 @@ class TextAttributeTest {
 
     @Test
     void shouldCreateNotStartsWithRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Author,String> restriction =
                 (BasicRestriction<Author, String>) testAttribute.notStartsWith("testValue");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.expression()).isEqualTo(testAttribute);
             soft.assertThat(restriction.constraint()).isInstanceOf(NotLike.class);
             soft.assertThat(((NotLike) restriction.constraint()).pattern()).isEqualTo("testValue%");
         });
@@ -119,11 +126,12 @@ class TextAttributeTest {
 
     @Test
     void shouldCreateNotEndsWithRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Author,String> restriction =
                 (BasicRestriction<Author, String>) testAttribute.notEndsWith("testValue");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("testAttribute");
+            soft.assertThat(restriction.expression()).isEqualTo(testAttribute);
             soft.assertThat(restriction.constraint()).isInstanceOf(NotLike.class);
             soft.assertThat(((NotLike) restriction.constraint()).pattern()).isEqualTo("%testValue");
         });

--- a/api/src/test/java/jakarta/data/metamodel/expression/ExpressionTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/expression/ExpressionTest.java
@@ -78,9 +78,6 @@ class ExpressionTest {
             (NumericLiteral<Book, Integer>) leftArgs.get(1);
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute())
-                .isNull(); // restriction on an expression that is not an attribute
-
             soft.assertThat(leftExpression.name())
                 .isEqualTo(TextFunctionExpression.LEFT);
 
@@ -122,9 +119,6 @@ class ExpressionTest {
             (NumericFunctionExpression<Book, Integer>) restriction.expression();
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute())
-                .isNull(); // restriction on an expression that is not an attribute
-
             soft.assertThat(lengthExpression.name())
                 .isEqualTo(NumericFunctionExpression.LENGTH);
 

--- a/api/src/test/java/jakarta/data/metamodel/restrict/BasicRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/BasicRestrictionRecordTest.java
@@ -32,29 +32,32 @@ class BasicRestrictionRecordTest {
 
     @Test
     void shouldCreateBasicRestrictionWithDefaultNegation() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Book, String> restriction =
                 (BasicRestriction<Book, String>) _Book.title.equalTo("Java Guide");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("title");
+            soft.assertThat(restriction.expression()).isEqualTo(_Book.title);
             soft.assertThat(restriction.constraint()).isEqualTo(EqualTo.value("Java Guide"));
         });
     }
 
     @Test
     void shouldCreateBasicRestrictionWithExplicitNegation() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Book, String> restriction =
                 (BasicRestriction<Book, String>) _Book.title.equalTo("Java Guide")
                         .negate();
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("title");
+            soft.assertThat(restriction.expression()).isEqualTo(_Book.title);
             soft.assertThat(restriction.constraint()).isEqualTo(NotEqualTo.value("Java Guide"));
         });
     }
 
     @Test
     void shouldNegateLTERestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Book, Integer> numChaptersLTE10Basic =
                 (BasicRestriction<Book, Integer>) _Book.numChapters.lessThanEqual(10);
         BasicRestriction<Book, Integer> numChaptersGT10Basic = numChaptersLTE10Basic.negate();
@@ -68,6 +71,7 @@ class BasicRestrictionRecordTest {
 
     @Test
     void shouldNegateNegatedRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Book, String> titleRestrictionBasic =
                 (BasicRestriction<Book, String>) _Book.title.equalTo("A Developer's Guide to Jakarta Data");
         BasicRestriction<Book, String> negatedTitleRestrictionBasic =
@@ -89,6 +93,7 @@ class BasicRestrictionRecordTest {
 
     @Test
     void shouldOutputToString() {
+        @SuppressWarnings("unchecked")
         Restriction<Book> restriction =
                 (BasicRestriction<Book, Integer>) _Book.numPages.greaterThan(100);
 
@@ -100,11 +105,12 @@ class BasicRestrictionRecordTest {
 
     @Test
     void shouldSupportNegatedRestrictionUsingDefaultConstructor() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Book, String> negatedRestriction =
                 (BasicRestriction<Book, String>) _Book.author.notEqualTo("Unknown");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(negatedRestriction.attribute()).isEqualTo("author");
+            soft.assertThat(negatedRestriction.expression()).isEqualTo(_Book.author);
             soft.assertThat(negatedRestriction.constraint()).isEqualTo(NotEqualTo.value("Unknown"));
         });
     }

--- a/api/src/test/java/jakarta/data/metamodel/restrict/RestrictTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/RestrictTest.java
@@ -69,11 +69,12 @@ class RestrictTest {
 
     @Test
     void shouldCreateEqualToRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Employee, Integer> restriction =
                 (BasicRestriction<Employee, Integer>) _Employee.yearHired.equalTo(2020);
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("yearHired");
+            soft.assertThat(restriction.expression()).isEqualTo(_Employee.yearHired);
             soft.assertThat(restriction.constraint()).isInstanceOf(EqualTo.class);
             soft.assertThat(restriction.constraint()).isEqualTo(Constraint.equalTo(2020));
         });
@@ -81,11 +82,12 @@ class RestrictTest {
 
     @Test
     void shouldCreateNotEqualToRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Employee, Integer> restriction =
                 (BasicRestriction<Employee, Integer>) _Employee.badgeNum.notEqualTo(0);
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("badgeNum");
+            soft.assertThat(restriction.expression()).isEqualTo(_Employee.badgeNum);
             soft.assertThat(restriction.constraint()).isInstanceOf(NotEqualTo.class);
             soft.assertThat(restriction.constraint()).isEqualTo(NotEqualTo.value(0));
         });
@@ -93,11 +95,12 @@ class RestrictTest {
 
     @Test
     void shouldCreateEqualToStringRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Employee,String> restriction =
                 (BasicRestriction<Employee, String>) _Employee.position.equalTo("Software Engineer");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("position");
+            soft.assertThat(restriction.expression()).isEqualTo(_Employee.position);
             soft.assertThat(restriction.constraint()).isInstanceOf(EqualTo.class);
             soft.assertThat(restriction.constraint()).isEqualTo(EqualTo.value("Software Engineer"));
         });
@@ -105,11 +108,12 @@ class RestrictTest {
 
     @Test
     void shouldCreateNotEqualToStringRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Employee,String> restriction =
                 (BasicRestriction<Employee, String>) _Employee.position.notEqualTo("Manager");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("position");
+            soft.assertThat(restriction.expression()).isEqualTo(_Employee.position);
             soft.assertThat(restriction.constraint()).isInstanceOf(NotEqualTo.class);
             soft.assertThat(restriction.constraint()).isEqualTo(NotEqualTo.value("Manager"));
         });
@@ -134,11 +138,12 @@ class RestrictTest {
 
     @Test
     void shouldCreateContainsRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Employee,String> restriction =
                 (BasicRestriction<Employee, String>) _Employee.position.contains("Manager");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("position");
+            soft.assertThat(restriction.expression()).isEqualTo(_Employee.position);
             soft.assertThat(restriction.constraint()).isInstanceOf(Like.class);
             soft.assertThat(((Like) restriction.constraint()).pattern()).isEqualTo("%Manager%");
         });
@@ -146,11 +151,12 @@ class RestrictTest {
 
     @Test
     void shouldCreateNegatedContainsRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Employee,String> restriction =
                 (BasicRestriction<Employee, String>) _Employee.position.notContains("Director");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("position");
+            soft.assertThat(restriction.expression()).isEqualTo(_Employee.position);
             soft.assertThat(restriction.constraint()).isInstanceOf(NotLike.class);
             soft.assertThat(((NotLike) restriction.constraint()).pattern()).isEqualTo("%Director%");
         });
@@ -158,11 +164,12 @@ class RestrictTest {
 
     @Test
     void shouldCreateStartsWithRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Employee,String> restriction =
                 (BasicRestriction<Employee, String>) _Employee.position.startsWith("Director");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("position");
+            soft.assertThat(restriction.expression()).isEqualTo(_Employee.position);
             soft.assertThat(restriction.constraint()).isInstanceOf(Like.class);
             soft.assertThat(((Like) restriction.constraint()).pattern()).isEqualTo("Director%");
         });
@@ -170,11 +177,12 @@ class RestrictTest {
 
     @Test
     void shouldCreateNegatedStartsWithRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Employee,String> restriction =
                 (BasicRestriction<Employee, String>) _Employee.position.notStartsWith("Manager");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("position");
+            soft.assertThat(restriction.expression()).isEqualTo(_Employee.position);
             soft.assertThat(restriction.constraint()).isInstanceOf(NotLike.class);
             soft.assertThat(((NotLike) restriction.constraint()).pattern()).isEqualTo("Manager%");
         });
@@ -182,11 +190,12 @@ class RestrictTest {
 
     @Test
     void shouldCreateEndsWithRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Employee,String> restriction =
                 (BasicRestriction<Employee,String>) _Employee.position.endsWith("Manager");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("position");
+            soft.assertThat(restriction.expression()).isEqualTo(_Employee.position);
             soft.assertThat(restriction.constraint()).isInstanceOf(Like.class);
             soft.assertThat(((Like) restriction.constraint()).pattern()).isEqualTo("%Manager");
         });
@@ -194,11 +203,12 @@ class RestrictTest {
 
     @Test
     void shouldCreateNegatedEndsWithRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Employee,String> restriction =
                 (BasicRestriction<Employee, String>) _Employee.position.notEndsWith("Supervisor");
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("position");
+            soft.assertThat(restriction.expression()).isEqualTo(_Employee.position);
             soft.assertThat(restriction.constraint()).isInstanceOf(NotLike.class);
             soft.assertThat(((NotLike) restriction.constraint()).pattern()).isEqualTo("%Supervisor");
         });
@@ -239,7 +249,9 @@ class RestrictTest {
 
     @Test
     void shouldEscapeToLikePatternCorrectly() {
-        Like like = (Like) ((BasicRestriction<Employee,String>) _Employee.position.endsWith("test_value")).constraint();
+        @SuppressWarnings("unchecked")
+        Like like = (Like) ((BasicRestriction<Employee,String>)
+                _Employee.position.endsWith("test_value")).constraint();
         String result = like.pattern();
 
         assertThat(result).isEqualTo("%test\\_value");
@@ -248,12 +260,13 @@ class RestrictTest {
     @Test
     void shouldIgnoreCase() {
         // TODO TextRestriction.ignoreCase vs TextAttribute.upper/lowercased
+        @SuppressWarnings("unchecked")
         BasicRestriction<Employee,String> restriction =
                 (BasicRestriction<Employee, String>) _Employee.position.contains("SOFTWARE");
         //        .ignoreCase();
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo(_Employee.POSITION);
+            soft.assertThat(restriction.expression()).isEqualTo(_Employee.position);
             //soft.assertThat(restriction.isCaseSensitive()).isFalse();
             soft.assertThat(restriction.constraint()).isEqualTo(Like.substring("SOFTWARE"));
         });

--- a/api/src/test/java/jakarta/data/metamodel/restrict/TextRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/TextRestrictionRecordTest.java
@@ -34,13 +34,14 @@ class TextRestrictionRecordTest {
 
     @Test
     void shouldCreateTextRestrictionWithDefaultValues() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Book,String> restriction =
                 (BasicRestriction<Book, String>) _Book.title.like("%Java%");
 
         Like constraint = (Like) restriction.constraint();
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("title");
+            soft.assertThat(restriction.expression()).isEqualTo(_Book.title);
             // TODO TextRestriction.ignoreCase vs TextAttribute.upper/lowercased
             //soft.assertThat(restriction.isCaseSensitive()).isTrue();
             soft.assertThat(constraint.pattern()).isEqualTo("%Java%");
@@ -50,13 +51,14 @@ class TextRestrictionRecordTest {
 
     @Test
     void shouldCreateTextRestrictionWithExplicitNegation() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Book,String> restriction =
                 (BasicRestriction<Book, String>) _Book.title.like("%Java%").negate();
 
         NotLike constraint = (NotLike) restriction.constraint();
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("title");
+            soft.assertThat(restriction.expression()).isEqualTo(_Book.title);
             // TODO TextRestriction.ignoreCase vs TextAttribute.upper/lowercased
             //soft.assertThat(restriction.isCaseSensitive()).isTrue();
             soft.assertThat(constraint.pattern()).isEqualTo("%Java%");
@@ -66,6 +68,7 @@ class TextRestrictionRecordTest {
 
     @Test
     void shouldIgnoreCaseForTextRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Book,String> restriction =
                 (BasicRestriction<Book, String>) _Book.title.like("%Java%");
 
@@ -74,7 +77,7 @@ class TextRestrictionRecordTest {
         Like constraint = (Like) restriction.constraint();
 
         SoftAssertions.assertSoftly(soft -> {
-        //    soft.assertThat(caseInsensitiveRestriction.attribute()).isEqualTo("title");
+        //    soft.assertThat(caseInsensitiveRestriction.expression()).isEqualTo(_Book.title);
         //    soft.assertThat(caseInsensitiveRestriction.isCaseSensitive()).isFalse();
             soft.assertThat(constraint.pattern()).isEqualTo("%Java%");
             soft.assertThat(constraint.escape()).isNull();
@@ -83,13 +86,14 @@ class TextRestrictionRecordTest {
 
     @Test
     void shouldCreateTextRestrictionWithEscapedValue() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Book,String> restriction =
                 (BasicRestriction<Book, String>) _Book.title.like("%Java%");
 
         Like constraint = (Like) restriction.constraint();
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("title");
+            soft.assertThat(restriction.expression()).isEqualTo(_Book.title);
             // TODO TextRestriction.ignoreCase vs TextAttribute.upper/lowercased
             //soft.assertThat(restriction.isCaseSensitive()).isTrue();
             soft.assertThat(constraint.pattern()).isEqualTo("%Java%");
@@ -99,13 +103,14 @@ class TextRestrictionRecordTest {
 
     @Test
     void shouldCreateTextRestrictionWithCustomWildcards() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Book,String> restriction =
                 (BasicRestriction<Book, String>) _Book.title.like("*Java??", '?', '*', '$');
 
         Like constraint = (Like) restriction.constraint();
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("title");
+            soft.assertThat(restriction.expression()).isEqualTo(_Book.title);
             // TODO TextRestriction.ignoreCase vs TextAttribute.upper/lowercased
             //soft.assertThat(restriction.isCaseSensitive()).isTrue();
             soft.assertThat(constraint.pattern()).isEqualTo("%Java__");
@@ -115,6 +120,7 @@ class TextRestrictionRecordTest {
 
     @Test
     void shouldNegateLikeRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Book,String> likeJakartaEE =
                 (BasicRestriction<Book, String>) _Book.title.endsWith("Jakarta EE");
         BasicRestriction<Book,String> notLikeJakartaEE = likeJakartaEE.negate();
@@ -132,6 +138,7 @@ class TextRestrictionRecordTest {
 
     @Test
     void shouldNegateNegatedRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Book,String> endsWithJakartaEE =
                 (BasicRestriction<Book, String>) _Book.title.endsWith("Jakarta EE");
         BasicRestriction<Book,String> notEndsWithJakartaEE = endsWithJakartaEE.negate();
@@ -154,8 +161,10 @@ class TextRestrictionRecordTest {
 
     @Test
     void shouldOutputToString() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Book,String> titleRestriction =
                 (BasicRestriction<Book, String>) _Book.title.contains("Jakarta Data");
+        @SuppressWarnings("unchecked")
         BasicRestriction<Book,String> authorRestriction =
                 (BasicRestriction<Book, String>) _Book.author.equalTo("Myself")
                 // TODO TextRestriction.ignoreCase vs TextAttribute.upper/lowercased
@@ -174,13 +183,14 @@ class TextRestrictionRecordTest {
 
     @Test
     void shouldSupportNegationForTextRestriction() {
+        @SuppressWarnings("unchecked")
         BasicRestriction<Book,String> restriction =
                 (BasicRestriction<Book, String>) _Book.author.equalTo("John Doe").negate();
 
         NotEqualTo<String> constraint = (NotEqualTo<String>) restriction.constraint();
 
         SoftAssertions.assertSoftly(soft -> {
-            soft.assertThat(restriction.attribute()).isEqualTo("author");
+            soft.assertThat(restriction.expression()).isEqualTo(_Book.author);
             // TODO TextRestriction.ignoreCase vs TextAttribute.upper/lowercased
             //soft.assertThat(restriction.isCaseSensitive()).isTrue();
             soft.assertThat(constraint.value()).isEqualTo("John Doe");


### PR DESCRIPTION
BasicRestriction has a method, `attribute()`, that returns `String`, which is possibly the name of an entity attribute and otherwise `null`.  This is kind of awkward and is actually unnecessary because whenever the entity attribute name is available, then the `.expression()` is also an instance of `Attribute` which has `.name()` to get the entity attribute name. So we can omit the `attribute()` method entirely and not need to deal with the `null` at all, which seems preferable.

Also, under this PR, I noticed that we have a unit test case called SortableAttributeTest, but it tests ComparableAttribute rather than SortableAttribute, so I renamed it to better reflect what it covers.