### PR TITLE
Can we use vargargs instead of Set?

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/Expression.java
+++ b/api/src/main/java/jakarta/data/metamodel/Expression.java
@@ -26,7 +26,6 @@ import jakarta.data.metamodel.constraint.Null;
 import jakarta.data.metamodel.restrict.BasicRestriction;
 import jakarta.data.metamodel.restrict.Restriction;
 
-import java.util.Set;
 
 public interface Expression<T,V> {
 

--- a/api/src/main/java/jakarta/data/metamodel/Expression.java
+++ b/api/src/main/java/jakarta/data/metamodel/Expression.java
@@ -35,6 +35,14 @@ public interface Expression<T,V> {
     }
 
     default Restriction<T> in(Set<V> values) {
+        if (values == null || values.isEmpty()){
+            throw new IllegalArgumentException("values are required");
+        }
+
+        return BasicRestriction.of(this, In.values(values));
+    }
+
+    default Restriction<T> in(V... values) {
         if (values == null || values.isEmpty())
             throw new IllegalArgumentException("values are required");
 

--- a/api/src/main/java/jakarta/data/metamodel/Expression.java
+++ b/api/src/main/java/jakarta/data/metamodel/Expression.java
@@ -34,18 +34,10 @@ public interface Expression<T,V> {
         return BasicRestriction.of(this, Constraint.equalTo(value));
     }
 
-    default Restriction<T> in(Set<V> values) {
-        if (values == null || values.isEmpty()){
+    default Restriction<T> in(V... values) {
+        if (values == null || values.length == 0){
             throw new IllegalArgumentException("values are required");
         }
-
-        return BasicRestriction.of(this, In.values(values));
-    }
-
-    default Restriction<T> in(V... values) {
-        if (values == null || values.isEmpty())
-            throw new IllegalArgumentException("values are required");
-
         return BasicRestriction.of(this, In.values(values));
     }
 
@@ -57,9 +49,10 @@ public interface Expression<T,V> {
         return BasicRestriction.of(this, NotEqualTo.value(value));
     }
 
-    default Restriction<T> notIn(Set<V> values) {
-        if (values == null || values.isEmpty())
+    default Restriction<T> notIn(V... values) {
+        if (values == null || values.length == 0){
             throw new IllegalArgumentException("values are required");
+        }
 
         return BasicRestriction.of(this, NotIn.values(values));
     }

--- a/api/src/test/java/jakarta/data/metamodel/AttributeTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/AttributeTest.java
@@ -77,7 +77,7 @@ class AttributeTest {
     void shouldCreateInRestriction() {
         @SuppressWarnings("unchecked")
         BasicRestriction<Person, String> restriction =
-                (BasicRestriction<Person, String>) testAttribute.in(Set.of("value1", "value2"));
+                (BasicRestriction<Person, String>) testAttribute.in("value1", "value2");
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
@@ -89,7 +89,7 @@ class AttributeTest {
 
     @Test
     void shouldThrowExceptionForEmptyInRestriction() {
-        assertThatThrownBy(() -> testAttribute.in(Set.of()))
+        assertThatThrownBy(() -> testAttribute.in())
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("values are required");
     }

--- a/api/src/test/java/jakarta/data/metamodel/AttributeTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/AttributeTest.java
@@ -98,7 +98,7 @@ class AttributeTest {
     void shouldCreateNotInRestriction() {
         @SuppressWarnings("unchecked")
         BasicRestriction<Person, String> restriction =
-                (BasicRestriction<Person, String>) testAttribute.notIn(Set.of("value1", "value2"));
+                (BasicRestriction<Person, String>) testAttribute.notIn("value1", "value2");
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
@@ -110,7 +110,7 @@ class AttributeTest {
 
     @Test
     void shouldThrowExceptionForEmptyNotInRestriction() {
-        assertThatThrownBy(() -> testAttribute.notIn(Set.of()))
+        assertThatThrownBy(() -> testAttribute.notIn())
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("values are required");
     }

--- a/api/src/test/java/jakarta/data/metamodel/restrict/BasicRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/BasicRestrictionRecordTest.java
@@ -197,7 +197,7 @@ class BasicRestrictionRecordTest {
     @DisplayName("should create In constraint correctly")
     @Test
     void shouldCreateInRestriction() {
-        var restriction = (BasicRestriction<Book, String>) _Book.author.in(Set.of("Alice", "Bob"));
+        var restriction = (BasicRestriction<Book, String>) _Book.author.in("Alice", "Bob");
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.expression()).isEqualTo(_Book.author);
@@ -209,7 +209,7 @@ class BasicRestrictionRecordTest {
     @DisplayName("should create NotIn constraint correctly")
     @Test
     void shouldCreateNotInRestriction() {
-        var restriction = (BasicRestriction<Book, String>) _Book.author.in(Set.of("Alice", "Bob")).negate();
+        var restriction = (BasicRestriction<Book, String>) _Book.author.in("Alice", "Bob").negate();
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.expression()).isEqualTo(_Book.author);


### PR DESCRIPTION

Can we use varags here instead of `Set`?

This is a small change, but it simplifies the goal, which is to move the input without creating a Set instance.

```java
   var restriction =  _Book.author.in("Alice", "Bob");
```

instead of:

```java
   var restriction =  _Book.author.in(Set.of("Alice", "Bob"));
```