### PR TITLE
move *Expression classes into the expression package with the other *Expression classes

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/BasicAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/BasicAttribute.java
@@ -17,6 +17,7 @@
  */
 package jakarta.data.metamodel;
 
+import jakarta.data.metamodel.expression.Expression;
 import jakarta.data.metamodel.impl.BasicAttributeRecord;
 
 import java.util.Objects;

--- a/api/src/main/java/jakarta/data/metamodel/ComparableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/ComparableAttribute.java
@@ -17,6 +17,7 @@
  */
 package jakarta.data.metamodel;
 
+import jakarta.data.metamodel.expression.ComparableExpression;
 import jakarta.data.metamodel.impl.ComparableAttributeRecord;
 
 import java.util.Objects;

--- a/api/src/main/java/jakarta/data/metamodel/NavigableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/NavigableAttribute.java
@@ -17,6 +17,7 @@
  */
 package jakarta.data.metamodel;
 
+import jakarta.data.metamodel.expression.NavigableExpression;
 import jakarta.data.metamodel.impl.NavigableAttributeRecord;
 
 import java.util.Objects;

--- a/api/src/main/java/jakarta/data/metamodel/NumericAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/NumericAttribute.java
@@ -17,6 +17,7 @@
  */
 package jakarta.data.metamodel;
 
+import jakarta.data.metamodel.expression.NumericExpression;
 import jakarta.data.metamodel.impl.NumericAttributeRecord;
 
 import java.util.Objects;

--- a/api/src/main/java/jakarta/data/metamodel/TextAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/TextAttribute.java
@@ -18,6 +18,7 @@
 package jakarta.data.metamodel;
 
 import jakarta.data.Sort;
+import jakarta.data.metamodel.expression.TextExpression;
 import jakarta.data.metamodel.impl.TextAttributeRecord;
 
 import java.util.Objects;

--- a/api/src/main/java/jakarta/data/metamodel/expression/ComparableExpression.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/ComparableExpression.java
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package jakarta.data.metamodel;
+package jakarta.data.metamodel.expression;
 
 import jakarta.data.metamodel.constraint.Between;
 import jakarta.data.metamodel.constraint.GreaterThan;

--- a/api/src/main/java/jakarta/data/metamodel/expression/Expression.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/Expression.java
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package jakarta.data.metamodel;
+package jakarta.data.metamodel.expression;
 
 import jakarta.data.metamodel.constraint.Constraint;
 import jakarta.data.metamodel.constraint.In;

--- a/api/src/main/java/jakarta/data/metamodel/expression/FunctionExpression.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/FunctionExpression.java
@@ -17,8 +17,6 @@
  */
 package jakarta.data.metamodel.expression;
 
-import jakarta.data.metamodel.Expression;
-
 import java.util.List;
 
 public interface FunctionExpression<T,V> extends Expression<T,V> {

--- a/api/src/main/java/jakarta/data/metamodel/expression/NavigableExpression.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/NavigableExpression.java
@@ -15,8 +15,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package jakarta.data.metamodel;
+package jakarta.data.metamodel.expression;
 
+import jakarta.data.metamodel.ComparableAttribute;
+import jakarta.data.metamodel.NavigableAttribute;
+import jakarta.data.metamodel.NumericAttribute;
+import jakarta.data.metamodel.TextAttribute;
 import jakarta.data.metamodel.path.ComparablePath;
 import jakarta.data.metamodel.path.NavigablePath;
 import jakarta.data.metamodel.path.NumericPath;

--- a/api/src/main/java/jakarta/data/metamodel/expression/NumericCast.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/NumericCast.java
@@ -17,8 +17,6 @@
  */
 package jakarta.data.metamodel.expression;
 
-import jakarta.data.metamodel.NumericExpression;
-
 public interface NumericCast<T, N extends Number & Comparable<N>>
         extends NumericExpression<T,N> {
     NumericExpression<T, ?> expression();

--- a/api/src/main/java/jakarta/data/metamodel/expression/NumericCastRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/NumericCastRecord.java
@@ -17,8 +17,6 @@
  */
 package jakarta.data.metamodel.expression;
 
-import jakarta.data.metamodel.NumericExpression;
-
 record NumericCastRecord<T, N extends Number & Comparable<N>>
         (NumericExpression<T,?> expression, Class<N> type)
         implements NumericCast<T,N> {

--- a/api/src/main/java/jakarta/data/metamodel/expression/NumericExpression.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/NumericExpression.java
@@ -15,11 +15,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package jakarta.data.metamodel;
-
-import jakarta.data.metamodel.expression.NumericCast;
-import jakarta.data.metamodel.expression.NumericFunctionExpression;
-import jakarta.data.metamodel.expression.NumericOperatorExpression;
+package jakarta.data.metamodel.expression;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;

--- a/api/src/main/java/jakarta/data/metamodel/expression/NumericFunctionExpression.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/NumericFunctionExpression.java
@@ -17,9 +17,6 @@
  */
 package jakarta.data.metamodel.expression;
 
-import jakarta.data.metamodel.NumericExpression;
-import jakarta.data.metamodel.TextExpression;
-
 import java.util.List;
 
 public interface NumericFunctionExpression<T, N extends Number & Comparable<N>>

--- a/api/src/main/java/jakarta/data/metamodel/expression/NumericFunctionExpressionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/NumericFunctionExpressionRecord.java
@@ -17,8 +17,6 @@
  */
 package jakarta.data.metamodel.expression;
 
-import jakarta.data.metamodel.Expression;
-
 import java.util.List;
 
 record NumericFunctionExpressionRecord<T, N extends Number & Comparable<N>>

--- a/api/src/main/java/jakarta/data/metamodel/expression/NumericLiteral.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/NumericLiteral.java
@@ -17,8 +17,6 @@
  */
 package jakarta.data.metamodel.expression;
 
-import jakarta.data.metamodel.NumericExpression;
-
 public interface NumericLiteral<T, N extends Number & Comparable<N>>
         extends NumericExpression<T,N> {
     N value();

--- a/api/src/main/java/jakarta/data/metamodel/expression/NumericOperatorExpression.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/NumericOperatorExpression.java
@@ -17,9 +17,6 @@
  */
 package jakarta.data.metamodel.expression;
 
-import jakarta.data.metamodel.Expression;
-import jakarta.data.metamodel.NumericExpression;
-
 public interface NumericOperatorExpression<T, N extends Number & Comparable<N>>
         extends NumericExpression<T,N> {
     enum Operator {

--- a/api/src/main/java/jakarta/data/metamodel/expression/NumericOperatorExpressionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/NumericOperatorExpressionRecord.java
@@ -17,8 +17,6 @@
  */
 package jakarta.data.metamodel.expression;
 
-import jakarta.data.metamodel.NumericExpression;
-
 record NumericOperatorExpressionRecord<T, N extends Number & Comparable<N>>
         (Operator operator, NumericExpression<T,N> left, NumericExpression<T,N> right)
         implements NumericOperatorExpression<T,N> {

--- a/api/src/main/java/jakarta/data/metamodel/expression/StringLiteral.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/StringLiteral.java
@@ -17,8 +17,6 @@
  */
 package jakarta.data.metamodel.expression;
 
-import jakarta.data.metamodel.TextExpression;
-
 public interface StringLiteral<T> extends TextExpression<T> {
     String value();
 

--- a/api/src/main/java/jakarta/data/metamodel/expression/TextExpression.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/TextExpression.java
@@ -15,12 +15,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package jakarta.data.metamodel;
+package jakarta.data.metamodel.expression;
 
 import jakarta.data.metamodel.constraint.Like;
 import jakarta.data.metamodel.constraint.NotLike;
-import jakarta.data.metamodel.expression.NumericFunctionExpression;
-import jakarta.data.metamodel.expression.TextFunctionExpression;
 import jakarta.data.metamodel.restrict.BasicRestriction;
 import jakarta.data.metamodel.restrict.Restriction;
 

--- a/api/src/main/java/jakarta/data/metamodel/expression/TextFunctionExpression.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/TextFunctionExpression.java
@@ -17,8 +17,6 @@
  */
 package jakarta.data.metamodel.expression;
 
-import jakarta.data.metamodel.TextExpression;
-
 import java.util.List;
 
 public interface TextFunctionExpression<T>

--- a/api/src/main/java/jakarta/data/metamodel/expression/TextFunctionExpressionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/TextFunctionExpressionRecord.java
@@ -17,8 +17,6 @@
  */
 package jakarta.data.metamodel.expression;
 
-import jakarta.data.metamodel.Expression;
-
 import java.util.List;
 
 record TextFunctionExpressionRecord<T>(String name, List<? extends Expression<T,?>> arguments)

--- a/api/src/main/java/jakarta/data/metamodel/path/ComparablePath.java
+++ b/api/src/main/java/jakarta/data/metamodel/path/ComparablePath.java
@@ -18,9 +18,8 @@
 package jakarta.data.metamodel.path;
 
 import jakarta.data.metamodel.ComparableAttribute;
-import jakarta.data.metamodel.ComparableExpression;
-import jakarta.data.metamodel.NavigableExpression;
-import jakarta.data.metamodel.Path;
+import jakarta.data.metamodel.expression.ComparableExpression;
+import jakarta.data.metamodel.expression.NavigableExpression;
 
 public interface ComparablePath<T,U,C extends Comparable<?>>
     extends Path<T,U>, ComparableExpression<T,C> {

--- a/api/src/main/java/jakarta/data/metamodel/path/ComparablePathRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/path/ComparablePathRecord.java
@@ -18,7 +18,7 @@
 package jakarta.data.metamodel.path;
 
 import jakarta.data.metamodel.ComparableAttribute;
-import jakarta.data.metamodel.NavigableExpression;
+import jakarta.data.metamodel.expression.NavigableExpression;
 
 record ComparablePathRecord<T,U,C extends Comparable<?>>
         (NavigableExpression<T,U> expression, ComparableAttribute<U, C> attribute)

--- a/api/src/main/java/jakarta/data/metamodel/path/NavigablePath.java
+++ b/api/src/main/java/jakarta/data/metamodel/path/NavigablePath.java
@@ -18,8 +18,7 @@
 package jakarta.data.metamodel.path;
 
 import jakarta.data.metamodel.NavigableAttribute;
-import jakarta.data.metamodel.NavigableExpression;
-import jakarta.data.metamodel.Path;
+import jakarta.data.metamodel.expression.NavigableExpression;
 
 public interface NavigablePath<T,U,V>
         extends Path<T,U>, NavigableExpression<T,V> {

--- a/api/src/main/java/jakarta/data/metamodel/path/NavigablePathRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/path/NavigablePathRecord.java
@@ -18,7 +18,7 @@
 package jakarta.data.metamodel.path;
 
 import jakarta.data.metamodel.NavigableAttribute;
-import jakarta.data.metamodel.NavigableExpression;
+import jakarta.data.metamodel.expression.NavigableExpression;
 
 record NavigablePathRecord<T,U,V>
         (NavigableExpression<T,U> expression, NavigableAttribute<U,V> attribute)

--- a/api/src/main/java/jakarta/data/metamodel/path/NumericPath.java
+++ b/api/src/main/java/jakarta/data/metamodel/path/NumericPath.java
@@ -17,10 +17,9 @@
  */
 package jakarta.data.metamodel.path;
 
-import jakarta.data.metamodel.NavigableExpression;
 import jakarta.data.metamodel.NumericAttribute;
-import jakarta.data.metamodel.NumericExpression;
-import jakarta.data.metamodel.Path;
+import jakarta.data.metamodel.expression.NavigableExpression;
+import jakarta.data.metamodel.expression.NumericExpression;
 
 public interface NumericPath<T,U,N extends Number & Comparable<N>>
         extends Path<T,U>, NumericExpression<T,N> {

--- a/api/src/main/java/jakarta/data/metamodel/path/NumericPathRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/path/NumericPathRecord.java
@@ -17,8 +17,8 @@
  */
 package jakarta.data.metamodel.path;
 
-import jakarta.data.metamodel.NavigableExpression;
 import jakarta.data.metamodel.NumericAttribute;
+import jakarta.data.metamodel.expression.NavigableExpression;
 
 record NumericPathRecord<T,U,N extends Number & Comparable<N>>
         (NavigableExpression<T,U> expression, NumericAttribute<U,N> attribute)

--- a/api/src/main/java/jakarta/data/metamodel/path/Path.java
+++ b/api/src/main/java/jakarta/data/metamodel/path/Path.java
@@ -15,7 +15,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package jakarta.data.metamodel;
+package jakarta.data.metamodel.path;
+
+import jakarta.data.metamodel.Attribute;
+import jakarta.data.metamodel.expression.NavigableExpression;
 
 public interface Path<T,U> {
     NavigableExpression<T,U> expression();

--- a/api/src/main/java/jakarta/data/metamodel/path/TextPath.java
+++ b/api/src/main/java/jakarta/data/metamodel/path/TextPath.java
@@ -17,10 +17,9 @@
  */
 package jakarta.data.metamodel.path;
 
-import jakarta.data.metamodel.NavigableExpression;
-import jakarta.data.metamodel.Path;
 import jakarta.data.metamodel.TextAttribute;
-import jakarta.data.metamodel.TextExpression;
+import jakarta.data.metamodel.expression.NavigableExpression;
+import jakarta.data.metamodel.expression.TextExpression;
 
 public interface TextPath<T,U>
         extends Path<T,U>, TextExpression<T> {

--- a/api/src/main/java/jakarta/data/metamodel/path/TextPathRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/path/TextPathRecord.java
@@ -17,8 +17,8 @@
  */
 package jakarta.data.metamodel.path;
 
-import jakarta.data.metamodel.NavigableExpression;
 import jakarta.data.metamodel.TextAttribute;
+import jakarta.data.metamodel.expression.NavigableExpression;
 
 record TextPathRecord<T,U>
         (NavigableExpression<T,U> expression, TextAttribute<U> attribute)

--- a/api/src/main/java/jakarta/data/metamodel/restrict/BasicRestriction.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/BasicRestriction.java
@@ -17,8 +17,8 @@
  */
 package jakarta.data.metamodel.restrict;
 
-import jakarta.data.metamodel.Expression;
 import jakarta.data.metamodel.constraint.Constraint;
+import jakarta.data.metamodel.expression.Expression;
 
 public interface BasicRestriction<T, V> extends Restriction<T> {
 

--- a/api/src/main/java/jakarta/data/metamodel/restrict/BasicRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/BasicRestrictionRecord.java
@@ -22,8 +22,8 @@ package jakarta.data.metamodel.restrict;
 // the static metamodel or Restrict.* methods 
 
 import jakarta.data.metamodel.Attribute;
-import jakarta.data.metamodel.Expression;
 import jakarta.data.metamodel.constraint.Constraint;
+import jakarta.data.metamodel.expression.Expression;
 
 import java.util.Objects;
 

--- a/api/src/test/java/jakarta/data/metamodel/expression/ExpressionTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/expression/ExpressionTest.java
@@ -17,7 +17,6 @@
  */
 package jakarta.data.metamodel.expression;
 
-import jakarta.data.metamodel.Expression;
 import jakarta.data.metamodel.constraint.*;
 import jakarta.data.metamodel.restrict.BasicRestriction;
 import jakarta.data.metamodel.restrict.Restriction;


### PR DESCRIPTION
We have a `jakarta.data.metamodel.expression` package with some of the *Expression classes and interfaces there, but others in the base `jakarta.data.metamodel` package.  This PR moves them all over to `jakarta.data.metamodel.expression` so they will be in the same place.  Also, there is a `jakarta.data.metamodel.path` package that has most things for Path, except for the `Path` class, so I have moved that as well under this PR.