### PR TITLE
Fix the URL reference at Jakarta EE theme on Data spec

### DIFF
--- a/spec/src/main/asciidoc/jakarta-data.adoc
+++ b/spec/src/main/asciidoc/jakarta-data.adoc
@@ -14,7 +14,7 @@
 
 = Jakarta Data
 :title: Jakarta Data
-:pdf-theme: ../../theme/jakartaee-theme.yml
+:pdf-theme: {docdir}/../../theme/jakartaee-theme.yml
 :authors:
 :email:
 :version-label!:

--- a/spec/src/main/asciidoc/method-query.asciidoc
+++ b/spec/src/main/asciidoc/method-query.asciidoc
@@ -14,7 +14,7 @@
 
 = Jakarta Data: Query by Method Name Extension
 :title: Jakarta Data: Query by Method Name Extension
-:pdf-theme: ../../theme/jakartaee-theme.yml
+:pdf-theme: {docdir}/../../theme/jakartaee-theme.yml
 :authors:
 :email:
 :version-label!:


### PR DESCRIPTION

After creating the Jakarta-Query project, I realized that we were not creating the spec with the proper theme, as shown by this warning:

```
[INFO] asciidoctor: ERROR: jakarta-data.adoc: could not locate or load the built-in pdf theme `../../theme/jakartaee-theme.yml' because of Errno::ENOENT No such file or directory - /Users/otaviosantana/Env/code/workspace-jakarta/theme/jakartaee-theme.yml; reverting to default theme
``` 

This PR fixes it, and now we have the proper Jakarta Theme on the spec.