### PR TITLE
deprecate metamodel impl package

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/BasicAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/BasicAttribute.java
@@ -17,8 +17,6 @@
  */
 package jakarta.data.metamodel;
 
-import jakarta.data.metamodel.impl.BasicAttributeRecord;
-
 import java.util.Objects;
 
 /**

--- a/api/src/main/java/jakarta/data/metamodel/BasicAttributeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/BasicAttributeRecord.java
@@ -15,11 +15,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package jakarta.data.metamodel.impl;
+package jakarta.data.metamodel;
 
-import jakarta.data.metamodel.ComparableAttribute;
-
-public record ComparableAttributeRecord<T,V extends Comparable<?>>
-        (Class<T> declaringType, String name)
-        implements ComparableAttribute<T,V> {
+record BasicAttributeRecord<T,V>(Class<T> declaringType, String name)
+        implements BasicAttribute<T,V> {
 }

--- a/api/src/main/java/jakarta/data/metamodel/ComparableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/ComparableAttribute.java
@@ -17,8 +17,6 @@
  */
 package jakarta.data.metamodel;
 
-import jakarta.data.metamodel.impl.ComparableAttributeRecord;
-
 import java.util.Objects;
 
 /**

--- a/api/src/main/java/jakarta/data/metamodel/ComparableAttributeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/ComparableAttributeRecord.java
@@ -15,10 +15,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package jakarta.data.metamodel.impl;
+package jakarta.data.metamodel;
 
-import jakarta.data.metamodel.BasicAttribute;
-
-public record BasicAttributeRecord<T,V>(Class<T> declaringType, String name)
-        implements BasicAttribute<T,V> {
+record ComparableAttributeRecord<T,V extends Comparable<?>>
+        (Class<T> declaringType, String name)
+        implements ComparableAttribute<T,V> {
 }

--- a/api/src/main/java/jakarta/data/metamodel/NavigableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/NavigableAttribute.java
@@ -17,8 +17,6 @@
  */
 package jakarta.data.metamodel;
 
-import jakarta.data.metamodel.impl.NavigableAttributeRecord;
-
 import java.util.Objects;
 
 /**

--- a/api/src/main/java/jakarta/data/metamodel/NavigableAttributeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/NavigableAttributeRecord.java
@@ -15,11 +15,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package jakarta.data.metamodel.impl;
+package jakarta.data.metamodel;
 
-import jakarta.data.metamodel.NumericAttribute;
-
-public record NumericAttributeRecord<T,V extends Number & Comparable<V>>
-        (Class<T> declaringType, String name)
-        implements NumericAttribute<T,V> {
+record NavigableAttributeRecord<T,U>(Class<T> declaringType, String name)
+        implements NavigableAttribute<T,U> {
 }

--- a/api/src/main/java/jakarta/data/metamodel/NumericAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/NumericAttribute.java
@@ -17,8 +17,6 @@
  */
 package jakarta.data.metamodel;
 
-import jakarta.data.metamodel.impl.NumericAttributeRecord;
-
 import java.util.Objects;
 
 /**

--- a/api/src/main/java/jakarta/data/metamodel/NumericAttributeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/NumericAttributeRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,18 +15,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package jakarta.data.metamodel.impl;
+package jakarta.data.metamodel;
 
-import jakarta.data.metamodel.TextAttribute;
-
-/**
- * @deprecated For more complete access to the static metamodel, use the
- * {@link jakarta.data.metamodel.TextAttribute#of(Class, String)} method
- * to obtain instances of {@link TextAttribute}.
- *
- * @param name the name of the attribute
- */
-@Deprecated(since = "1.1")
-public record TextAttributeRecord<T>(String name)
-        implements TextAttribute<T> {
+record NumericAttributeRecord<T,V extends Number & Comparable<V>>
+        (Class<T> declaringType, String name)
+        implements NumericAttribute<T,V> {
 }

--- a/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java
@@ -20,7 +20,6 @@ package jakarta.data.metamodel;
 import java.util.Objects;
 
 import jakarta.data.Sort;
-import jakarta.data.metamodel.impl.SortableAttributeRecord;
 
 /**
  * <p>Represents a entity attribute in the {@link StaticMetamodel}

--- a/api/src/main/java/jakarta/data/metamodel/SortableAttributeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/SortableAttributeRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,18 +15,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package jakarta.data.metamodel.impl;
+package jakarta.data.metamodel;
 
-import jakarta.data.metamodel.TextAttribute;
-
-/**
- * @deprecated For more complete access to the static metamodel, use the
- * {@link jakarta.data.metamodel.TextAttribute#of(Class, String)} method
- * to obtain instances of {@link TextAttribute}.
- *
- * @param name the name of the attribute
- */
-@Deprecated(since = "1.1")
-public record TextAttributeRecord<T>(String name)
-        implements TextAttribute<T> {
+record SortableAttributeRecord<T>(Class<T> declaringType, String name)
+        implements SortableAttribute<T> {
 }
+

--- a/api/src/main/java/jakarta/data/metamodel/TextAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/TextAttribute.java
@@ -18,7 +18,6 @@
 package jakarta.data.metamodel;
 
 import jakarta.data.Sort;
-import jakarta.data.metamodel.impl.TextAttributeRecord;
 
 import java.util.Objects;
 

--- a/api/src/main/java/jakarta/data/metamodel/TextAttributeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/TextAttributeRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,18 +15,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package jakarta.data.metamodel.impl;
+package jakarta.data.metamodel;
 
-import jakarta.data.metamodel.TextAttribute;
-
-/**
- * @deprecated For more complete access to the static metamodel, use the
- * {@link jakarta.data.metamodel.TextAttribute#of(Class, String)} method
- * to obtain instances of {@link TextAttribute}.
- *
- * @param name the name of the attribute
- */
-@Deprecated(since = "1.1")
-public record TextAttributeRecord<T>(String name)
+record TextAttributeRecord<T>(Class<T> declaringType, String name)
         implements TextAttribute<T> {
 }

--- a/api/src/main/java/jakarta/data/metamodel/impl/AttributeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/impl/AttributeRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,19 +18,20 @@
 package jakarta.data.metamodel.impl;
 
 import jakarta.data.metamodel.Attribute;
+import jakarta.data.metamodel.NumericAttribute;
+import jakarta.data.metamodel.TextAttribute;
 
 /**
- * Record type implementing {@link jakarta.data.metamodel.TextAttribute}.
- * This may be used to simplify implementation of the static metamodel.
+ * @deprecated For more complete access to the static metamodel, use the
+ * most specific subtype of {@link Attribute} that describes the entity
+ * attribute, such as
+ * {@link TextAttribute#of(Class, String) TextAttribute} or
+ * {@link NumericAttribute#of(Class, String, Class) NumericAttribute}.
  *
- * @param <T> entity class of the static metamodel.
  * @param name the name of the attribute
  */
-public record AttributeRecord<T>(Class<T> declaringType, String name)
+@Deprecated(since = "1.1")
+public record AttributeRecord<T>(String name)
         implements Attribute<T> {
-    @Deprecated(since = "1.1")
-    public AttributeRecord(String name) {
-        this(null, name);
-    }
 }
 

--- a/api/src/main/java/jakarta/data/metamodel/impl/SortableAttributeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/impl/SortableAttributeRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,19 +17,21 @@
  */
 package jakarta.data.metamodel.impl;
 
+import jakarta.data.metamodel.NumericAttribute;
 import jakarta.data.metamodel.SortableAttribute;
+import jakarta.data.metamodel.TextAttribute;
 
 /**
- * Record type implementing {@link jakarta.data.metamodel.SortableAttribute}.
- * This may be used to simplify implementation of the static metamodel.
+ * @deprecated For more complete access to the static metamodel, use the
+ * most specific subtype of {@link SortableAttribute} that applies to the
+ * entity attribute, such as
+ * {@link TextAttribute#of(Class, String) TextAttribute} or
+ * {@link NumericAttribute#of(Class, String, Class) NumericAttribute}.
  *
  * @param name the name of the attribute
  */
-public record SortableAttributeRecord<T>(Class<T> declaringType, String name)
+@Deprecated(since = "1.1")
+public record SortableAttributeRecord<T>(String name)
         implements SortableAttribute<T> {
-    @Deprecated(since = "1.1")
-    public SortableAttributeRecord(String name) {
-        this(null, name);
-    }
 }
 

--- a/api/src/main/java/jakarta/data/metamodel/impl/package-info.java
+++ b/api/src/main/java/jakarta/data/metamodel/impl/package-info.java
@@ -15,10 +15,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+@Deprecated(since = "1.1")
 package jakarta.data.metamodel.impl;
-
-import jakarta.data.metamodel.NavigableAttribute;
-
-public record NavigableAttributeRecord<T,U>(Class<T> declaringType, String name)
-        implements NavigableAttribute<T,U> {
-}


### PR DESCRIPTION
fixes #689

Given that a recent change to add `declaringType()` to `Attribute` has already resulted in deprecating all existing usage of the `AttributeRecord`, `SortableAttributeRecord`,  and `TextAttributeRecord` constructors, and these were the only 3 classes in the `jakarta.data.metamodel.impl` package as of Data 1.0, it means that every static metamodel generated to use the `jakarta.data.metamodel.impl` package of Data 1.0 is now using deprecated function.  That makes now the ideal time to deprecate the package and stop adding to it, instead directing any users and annotation processors to the `*Attribute.of` methods which are the preferred and more complete way to create static metamodel classes that are properly typed.  What is done under this PR is a clean way to encourage moving static metamodels off of the `impl` package that causes zero additional churn for users beyond what has already been done in Data 1.1 regardless of this PR.