### PR TITLE
Follow consistent style for messages

### DIFF
--- a/api/src/main/java/jakarta/data/Sort.java
+++ b/api/src/main/java/jakarta/data/Sort.java
@@ -108,7 +108,7 @@ public record Sort<T>(String property, boolean isAscending, boolean ignoreCase) 
      * @param ignoreCase  whether or not to request case insensitive ordering from a database with case sensitive collation.
      */
     public Sort {
-        Objects.requireNonNull(property, "property is required");
+        Objects.requireNonNull(property, "The property is required");
     }
 
     // Override to provide method documentation:
@@ -166,7 +166,7 @@ public record Sort<T>(String property, boolean isAscending, boolean ignoreCase) 
      * @throws NullPointerException when there is a null parameter
      */
     public static <T> Sort<T> of(String attribute, Direction direction, boolean ignoreCase) {
-        Objects.requireNonNull(direction, "direction is required");
+        Objects.requireNonNull(direction, "The direction is required");
         return new Sort<>(attribute, Direction.ASC.equals(direction), ignoreCase);
     }
 

--- a/api/src/main/java/jakarta/data/metamodel/BasicAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/BasicAttribute.java
@@ -42,9 +42,9 @@ public interface BasicAttribute<T,V> extends Attribute<T>, Expression<T,V> {
     static <T,V> BasicAttribute<T,V> of(Class<T> entityClass,
                                         String name,
                                         Class<V> attributeType) {
-        Objects.requireNonNull(entityClass, "Entity class is required.");
-        Objects.requireNonNull(name, "Entity attribute name is required.");
-        Objects.requireNonNull(attributeType, "Entity attribute type is required.");
+        Objects.requireNonNull(entityClass, "Entity class is required");
+        Objects.requireNonNull(name, "Entity attribute name is required");
+        Objects.requireNonNull(attributeType, "Entity attribute type is required");
 
         return new BasicAttributeRecord<>(entityClass, name);
     }

--- a/api/src/main/java/jakarta/data/metamodel/BasicAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/BasicAttribute.java
@@ -42,9 +42,9 @@ public interface BasicAttribute<T,V> extends Attribute<T>, Expression<T,V> {
     static <T,V> BasicAttribute<T,V> of(Class<T> entityClass,
                                         String name,
                                         Class<V> attributeType) {
-        Objects.requireNonNull(entityClass, "Entity class is required");
-        Objects.requireNonNull(name, "Entity attribute name is required");
-        Objects.requireNonNull(attributeType, "Entity attribute type is required");
+        Objects.requireNonNull(entityClass, "The entityClass is required");
+        Objects.requireNonNull(name, "The name is required");
+        Objects.requireNonNull(attributeType, "The attributeType is required");
 
         return new BasicAttributeRecord<>(entityClass, name);
     }

--- a/api/src/main/java/jakarta/data/metamodel/BasicAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/BasicAttribute.java
@@ -42,9 +42,9 @@ public interface BasicAttribute<T,V> extends Attribute<T>, Expression<T,V> {
     static <T,V> BasicAttribute<T,V> of(Class<T> entityClass,
                                         String name,
                                         Class<V> attributeType) {
-        Objects.requireNonNull(entityClass, "entity class is required");
-        Objects.requireNonNull(name, "entity attribute name is required");
-        Objects.requireNonNull(attributeType, "entity attribute type is required");
+        Objects.requireNonNull(entityClass, "Entity class is required.");
+        Objects.requireNonNull(name, "Entity attribute name is required.");
+        Objects.requireNonNull(attributeType, "Entity attribute type is required.");
 
         return new BasicAttributeRecord<>(entityClass, name);
     }

--- a/api/src/main/java/jakarta/data/metamodel/ComparableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/ComparableAttribute.java
@@ -73,9 +73,9 @@ public interface ComparableAttribute<T,V extends Comparable<?>>
             Class<T> entityClass,
             String name,
             Class<V> attributeType) {
-        Objects.requireNonNull(entityClass, "entity class is required");
-        Objects.requireNonNull(name, "entity attribute name is required");
-        Objects.requireNonNull(attributeType, "entity attribute type is required");
+        Objects.requireNonNull(entityClass, "Entity class is required.");
+        Objects.requireNonNull(name, "Entity attribute name is required.");
+        Objects.requireNonNull(attributeType, "Entity attribute type is required.");
 
         return new ComparableAttributeRecord<>(entityClass, name);
     }

--- a/api/src/main/java/jakarta/data/metamodel/ComparableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/ComparableAttribute.java
@@ -73,9 +73,9 @@ public interface ComparableAttribute<T,V extends Comparable<?>>
             Class<T> entityClass,
             String name,
             Class<V> attributeType) {
-        Objects.requireNonNull(entityClass, "Entity class is required");
-        Objects.requireNonNull(name, "Entity attribute name is required");
-        Objects.requireNonNull(attributeType, "Entity attribute type is required");
+        Objects.requireNonNull(entityClass, "The entityClass is required");
+        Objects.requireNonNull(name, "The name is required");
+        Objects.requireNonNull(attributeType, "The attributeType is required");
 
         return new ComparableAttributeRecord<>(entityClass, name);
     }

--- a/api/src/main/java/jakarta/data/metamodel/ComparableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/ComparableAttribute.java
@@ -73,9 +73,9 @@ public interface ComparableAttribute<T,V extends Comparable<?>>
             Class<T> entityClass,
             String name,
             Class<V> attributeType) {
-        Objects.requireNonNull(entityClass, "Entity class is required.");
-        Objects.requireNonNull(name, "Entity attribute name is required.");
-        Objects.requireNonNull(attributeType, "Entity attribute type is required.");
+        Objects.requireNonNull(entityClass, "Entity class is required");
+        Objects.requireNonNull(name, "Entity attribute name is required");
+        Objects.requireNonNull(attributeType, "Entity attribute type is required");
 
         return new ComparableAttributeRecord<>(entityClass, name);
     }

--- a/api/src/main/java/jakarta/data/metamodel/Expression.java
+++ b/api/src/main/java/jakarta/data/metamodel/Expression.java
@@ -41,7 +41,7 @@ public interface Expression<T,V> {
 
     default Restriction<T> in(Collection<V> values) {
         if (values == null || values.isEmpty())
-            throw new IllegalArgumentException("values are required");
+            throw new IllegalArgumentException("Values are required.");
 
         return BasicRestriction.of(this, In.values(values));
     }
@@ -70,7 +70,7 @@ public interface Expression<T,V> {
 
     default Restriction<T> notIn(Collection<V> values) {
         if (values == null || values.isEmpty())
-            throw new IllegalArgumentException("values are required");
+            throw new IllegalArgumentException("Values are required.");
 
         return BasicRestriction.of(this, NotIn.values(values));
     }

--- a/api/src/main/java/jakarta/data/metamodel/Expression.java
+++ b/api/src/main/java/jakarta/data/metamodel/Expression.java
@@ -41,7 +41,7 @@ public interface Expression<T,V> {
 
     default Restriction<T> in(Collection<V> values) {
         if (values == null || values.isEmpty())
-            throw new IllegalArgumentException("Values are required.");
+            throw new IllegalArgumentException("Values are required");
 
         return BasicRestriction.of(this, In.values(values));
     }
@@ -70,7 +70,7 @@ public interface Expression<T,V> {
 
     default Restriction<T> notIn(Collection<V> values) {
         if (values == null || values.isEmpty())
-            throw new IllegalArgumentException("Values are required.");
+            throw new IllegalArgumentException("Values are required");
 
         return BasicRestriction.of(this, NotIn.values(values));
     }

--- a/api/src/main/java/jakarta/data/metamodel/Expression.java
+++ b/api/src/main/java/jakarta/data/metamodel/Expression.java
@@ -41,7 +41,7 @@ public interface Expression<T,V> {
 
     default Restriction<T> in(Collection<V> values) {
         if (values == null || values.isEmpty())
-            throw new IllegalArgumentException("Values are required");
+            throw new IllegalArgumentException("The values are required");
 
         return BasicRestriction.of(this, In.values(values));
     }
@@ -70,7 +70,7 @@ public interface Expression<T,V> {
 
     default Restriction<T> notIn(Collection<V> values) {
         if (values == null || values.isEmpty())
-            throw new IllegalArgumentException("Values are required");
+            throw new IllegalArgumentException("The values are required");
 
         return BasicRestriction.of(this, NotIn.values(values));
     }

--- a/api/src/main/java/jakarta/data/metamodel/NavigableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/NavigableAttribute.java
@@ -44,9 +44,9 @@ public interface NavigableAttribute<T,U>
     static <T,U> NavigableAttribute<T,U> of(Class<T> entityClass,
                                             String name,
                                             Class<U> attributeType) {
-        Objects.requireNonNull(entityClass, "Entity class is required");
-        Objects.requireNonNull(name, "Entity attribute name is required");
-        Objects.requireNonNull(attributeType, "Entity attribute type is required");
+        Objects.requireNonNull(entityClass, "The entityClass is required");
+        Objects.requireNonNull(name, "The name is required");
+        Objects.requireNonNull(attributeType, "The attributeType is required");
 
         return new NavigableAttributeRecord<>(entityClass, name);
     }

--- a/api/src/main/java/jakarta/data/metamodel/NavigableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/NavigableAttribute.java
@@ -44,9 +44,9 @@ public interface NavigableAttribute<T,U>
     static <T,U> NavigableAttribute<T,U> of(Class<T> entityClass,
                                             String name,
                                             Class<U> attributeType) {
-        Objects.requireNonNull(entityClass, "entity class is required");
-        Objects.requireNonNull(name, "entity attribute name is required");
-        Objects.requireNonNull(attributeType, "entity attribute type is required");
+        Objects.requireNonNull(entityClass, "Entity class is required.");
+        Objects.requireNonNull(name, "Entity attribute name is required.");
+        Objects.requireNonNull(attributeType, "Entity attribute type is required.");
 
         return new NavigableAttributeRecord<>(entityClass, name);
     }

--- a/api/src/main/java/jakarta/data/metamodel/NavigableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/NavigableAttribute.java
@@ -44,9 +44,9 @@ public interface NavigableAttribute<T,U>
     static <T,U> NavigableAttribute<T,U> of(Class<T> entityClass,
                                             String name,
                                             Class<U> attributeType) {
-        Objects.requireNonNull(entityClass, "Entity class is required.");
-        Objects.requireNonNull(name, "Entity attribute name is required.");
-        Objects.requireNonNull(attributeType, "Entity attribute type is required.");
+        Objects.requireNonNull(entityClass, "Entity class is required");
+        Objects.requireNonNull(name, "Entity attribute name is required");
+        Objects.requireNonNull(attributeType, "Entity attribute type is required");
 
         return new NavigableAttributeRecord<>(entityClass, name);
     }

--- a/api/src/main/java/jakarta/data/metamodel/NumericAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/NumericAttribute.java
@@ -60,9 +60,9 @@ public interface NumericAttribute<T,N extends Number & Comparable<N>>
      */
     static <T,N extends Number & Comparable<N>> NumericAttribute<T,N> of(
             Class<T> entityClass, String name, Class<N> attributeType) {
-        Objects.requireNonNull(entityClass, "entity class is required");
-        Objects.requireNonNull(name, "entity attribute name is required");
-        Objects.requireNonNull(attributeType, "entity attribute type is required");
+        Objects.requireNonNull(entityClass, "Entity class is required.");
+        Objects.requireNonNull(name, "Entity attribute name is required.");
+        Objects.requireNonNull(attributeType, "Entity attribute type is required.");
 
         return new NumericAttributeRecord<>(entityClass, name);
     }

--- a/api/src/main/java/jakarta/data/metamodel/NumericAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/NumericAttribute.java
@@ -60,9 +60,9 @@ public interface NumericAttribute<T,N extends Number & Comparable<N>>
      */
     static <T,N extends Number & Comparable<N>> NumericAttribute<T,N> of(
             Class<T> entityClass, String name, Class<N> attributeType) {
-        Objects.requireNonNull(entityClass, "Entity class is required");
-        Objects.requireNonNull(name, "Entity attribute name is required");
-        Objects.requireNonNull(attributeType, "Entity attribute type is required");
+        Objects.requireNonNull(entityClass, "The entityClass is required");
+        Objects.requireNonNull(name, "The name is required");
+        Objects.requireNonNull(attributeType, "The attributeType is required");
 
         return new NumericAttributeRecord<>(entityClass, name);
     }

--- a/api/src/main/java/jakarta/data/metamodel/NumericAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/NumericAttribute.java
@@ -60,9 +60,9 @@ public interface NumericAttribute<T,N extends Number & Comparable<N>>
      */
     static <T,N extends Number & Comparable<N>> NumericAttribute<T,N> of(
             Class<T> entityClass, String name, Class<N> attributeType) {
-        Objects.requireNonNull(entityClass, "Entity class is required.");
-        Objects.requireNonNull(name, "Entity attribute name is required.");
-        Objects.requireNonNull(attributeType, "Entity attribute type is required.");
+        Objects.requireNonNull(entityClass, "Entity class is required");
+        Objects.requireNonNull(name, "Entity attribute name is required");
+        Objects.requireNonNull(attributeType, "Entity attribute type is required");
 
         return new NumericAttributeRecord<>(entityClass, name);
     }

--- a/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java
@@ -71,9 +71,9 @@ public interface SortableAttribute<T> extends Attribute<T> {
     static <T, V> SortableAttribute<T> of(Class<T> entityClass,
                                           String name,
                                           Class<V> attributeType) {
-        Objects.requireNonNull(entityClass, "entity class is required");
-        Objects.requireNonNull(name, "entity attribute name is required");
-        Objects.requireNonNull(attributeType, "entity attribute type is required");
+        Objects.requireNonNull(entityClass, "Entity class is required.");
+        Objects.requireNonNull(name, "Entity attribute name is required.");
+        Objects.requireNonNull(attributeType, "Entity attribute type is required.");
 
         return new SortableAttributeRecord<>(entityClass, name);
     }

--- a/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java
@@ -71,9 +71,9 @@ public interface SortableAttribute<T> extends Attribute<T> {
     static <T, V> SortableAttribute<T> of(Class<T> entityClass,
                                           String name,
                                           Class<V> attributeType) {
-        Objects.requireNonNull(entityClass, "Entity class is required");
-        Objects.requireNonNull(name, "Entity attribute name is required");
-        Objects.requireNonNull(attributeType, "Entity attribute type is required");
+        Objects.requireNonNull(entityClass, "The entityClass is required");
+        Objects.requireNonNull(name, "The name is required");
+        Objects.requireNonNull(attributeType, "The attributeType is required");
 
         return new SortableAttributeRecord<>(entityClass, name);
     }

--- a/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java
@@ -71,9 +71,9 @@ public interface SortableAttribute<T> extends Attribute<T> {
     static <T, V> SortableAttribute<T> of(Class<T> entityClass,
                                           String name,
                                           Class<V> attributeType) {
-        Objects.requireNonNull(entityClass, "Entity class is required.");
-        Objects.requireNonNull(name, "Entity attribute name is required.");
-        Objects.requireNonNull(attributeType, "Entity attribute type is required.");
+        Objects.requireNonNull(entityClass, "Entity class is required");
+        Objects.requireNonNull(name, "Entity attribute name is required");
+        Objects.requireNonNull(attributeType, "Entity attribute type is required");
 
         return new SortableAttributeRecord<>(entityClass, name);
     }

--- a/api/src/main/java/jakarta/data/metamodel/TemporalAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/TemporalAttribute.java
@@ -59,9 +59,9 @@ public interface TemporalAttribute<T,V extends Temporal & Comparable<? extends T
      */
     static <T,V extends Temporal & Comparable<? extends Temporal>> TemporalAttribute<T,V> of(
             Class<T> entityClass, String name, Class<V> attributeType) {
-        Objects.requireNonNull(entityClass, "entity class is required");
-        Objects.requireNonNull(name, "entity attribute name is required");
-        Objects.requireNonNull(attributeType, "entity attribute type is required");
+        Objects.requireNonNull(entityClass, "Entity class is required.");
+        Objects.requireNonNull(name, "Entity attribute name is required.");
+        Objects.requireNonNull(attributeType, "Entity attribute type is required.");
 
         return new TemporalAttributeRecord<T, V>(entityClass, name);
     }

--- a/api/src/main/java/jakarta/data/metamodel/TemporalAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/TemporalAttribute.java
@@ -59,9 +59,9 @@ public interface TemporalAttribute<T,V extends Temporal & Comparable<? extends T
      */
     static <T,V extends Temporal & Comparable<? extends Temporal>> TemporalAttribute<T,V> of(
             Class<T> entityClass, String name, Class<V> attributeType) {
-        Objects.requireNonNull(entityClass, "Entity class is required.");
-        Objects.requireNonNull(name, "Entity attribute name is required.");
-        Objects.requireNonNull(attributeType, "Entity attribute type is required.");
+        Objects.requireNonNull(entityClass, "Entity class is required");
+        Objects.requireNonNull(name, "Entity attribute name is required");
+        Objects.requireNonNull(attributeType, "Entity attribute type is required");
 
         return new TemporalAttributeRecord<T, V>(entityClass, name);
     }

--- a/api/src/main/java/jakarta/data/metamodel/TemporalAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/TemporalAttribute.java
@@ -59,9 +59,9 @@ public interface TemporalAttribute<T,V extends Temporal & Comparable<? extends T
      */
     static <T,V extends Temporal & Comparable<? extends Temporal>> TemporalAttribute<T,V> of(
             Class<T> entityClass, String name, Class<V> attributeType) {
-        Objects.requireNonNull(entityClass, "Entity class is required");
-        Objects.requireNonNull(name, "Entity attribute name is required");
-        Objects.requireNonNull(attributeType, "Entity attribute type is required");
+        Objects.requireNonNull(entityClass, "The entityClass is required");
+        Objects.requireNonNull(name, "The name is required");
+        Objects.requireNonNull(attributeType, "The attributeType is required");
 
         return new TemporalAttributeRecord<T, V>(entityClass, name);
     }

--- a/api/src/main/java/jakarta/data/metamodel/TextAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/TextAttribute.java
@@ -56,8 +56,8 @@ public interface TextAttribute<T> extends ComparableAttribute<T,String>, TextExp
      * @return instance of {@code TextAttribute}.
      */
     static <T> TextAttribute<T> of(Class<T> entityClass, String name) {
-        Objects.requireNonNull(entityClass, "Entity class is required");
-        Objects.requireNonNull(name, "Entity attribute name is required");
+        Objects.requireNonNull(entityClass, "The entityClass is required");
+        Objects.requireNonNull(name, "The name is required");
 
         return new TextAttributeRecord<>(entityClass, name);
     }

--- a/api/src/main/java/jakarta/data/metamodel/TextAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/TextAttribute.java
@@ -56,8 +56,8 @@ public interface TextAttribute<T> extends ComparableAttribute<T,String>, TextExp
      * @return instance of {@code TextAttribute}.
      */
     static <T> TextAttribute<T> of(Class<T> entityClass, String name) {
-        Objects.requireNonNull(entityClass, "entity class is required");
-        Objects.requireNonNull(name, "entity attribute name is required");
+        Objects.requireNonNull(entityClass, "Entity class is required.");
+        Objects.requireNonNull(name, "Entity attribute name is required.");
 
         return new TextAttributeRecord<>(entityClass, name);
     }

--- a/api/src/main/java/jakarta/data/metamodel/TextAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/TextAttribute.java
@@ -56,8 +56,8 @@ public interface TextAttribute<T> extends ComparableAttribute<T,String>, TextExp
      * @return instance of {@code TextAttribute}.
      */
     static <T> TextAttribute<T> of(Class<T> entityClass, String name) {
-        Objects.requireNonNull(entityClass, "Entity class is required.");
-        Objects.requireNonNull(name, "Entity attribute name is required.");
+        Objects.requireNonNull(entityClass, "Entity class is required");
+        Objects.requireNonNull(name, "Entity attribute name is required");
 
         return new TextAttributeRecord<>(entityClass, name);
     }

--- a/api/src/main/java/jakarta/data/metamodel/constraint/BetweenRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/BetweenRecord.java
@@ -26,8 +26,8 @@ record BetweenRecord<V extends Comparable<?>>(
         ComparableExpression<?, V> upperBound)
         implements Between<V> {
     public BetweenRecord {
-        Objects.requireNonNull(lowerBound, "Lower bound is required.");
-        Objects.requireNonNull(upperBound, "Upper bound is required.");
+        Objects.requireNonNull(lowerBound, "Lower bound is required");
+        Objects.requireNonNull(upperBound, "Upper bound is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/constraint/BetweenRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/BetweenRecord.java
@@ -26,8 +26,8 @@ record BetweenRecord<V extends Comparable<?>>(
         ComparableExpression<?, V> upperBound)
         implements Between<V> {
     public BetweenRecord {
-        Objects.requireNonNull(lowerBound);
-        Objects.requireNonNull(upperBound);
+        Objects.requireNonNull(lowerBound, "Lower bound is required.");
+        Objects.requireNonNull(upperBound, "Upper bound is required.");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/constraint/BetweenRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/BetweenRecord.java
@@ -26,8 +26,10 @@ record BetweenRecord<V extends Comparable<?>>(
         ComparableExpression<?, V> upperBound)
         implements Between<V> {
     public BetweenRecord {
-        Objects.requireNonNull(lowerBound, "Lower bound is required");
-        Objects.requireNonNull(upperBound, "Upper bound is required");
+        Objects.requireNonNull(lowerBound,
+                "The lower value or expression is required");
+        Objects.requireNonNull(upperBound,
+                "The upper value or expression is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/constraint/EqualTo.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/EqualTo.java
@@ -17,16 +17,20 @@
  */
 package jakarta.data.metamodel.constraint;
 
+import java.util.Objects;
+
 import jakarta.data.metamodel.Expression;
 import jakarta.data.metamodel.expression.Literal;
 
 public interface EqualTo<V> extends Constraint<V> {
 
     static <V> EqualTo<V> expression(Expression<?, V> expression) {
+        Objects.requireNonNull(expression, "The expression is required");
         return new EqualToRecord<>(expression);
     }
 
     static <V> EqualTo<V> value(V value) {
+        Objects.requireNonNull(value, "The value is required");
         return new EqualToRecord<>(Literal.of(value));
     }
 

--- a/api/src/main/java/jakarta/data/metamodel/constraint/EqualToRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/EqualToRecord.java
@@ -24,7 +24,7 @@ import jakarta.data.metamodel.Expression;
 record EqualToRecord<V>(Expression<?, V> expression)
         implements EqualTo<V> {
     public EqualToRecord {
-        Objects.requireNonNull(expression, "Value expression must not be null");
+        Objects.requireNonNull(expression, "Value expression is required.");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/constraint/EqualToRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/EqualToRecord.java
@@ -17,15 +17,10 @@
  */
 package jakarta.data.metamodel.constraint;
 
-import java.util.Objects;
-
 import jakarta.data.metamodel.Expression;
 
 record EqualToRecord<V>(Expression<?, V> expression)
         implements EqualTo<V> {
-    public EqualToRecord {
-        Objects.requireNonNull(expression, "Value expression is required");
-    }
 
     @Override
     public NotEqualTo<V> negate() {

--- a/api/src/main/java/jakarta/data/metamodel/constraint/EqualToRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/EqualToRecord.java
@@ -24,7 +24,7 @@ import jakarta.data.metamodel.Expression;
 record EqualToRecord<V>(Expression<?, V> expression)
         implements EqualTo<V> {
     public EqualToRecord {
-        Objects.requireNonNull(expression, "Value expression is required.");
+        Objects.requireNonNull(expression, "Value expression is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/constraint/GreaterThanOrEqualRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/GreaterThanOrEqualRecord.java
@@ -25,7 +25,7 @@ record GreaterThanOrEqualRecord<V extends Comparable<?>>(
         ComparableExpression<?, V> bound)
         implements GreaterThanOrEqual<V> {
     public GreaterThanOrEqualRecord {
-        Objects.requireNonNull(bound, "Lower bound must not be null");
+        Objects.requireNonNull(bound, "Lower bound is required.");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/constraint/GreaterThanOrEqualRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/GreaterThanOrEqualRecord.java
@@ -25,7 +25,7 @@ record GreaterThanOrEqualRecord<V extends Comparable<?>>(
         ComparableExpression<?, V> bound)
         implements GreaterThanOrEqual<V> {
     public GreaterThanOrEqualRecord {
-        Objects.requireNonNull(bound, "Lower bound is required");
+        Objects.requireNonNull(bound, "The minimum is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/constraint/GreaterThanOrEqualRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/GreaterThanOrEqualRecord.java
@@ -25,7 +25,7 @@ record GreaterThanOrEqualRecord<V extends Comparable<?>>(
         ComparableExpression<?, V> bound)
         implements GreaterThanOrEqual<V> {
     public GreaterThanOrEqualRecord {
-        Objects.requireNonNull(bound, "Lower bound is required.");
+        Objects.requireNonNull(bound, "Lower bound is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/constraint/GreaterThanRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/GreaterThanRecord.java
@@ -25,7 +25,7 @@ record GreaterThanRecord<V extends Comparable<?>>(
         ComparableExpression<?, V> bound)
         implements GreaterThan<V> {
     public GreaterThanRecord {
-        Objects.requireNonNull(bound, "Lower bound must not be null");
+        Objects.requireNonNull(bound, "Lower bound is required.");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/constraint/GreaterThanRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/GreaterThanRecord.java
@@ -25,7 +25,7 @@ record GreaterThanRecord<V extends Comparable<?>>(
         ComparableExpression<?, V> bound)
         implements GreaterThan<V> {
     public GreaterThanRecord {
-        Objects.requireNonNull(bound, "Lower bound is required.");
+        Objects.requireNonNull(bound, "Lower bound is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/constraint/GreaterThanRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/GreaterThanRecord.java
@@ -25,7 +25,7 @@ record GreaterThanRecord<V extends Comparable<?>>(
         ComparableExpression<?, V> bound)
         implements GreaterThan<V> {
     public GreaterThanRecord {
-        Objects.requireNonNull(bound, "Lower bound is required");
+        Objects.requireNonNull(bound, "The lowerBound is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/constraint/In.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/In.java
@@ -31,15 +31,15 @@ public interface In<V> extends Constraint<V> {
 
     @SafeVarargs
     static <V> In<V> values(V... values) {
-        Objects.requireNonNull(values, "Values are required.");
+        Objects.requireNonNull(values, "Values are required");
 
         if (values.length == 0) {
-            throw new IllegalArgumentException("Array of values must not be empty.");
+            throw new IllegalArgumentException("Array of values must not be empty");
         }
 
         List<Expression<?, V>> expressions = new ArrayList<>(values.length);
         for (V value : values) {
-            Objects.requireNonNull(value, "Value must not be null.");
+            Objects.requireNonNull(value, "Value must not be null");
             expressions.add(Literal.of(value));
         }
 
@@ -47,15 +47,15 @@ public interface In<V> extends Constraint<V> {
     }
 
     static <V> In<V> values(Collection<V> values) {
-        Objects.requireNonNull(values, "Values are required.");
+        Objects.requireNonNull(values, "Values are required");
 
         if (values.isEmpty()) {
-            throw new IllegalArgumentException("Values must not be empty.");
+            throw new IllegalArgumentException("Values must not be empty");
         }
 
         List<Expression<?, V>> expressions = new ArrayList<>(values.size());
         for (V value : values) {
-            Objects.requireNonNull(value, "Value must not be null.");
+            Objects.requireNonNull(value, "Value must not be null");
             expressions.add(Literal.of(value));
         }
 
@@ -63,15 +63,15 @@ public interface In<V> extends Constraint<V> {
     }
 
     static <V> In<V> expressions(List<Expression<?, V>> expressions) {
-        Objects.requireNonNull(expressions, "Value expressions are required.");
+        Objects.requireNonNull(expressions, "Value expressions are required");
 
         if (expressions.isEmpty()) {
             throw new IllegalArgumentException(
-                    "Value expressions must not be empty.");
+                    "Value expressions must not be empty");
         }
 
         for (Expression<?, V> expression : expressions) {
-            Objects.requireNonNull(expression, "Value expression must not be null.");
+            Objects.requireNonNull(expression, "Value expression must not be null");
         }
 
         return new InRecord<>(List.copyOf(expressions));
@@ -79,15 +79,15 @@ public interface In<V> extends Constraint<V> {
 
     @SafeVarargs
     static <V> In<V> expressions(Expression<?, V>... expressions) {
-        Objects.requireNonNull(expressions, "Value expressions are required.");
+        Objects.requireNonNull(expressions, "Value expressions are required");
 
         if (expressions.length == 0) {
             throw new IllegalArgumentException(
-                    "Array of value expressions must not be empty.");
+                    "Array of value expressions must not be empty");
         }
 
         for (Expression<?, V> expression : expressions) {
-            Objects.requireNonNull(expression, "Value expression must not be null.");
+            Objects.requireNonNull(expression, "Value expression must not be null");
         }
 
         return new InRecord<>(List.of(expressions));

--- a/api/src/main/java/jakarta/data/metamodel/constraint/In.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/In.java
@@ -31,15 +31,15 @@ public interface In<V> extends Constraint<V> {
 
     @SafeVarargs
     static <V> In<V> values(V... values) {
-        Objects.requireNonNull(values, "Values are required");
+        Objects.requireNonNull(values, "The values are required");
 
         if (values.length == 0) {
-            throw new IllegalArgumentException("Array of values must not be empty");
+            throw new IllegalArgumentException("The values must not be empty");
         }
 
         List<Expression<?, V>> expressions = new ArrayList<>(values.length);
         for (V value : values) {
-            Objects.requireNonNull(value, "Value must not be null");
+            Objects.requireNonNull(value, "The value must not be null");
             expressions.add(Literal.of(value));
         }
 
@@ -47,15 +47,15 @@ public interface In<V> extends Constraint<V> {
     }
 
     static <V> In<V> values(Collection<V> values) {
-        Objects.requireNonNull(values, "Values are required");
+        Objects.requireNonNull(values, "The values are required");
 
         if (values.isEmpty()) {
-            throw new IllegalArgumentException("Values must not be empty");
+            throw new IllegalArgumentException("The values must not be empty");
         }
 
         List<Expression<?, V>> expressions = new ArrayList<>(values.size());
         for (V value : values) {
-            Objects.requireNonNull(value, "Value must not be null");
+            Objects.requireNonNull(value, "The value must not be null");
             expressions.add(Literal.of(value));
         }
 
@@ -63,15 +63,15 @@ public interface In<V> extends Constraint<V> {
     }
 
     static <V> In<V> expressions(List<Expression<?, V>> expressions) {
-        Objects.requireNonNull(expressions, "Value expressions are required");
+        Objects.requireNonNull(expressions, "The expressions are required");
 
         if (expressions.isEmpty()) {
             throw new IllegalArgumentException(
-                    "Value expressions must not be empty");
+                    "The expressions must not be empty");
         }
 
         for (Expression<?, V> expression : expressions) {
-            Objects.requireNonNull(expression, "Value expression must not be null");
+            Objects.requireNonNull(expression, "The expression must not be null");
         }
 
         return new InRecord<>(List.copyOf(expressions));
@@ -79,15 +79,15 @@ public interface In<V> extends Constraint<V> {
 
     @SafeVarargs
     static <V> In<V> expressions(Expression<?, V>... expressions) {
-        Objects.requireNonNull(expressions, "Value expressions are required");
+        Objects.requireNonNull(expressions, "The expressions are required");
 
         if (expressions.length == 0) {
             throw new IllegalArgumentException(
-                    "Array of value expressions must not be empty");
+                    "The expressions must not be empty");
         }
 
         for (Expression<?, V> expression : expressions) {
-            Objects.requireNonNull(expression, "Value expression must not be null");
+            Objects.requireNonNull(expression, "The expression must not be null");
         }
 
         return new InRecord<>(List.of(expressions));

--- a/api/src/main/java/jakarta/data/metamodel/constraint/LessThanOrEqualRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/LessThanOrEqualRecord.java
@@ -25,7 +25,7 @@ record LessThanOrEqualRecord<V extends Comparable<?>>(
         ComparableExpression<?, V> bound)
         implements LessThanOrEqual<V> {
     public LessThanOrEqualRecord {
-        Objects.requireNonNull(bound, "Upper bound is required.");
+        Objects.requireNonNull(bound, "Upper bound is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/constraint/LessThanOrEqualRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/LessThanOrEqualRecord.java
@@ -25,7 +25,7 @@ record LessThanOrEqualRecord<V extends Comparable<?>>(
         ComparableExpression<?, V> bound)
         implements LessThanOrEqual<V> {
     public LessThanOrEqualRecord {
-        Objects.requireNonNull(bound, "Upper bound must not be null");
+        Objects.requireNonNull(bound, "Upper bound is required.");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/constraint/LessThanOrEqualRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/LessThanOrEqualRecord.java
@@ -25,7 +25,7 @@ record LessThanOrEqualRecord<V extends Comparable<?>>(
         ComparableExpression<?, V> bound)
         implements LessThanOrEqual<V> {
     public LessThanOrEqualRecord {
-        Objects.requireNonNull(bound, "Upper bound is required");
+        Objects.requireNonNull(bound, "The maximum is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/constraint/LessThanRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/LessThanRecord.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 record LessThanRecord<V extends Comparable<?>>(ComparableExpression<?, V> bound)
         implements LessThan<V> {
     public LessThanRecord {
-        Objects.requireNonNull(bound, "Upper bound must not be null");
+        Objects.requireNonNull(bound, "Upper bound is required.");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/constraint/LessThanRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/LessThanRecord.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 record LessThanRecord<V extends Comparable<?>>(ComparableExpression<?, V> bound)
         implements LessThan<V> {
     public LessThanRecord {
-        Objects.requireNonNull(bound, "Upper bound is required.");
+        Objects.requireNonNull(bound, "Upper bound is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/constraint/LessThanRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/LessThanRecord.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 record LessThanRecord<V extends Comparable<?>>(ComparableExpression<?, V> bound)
         implements LessThan<V> {
     public LessThanRecord {
-        Objects.requireNonNull(bound, "Upper bound is required");
+        Objects.requireNonNull(bound, "The upperBound is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/constraint/Like.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/Like.java
@@ -29,7 +29,7 @@ import jakarta.data.metamodel.expression.StringLiteral;
 public interface Like extends Constraint<String> {
 
     static Like pattern(String pattern) {
-        Objects.requireNonNull(pattern, "Pattern is required.");
+        Objects.requireNonNull(pattern, "Pattern is required");
         StringLiteral<Object> expression = StringLiteral.of(pattern);
         return new LikeRecord(expression, null);
     }
@@ -39,40 +39,40 @@ public interface Like extends Constraint<String> {
     }
 
     static Like pattern(String pattern, char charWildcard, char stringWildcard, char escape) {
-        Objects.requireNonNull(pattern, "Pattern is required.");
+        Objects.requireNonNull(pattern, "Pattern is required");
         StringLiteral<Object> expression = StringLiteral.of(
                 translate(pattern, charWildcard, stringWildcard, escape));
         return new LikeRecord(expression, escape);
     }
 
     static Like pattern(TextExpression<?> pattern, char escape) {
-        Objects.requireNonNull(pattern, "Pattern expression is required.");
+        Objects.requireNonNull(pattern, "Pattern expression is required");
         return new LikeRecord(pattern, escape);
     }
 
     static Like prefix(String prefix) {
-        Objects.requireNonNull(prefix, "Prefix is required.");
+        Objects.requireNonNull(prefix, "Prefix is required");
         StringLiteral<Object> expression = StringLiteral.of(
                 LikeRecord.escape(prefix) + STRING_WILDCARD);
         return new LikeRecord(expression, ESCAPE);
     }
 
     static Like substring(String substring) {
-        Objects.requireNonNull(substring, "Substring is required.");
+        Objects.requireNonNull(substring, "Substring is required");
         StringLiteral<Object> expression = StringLiteral.of(
                 STRING_WILDCARD + LikeRecord.escape(substring) + STRING_WILDCARD);
         return new LikeRecord(expression, ESCAPE);
     }
 
     static Like suffix(String suffix) {
-        Objects.requireNonNull(suffix, "Suffix is required.");
+        Objects.requireNonNull(suffix, "Suffix is required");
         StringLiteral<Object> expression = StringLiteral.of(
                 STRING_WILDCARD + LikeRecord.escape(suffix));
         return new LikeRecord(expression, ESCAPE);
     }
 
     static Like literal(String value) {
-        Objects.requireNonNull(value, "Value is required.");
+        Objects.requireNonNull(value, "Value is required");
         StringLiteral<Object> expression = StringLiteral.of(
                 LikeRecord.escape(value));
         return new LikeRecord(expression, ESCAPE);

--- a/api/src/main/java/jakarta/data/metamodel/constraint/Like.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/Like.java
@@ -29,7 +29,7 @@ import jakarta.data.metamodel.expression.StringLiteral;
 public interface Like extends Constraint<String> {
 
     static Like pattern(String pattern) {
-        Objects.requireNonNull(pattern, "Pattern is required");
+        Objects.requireNonNull(pattern, "The pattern is required");
         StringLiteral<Object> expression = StringLiteral.of(pattern);
         return new LikeRecord(expression, null);
     }
@@ -39,40 +39,40 @@ public interface Like extends Constraint<String> {
     }
 
     static Like pattern(String pattern, char charWildcard, char stringWildcard, char escape) {
-        Objects.requireNonNull(pattern, "Pattern is required");
+        Objects.requireNonNull(pattern, "The pattern is required");
         StringLiteral<Object> expression = StringLiteral.of(
                 translate(pattern, charWildcard, stringWildcard, escape));
         return new LikeRecord(expression, escape);
     }
 
     static Like pattern(TextExpression<?> pattern, char escape) {
-        Objects.requireNonNull(pattern, "Pattern expression is required");
+        Objects.requireNonNull(pattern, "The pattern is required");
         return new LikeRecord(pattern, escape);
     }
 
     static Like prefix(String prefix) {
-        Objects.requireNonNull(prefix, "Prefix is required");
+        Objects.requireNonNull(prefix, "The prefix is required");
         StringLiteral<Object> expression = StringLiteral.of(
                 LikeRecord.escape(prefix) + STRING_WILDCARD);
         return new LikeRecord(expression, ESCAPE);
     }
 
     static Like substring(String substring) {
-        Objects.requireNonNull(substring, "Substring is required");
+        Objects.requireNonNull(substring, "The substring is required");
         StringLiteral<Object> expression = StringLiteral.of(
                 STRING_WILDCARD + LikeRecord.escape(substring) + STRING_WILDCARD);
         return new LikeRecord(expression, ESCAPE);
     }
 
     static Like suffix(String suffix) {
-        Objects.requireNonNull(suffix, "Suffix is required");
+        Objects.requireNonNull(suffix, "The suffix is required");
         StringLiteral<Object> expression = StringLiteral.of(
                 STRING_WILDCARD + LikeRecord.escape(suffix));
         return new LikeRecord(expression, ESCAPE);
     }
 
     static Like literal(String value) {
-        Objects.requireNonNull(value, "Value is required");
+        Objects.requireNonNull(value, "The value is required");
         StringLiteral<Object> expression = StringLiteral.of(
                 LikeRecord.escape(value));
         return new LikeRecord(expression, ESCAPE);

--- a/api/src/main/java/jakarta/data/metamodel/constraint/LikeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/LikeRecord.java
@@ -51,10 +51,14 @@ record LikeRecord(TextExpression<?> pattern, Character escape)
 
     static String translate(String pattern, char charWildcard, char stringWildcard, char escape) {
         if ( charWildcard == stringWildcard ) {
-            throw new IllegalArgumentException("Cannot use the same character (" + charWildcard + ") for both wildcards.");
+            throw new IllegalArgumentException(
+                    "Cannot use the same character (" + charWildcard +
+                    ") for both wildcards");
         }
         if (charWildcard == escape || stringWildcard == escape) {
-            throw new IllegalArgumentException("Cannot use the same character (" + escape + ") for both a wildcard and escape character.");
+            throw new IllegalArgumentException(
+                    "Cannot use the same character (" + escape +
+                    ") for both a wildcard and escape character");
         }
         final var result = new StringBuilder();
         for (int i = 0; i<pattern.length(); i++) {

--- a/api/src/main/java/jakarta/data/metamodel/constraint/NotBetweenRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/NotBetweenRecord.java
@@ -27,8 +27,10 @@ record NotBetweenRecord<V extends Comparable<?>>(
     implements NotBetween<V> {
 
     NotBetweenRecord {
-        Objects.requireNonNull(lowerBound, "Lower bound is required");
-        Objects.requireNonNull(upperBound, "Upper bound is required");
+        Objects.requireNonNull(lowerBound,
+                "The lower value or expression is required");
+        Objects.requireNonNull(upperBound,
+                "The upper value or expression is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/constraint/NotBetweenRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/NotBetweenRecord.java
@@ -27,8 +27,8 @@ record NotBetweenRecord<V extends Comparable<?>>(
     implements NotBetween<V> {
 
     NotBetweenRecord {
-        Objects.requireNonNull(lowerBound, "Lower bound is required.");
-        Objects.requireNonNull(upperBound, "Upper bound is required.");
+        Objects.requireNonNull(lowerBound, "Lower bound is required");
+        Objects.requireNonNull(upperBound, "Upper bound is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/constraint/NotBetweenRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/NotBetweenRecord.java
@@ -27,8 +27,8 @@ record NotBetweenRecord<V extends Comparable<?>>(
     implements NotBetween<V> {
 
     NotBetweenRecord {
-        Objects.requireNonNull(lowerBound, "lowerBound must not be null");
-        Objects.requireNonNull(upperBound, "upperBound must not be null");
+        Objects.requireNonNull(lowerBound, "Lower bound is required.");
+        Objects.requireNonNull(upperBound, "Upper bound is required.");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/constraint/NotEqualTo.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/NotEqualTo.java
@@ -17,16 +17,20 @@
  */
 package jakarta.data.metamodel.constraint;
 
+import java.util.Objects;
+
 import jakarta.data.metamodel.Expression;
 import jakarta.data.metamodel.expression.Literal;
 
 public interface NotEqualTo<V> extends Constraint<V> {
 
     static <V> NotEqualTo<V> expression(Expression<?, V> expression) {
+        Objects.requireNonNull(expression, "The expression is required");
         return new NotEqualToRecord<>(expression);
     }
 
     static <V> NotEqualTo<V> value(V value) {
+        Objects.requireNonNull(value, "The value is required");
         return new NotEqualToRecord<>(Literal.of(value));
     }
 

--- a/api/src/main/java/jakarta/data/metamodel/constraint/NotEqualToRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/NotEqualToRecord.java
@@ -26,7 +26,7 @@ record NotEqualToRecord<V>(
         implements NotEqualTo<V> {
 
     NotEqualToRecord {
-        Objects.requireNonNull(expression, "Value expression is required.");
+        Objects.requireNonNull(expression, "Value expression is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/constraint/NotEqualToRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/NotEqualToRecord.java
@@ -26,7 +26,7 @@ record NotEqualToRecord<V>(
         implements NotEqualTo<V> {
 
     NotEqualToRecord {
-        Objects.requireNonNull(expression, "Value expression must not be null");
+        Objects.requireNonNull(expression, "Value expression is required.");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/constraint/NotEqualToRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/NotEqualToRecord.java
@@ -17,17 +17,11 @@
  */
 package jakarta.data.metamodel.constraint;
 
-import java.util.Objects;
-
 import jakarta.data.metamodel.Expression;
 
 record NotEqualToRecord<V>(
         Expression<?, V> expression)
         implements NotEqualTo<V> {
-
-    NotEqualToRecord {
-        Objects.requireNonNull(expression, "Value expression is required");
-    }
 
     @Override
     public EqualTo<V> negate() {

--- a/api/src/main/java/jakarta/data/metamodel/constraint/NotIn.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/NotIn.java
@@ -31,10 +31,10 @@ public interface NotIn<V> extends Constraint<V> {
 
     @SafeVarargs
     static <V> NotIn<V> values(V... values) {
-        Objects.requireNonNull(values, "Values are required");
+        Objects.requireNonNull(values, "The values are required");
 
         if (values.length == 0) {
-            throw new IllegalArgumentException("Array of values must not be empty");
+            throw new IllegalArgumentException("The values must not be empty");
         }
 
         final List<Expression<?, V>> expressions = new ArrayList<>(values.length);
@@ -47,15 +47,15 @@ public interface NotIn<V> extends Constraint<V> {
     }
 
     static <V> NotIn<V> values(Collection<V> values) {
-        Objects.requireNonNull(values, "Values are required");
+        Objects.requireNonNull(values, "The values are required");
 
         if (values.isEmpty()) {
-            throw new IllegalArgumentException("Values must not be empty");
+            throw new IllegalArgumentException("The values must not be empty");
         }
 
         final List<Expression<?, V>> expressions = new ArrayList<>(values.size());
         for (V value : values) {
-            Objects.requireNonNull(value, "Value must not be null");
+            Objects.requireNonNull(value, "The value must not be null");
             expressions.add(Literal.of(value));
         }
 
@@ -63,14 +63,14 @@ public interface NotIn<V> extends Constraint<V> {
     }
 
     static <V> NotIn<V> expressions(List<Expression<?, V>> expressions) {
-        Objects.requireNonNull(expressions, "Value expressions are required");
+        Objects.requireNonNull(expressions, "The expressions are required");
 
         if (expressions.isEmpty()) {
-            throw new IllegalArgumentException("Value expressions must not be empty");
+            throw new IllegalArgumentException("The expressions must not be empty");
         }
 
         for (Expression<?, V> expression : expressions) {
-            Objects.requireNonNull(expression, "Value expression must not be null");
+            Objects.requireNonNull(expression, "The expression must not be null");
         }
 
         return new NotInRecord<>(List.copyOf(expressions));
@@ -78,15 +78,15 @@ public interface NotIn<V> extends Constraint<V> {
 
     @SafeVarargs
     static <V> NotIn<V> expressions(Expression<?, V>... expressions) {
-        Objects.requireNonNull(expressions, "Value expressions are required");
+        Objects.requireNonNull(expressions, "The expressions are required");
 
         if (expressions.length == 0) {
             throw new IllegalArgumentException(
-                    "Array of value expressions must not be empty");
+                    "The expressions must not be empty");
         }
 
         for (Expression<?, V> expression : expressions) {
-            Objects.requireNonNull(expression, "Value expression must not be null");
+            Objects.requireNonNull(expression, "The expression must not be null");
         }
 
         return new NotInRecord<>(List.of(expressions));

--- a/api/src/main/java/jakarta/data/metamodel/constraint/NotIn.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/NotIn.java
@@ -31,15 +31,15 @@ public interface NotIn<V> extends Constraint<V> {
 
     @SafeVarargs
     static <V> NotIn<V> values(V... values) {
-        Objects.requireNonNull(values, "Values are required.");
+        Objects.requireNonNull(values, "Values are required");
 
         if (values.length == 0) {
-            throw new IllegalArgumentException("Array of values must not be empty.");
+            throw new IllegalArgumentException("Array of values must not be empty");
         }
 
         final List<Expression<?, V>> expressions = new ArrayList<>(values.length);
         for (V value : values) {
-            Objects.requireNonNull(value, "Value must not be null.");
+            Objects.requireNonNull(value, "Value must not be null");
             expressions.add(Literal.of(value));
         }
 
@@ -47,15 +47,15 @@ public interface NotIn<V> extends Constraint<V> {
     }
 
     static <V> NotIn<V> values(Collection<V> values) {
-        Objects.requireNonNull(values, "Values are required.");
+        Objects.requireNonNull(values, "Values are required");
 
         if (values.isEmpty()) {
-            throw new IllegalArgumentException("Values must not be empty.");
+            throw new IllegalArgumentException("Values must not be empty");
         }
 
         final List<Expression<?, V>> expressions = new ArrayList<>(values.size());
         for (V value : values) {
-            Objects.requireNonNull(value, "Value must not be null.");
+            Objects.requireNonNull(value, "Value must not be null");
             expressions.add(Literal.of(value));
         }
 
@@ -63,14 +63,14 @@ public interface NotIn<V> extends Constraint<V> {
     }
 
     static <V> NotIn<V> expressions(List<Expression<?, V>> expressions) {
-        Objects.requireNonNull(expressions, "Value expressions are required.");
+        Objects.requireNonNull(expressions, "Value expressions are required");
 
         if (expressions.isEmpty()) {
-            throw new IllegalArgumentException("Value expressions must not be empty.");
+            throw new IllegalArgumentException("Value expressions must not be empty");
         }
 
         for (Expression<?, V> expression : expressions) {
-            Objects.requireNonNull(expression, "Value expression must not be null.");
+            Objects.requireNonNull(expression, "Value expression must not be null");
         }
 
         return new NotInRecord<>(List.copyOf(expressions));
@@ -78,15 +78,15 @@ public interface NotIn<V> extends Constraint<V> {
 
     @SafeVarargs
     static <V> NotIn<V> expressions(Expression<?, V>... expressions) {
-        Objects.requireNonNull(expressions, "Value expressions are required.");
+        Objects.requireNonNull(expressions, "Value expressions are required");
 
         if (expressions.length == 0) {
             throw new IllegalArgumentException(
-                    "Array of value expressions must not be empty.");
+                    "Array of value expressions must not be empty");
         }
 
         for (Expression<?, V> expression : expressions) {
-            Objects.requireNonNull(expression, "Value expression must not be null.");
+            Objects.requireNonNull(expression, "Value expression must not be null");
         }
 
         return new NotInRecord<>(List.of(expressions));

--- a/api/src/main/java/jakarta/data/metamodel/constraint/NotLike.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/NotLike.java
@@ -29,7 +29,7 @@ import jakarta.data.metamodel.expression.StringLiteral;
 public interface NotLike extends Constraint<String> {
 
     static NotLike pattern(String pattern) {
-        Objects.requireNonNull(pattern, "Pattern is required.");
+        Objects.requireNonNull(pattern, "Pattern is required");
         StringLiteral<Object> expression = StringLiteral.of(pattern);
         return new NotLikeRecord(expression, null);
     }
@@ -39,40 +39,40 @@ public interface NotLike extends Constraint<String> {
     }
 
     static NotLike pattern(String pattern, char charWildcard, char stringWildcard, char escape) {
-        Objects.requireNonNull(pattern, "Pattern is required.");
+        Objects.requireNonNull(pattern, "Pattern is required");
         StringLiteral<Object> expression = StringLiteral.of(
                 translate(pattern, charWildcard, stringWildcard, escape));
         return new NotLikeRecord(expression, escape);
     }
 
     static NotLike pattern(TextExpression<?> pattern, char escape) {
-        Objects.requireNonNull(pattern, "Pattern expression is required.");
+        Objects.requireNonNull(pattern, "Pattern expression is required");
         return new NotLikeRecord(pattern, escape);
     }
 
     static NotLike prefix(String prefix) {
-        Objects.requireNonNull(prefix, "Prefix is required.");
+        Objects.requireNonNull(prefix, "Prefix is required");
         StringLiteral<Object> expression = StringLiteral.of(
                 LikeRecord.escape(prefix) + STRING_WILDCARD);
         return new NotLikeRecord(expression, ESCAPE);
     }
 
     static NotLike substring(String substring) {
-        Objects.requireNonNull(substring, "Substring is required.");
+        Objects.requireNonNull(substring, "Substring is required");
         StringLiteral<Object> expression = StringLiteral.of(
                 STRING_WILDCARD + LikeRecord.escape(substring) + STRING_WILDCARD);
         return new NotLikeRecord(expression, ESCAPE);
     }
 
     static NotLike suffix(String suffix) {
-        Objects.requireNonNull(suffix, "Suffix is required.");
+        Objects.requireNonNull(suffix, "Suffix is required");
         StringLiteral<Object> expression = StringLiteral.of(
                 STRING_WILDCARD + LikeRecord.escape(suffix));
         return new NotLikeRecord(expression, ESCAPE);
     }
 
     static NotLike literal(String value) {
-        Objects.requireNonNull(value, "Value is required.");
+        Objects.requireNonNull(value, "Value is required");
         StringLiteral<Object> expression = StringLiteral.of(
                 LikeRecord.escape(value));
         return new NotLikeRecord(expression, ESCAPE);

--- a/api/src/main/java/jakarta/data/metamodel/constraint/NotLike.java
+++ b/api/src/main/java/jakarta/data/metamodel/constraint/NotLike.java
@@ -29,7 +29,7 @@ import jakarta.data.metamodel.expression.StringLiteral;
 public interface NotLike extends Constraint<String> {
 
     static NotLike pattern(String pattern) {
-        Objects.requireNonNull(pattern, "Pattern is required");
+        Objects.requireNonNull(pattern, "The pattern is required");
         StringLiteral<Object> expression = StringLiteral.of(pattern);
         return new NotLikeRecord(expression, null);
     }
@@ -39,40 +39,40 @@ public interface NotLike extends Constraint<String> {
     }
 
     static NotLike pattern(String pattern, char charWildcard, char stringWildcard, char escape) {
-        Objects.requireNonNull(pattern, "Pattern is required");
+        Objects.requireNonNull(pattern, "The pattern is required");
         StringLiteral<Object> expression = StringLiteral.of(
                 translate(pattern, charWildcard, stringWildcard, escape));
         return new NotLikeRecord(expression, escape);
     }
 
     static NotLike pattern(TextExpression<?> pattern, char escape) {
-        Objects.requireNonNull(pattern, "Pattern expression is required");
+        Objects.requireNonNull(pattern, "The pattern is required");
         return new NotLikeRecord(pattern, escape);
     }
 
     static NotLike prefix(String prefix) {
-        Objects.requireNonNull(prefix, "Prefix is required");
+        Objects.requireNonNull(prefix, "The prefix is required");
         StringLiteral<Object> expression = StringLiteral.of(
                 LikeRecord.escape(prefix) + STRING_WILDCARD);
         return new NotLikeRecord(expression, ESCAPE);
     }
 
     static NotLike substring(String substring) {
-        Objects.requireNonNull(substring, "Substring is required");
+        Objects.requireNonNull(substring, "The substring is required");
         StringLiteral<Object> expression = StringLiteral.of(
                 STRING_WILDCARD + LikeRecord.escape(substring) + STRING_WILDCARD);
         return new NotLikeRecord(expression, ESCAPE);
     }
 
     static NotLike suffix(String suffix) {
-        Objects.requireNonNull(suffix, "Suffix is required");
+        Objects.requireNonNull(suffix, "The suffix is required");
         StringLiteral<Object> expression = StringLiteral.of(
                 STRING_WILDCARD + LikeRecord.escape(suffix));
         return new NotLikeRecord(expression, ESCAPE);
     }
 
     static NotLike literal(String value) {
-        Objects.requireNonNull(value, "Value is required");
+        Objects.requireNonNull(value, "The value is required");
         StringLiteral<Object> expression = StringLiteral.of(
                 LikeRecord.escape(value));
         return new NotLikeRecord(expression, ESCAPE);

--- a/api/src/main/java/jakarta/data/metamodel/expression/ComparableLiteralRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/ComparableLiteralRecord.java
@@ -23,7 +23,7 @@ record ComparableLiteralRecord<T, V extends Comparable<?>>(V value)
         implements ComparableLiteral<T,V> {
 
     ComparableLiteralRecord {
-        Objects.requireNonNull(value, "Value is required.");
+        Objects.requireNonNull(value, "Value is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/expression/ComparableLiteralRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/ComparableLiteralRecord.java
@@ -23,7 +23,7 @@ record ComparableLiteralRecord<T, V extends Comparable<?>>(V value)
         implements ComparableLiteral<T,V> {
 
     ComparableLiteralRecord {
-        Objects.requireNonNull(value, "Value is required");
+        Objects.requireNonNull(value, "The value is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/expression/LiteralRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/LiteralRecord.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 record LiteralRecord<T, V>(V value) implements Literal<T,V> {
 
     LiteralRecord {
-        Objects.requireNonNull(value, "Value is required");
+        Objects.requireNonNull(value, "The value is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/expression/LiteralRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/LiteralRecord.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 record LiteralRecord<T, V>(V value) implements Literal<T,V> {
 
     LiteralRecord {
-        Objects.requireNonNull(value, "Value is required.");
+        Objects.requireNonNull(value, "Value is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/expression/NumericCastRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/NumericCastRecord.java
@@ -26,8 +26,8 @@ record NumericCastRecord<T, N extends Number & Comparable<N>>
         implements NumericCast<T,N> {
 
     NumericCastRecord {
-        Objects.requireNonNull(expression, "Expression is required.");
-        Objects.requireNonNull(type, "Attribute type is required.");
+        Objects.requireNonNull(expression, "Expression is required");
+        Objects.requireNonNull(type, "Attribute type is required");
     }
 
 }

--- a/api/src/main/java/jakarta/data/metamodel/expression/NumericCastRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/NumericCastRecord.java
@@ -26,8 +26,8 @@ record NumericCastRecord<T, N extends Number & Comparable<N>>
         implements NumericCast<T,N> {
 
     NumericCastRecord {
-        Objects.requireNonNull(expression, "Expression is required");
-        Objects.requireNonNull(type, "Attribute type is required");
+        Objects.requireNonNull(expression, "The expression is required");
+        Objects.requireNonNull(type, "The type is required");
     }
 
 }

--- a/api/src/main/java/jakarta/data/metamodel/expression/NumericFunctionExpression.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/NumericFunctionExpression.java
@@ -22,6 +22,7 @@ import jakarta.data.metamodel.NumericExpression;
 import jakarta.data.metamodel.TextExpression;
 
 import java.util.List;
+import java.util.Objects;
 
 public interface NumericFunctionExpression<T, N extends Number & Comparable<N>>
         extends FunctionExpression<T,N>, NumericExpression<T,N> {
@@ -32,10 +33,12 @@ public interface NumericFunctionExpression<T, N extends Number & Comparable<N>>
 
     static <T,N extends Number & Comparable<N>> NumericFunctionExpression<T, N>
     of(String name, TextExpression<? super T> argument) {
+        Objects.requireNonNull(argument, "The argument is required");
         return new NumericFunctionExpressionRecord<>(name, List.of(argument));
     }
     static <T,N extends Number & Comparable<N>> NumericFunctionExpression<T, N>
     of(String name, NumericExpression<? super T,N> argument) {
+        Objects.requireNonNull(argument, "The argument is required");
         return new NumericFunctionExpressionRecord<>(name, List.of(argument));
     }
 

--- a/api/src/main/java/jakarta/data/metamodel/expression/NumericFunctionExpressionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/NumericFunctionExpressionRecord.java
@@ -28,8 +28,8 @@ record NumericFunctionExpressionRecord<T, N extends Number & Comparable<N>>(
         implements NumericFunctionExpression<T,N> {
 
     NumericFunctionExpressionRecord {
-        Objects.requireNonNull(name, "Function name is required.");
-        Objects.requireNonNull(arguments, "Function arguments is required.");
+        Objects.requireNonNull(name, "Function name is required");
+        Objects.requireNonNull(arguments, "Function arguments are required");
     }
 
 }

--- a/api/src/main/java/jakarta/data/metamodel/expression/NumericFunctionExpressionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/NumericFunctionExpressionRecord.java
@@ -28,8 +28,7 @@ record NumericFunctionExpressionRecord<T, N extends Number & Comparable<N>>(
         implements NumericFunctionExpression<T,N> {
 
     NumericFunctionExpressionRecord {
-        Objects.requireNonNull(name, "Function name is required");
-        Objects.requireNonNull(arguments, "Function arguments are required");
+        Objects.requireNonNull(name, "The name is required");
     }
 
 }

--- a/api/src/main/java/jakarta/data/metamodel/expression/NumericLiteralRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/NumericLiteralRecord.java
@@ -25,7 +25,7 @@ record NumericLiteralRecord<T, N extends Number & Comparable<N>>
         (N value) implements NumericLiteral<T,N> {
 
     NumericLiteralRecord {
-        Objects.requireNonNull(value, "Value is required");
+        Objects.requireNonNull(value, "The value is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/expression/NumericLiteralRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/NumericLiteralRecord.java
@@ -25,7 +25,7 @@ record NumericLiteralRecord<T, N extends Number & Comparable<N>>
         (N value) implements NumericLiteral<T,N> {
 
     NumericLiteralRecord {
-        Objects.requireNonNull(value, "Value is required.");
+        Objects.requireNonNull(value, "Value is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/expression/NumericOperatorExpression.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/NumericOperatorExpression.java
@@ -17,6 +17,8 @@
  */
 package jakarta.data.metamodel.expression;
 
+import java.util.Objects;
+
 import jakarta.data.metamodel.Expression;
 import jakarta.data.metamodel.NumericExpression;
 
@@ -31,6 +33,7 @@ public interface NumericOperatorExpression<T, N extends Number & Comparable<N>>
 
     static <T, N extends Number & Comparable<N>>
     NumericOperatorExpression<T,N> of(Operator operator, NumericExpression<T, N> left, N right) {
+        Objects.requireNonNull(left, "The right value is required");
         return new NumericOperatorExpressionRecord<>(operator, left, NumericLiteral.of(right));
     }
     static <T, N extends Number & Comparable<N>>

--- a/api/src/main/java/jakarta/data/metamodel/expression/NumericOperatorExpressionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/NumericOperatorExpressionRecord.java
@@ -26,9 +26,9 @@ record NumericOperatorExpressionRecord<T, N extends Number & Comparable<N>>
         implements NumericOperatorExpression<T,N> {
 
     NumericOperatorExpressionRecord {
-        Objects.requireNonNull(operator, "Operator is required.");
-        Objects.requireNonNull(left, "Left side expression is required.");
-        Objects.requireNonNull(left, "Right side expression is required.");
+        Objects.requireNonNull(operator, "Operator is required");
+        Objects.requireNonNull(left, "Left side expression is required");
+        Objects.requireNonNull(left, "Right side expression is required");
     }
 
 }

--- a/api/src/main/java/jakarta/data/metamodel/expression/NumericOperatorExpressionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/NumericOperatorExpressionRecord.java
@@ -26,9 +26,9 @@ record NumericOperatorExpressionRecord<T, N extends Number & Comparable<N>>
         implements NumericOperatorExpression<T,N> {
 
     NumericOperatorExpressionRecord {
-        Objects.requireNonNull(operator, "Operator is required");
-        Objects.requireNonNull(left, "Left side expression is required");
-        Objects.requireNonNull(left, "Right side expression is required");
+        Objects.requireNonNull(operator, "The operator is required");
+        Objects.requireNonNull(left, "The left expression is required");
+        Objects.requireNonNull(left, "The right expression is required");
     }
 
 }

--- a/api/src/main/java/jakarta/data/metamodel/expression/StringLiteralRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/StringLiteralRecord.java
@@ -23,7 +23,7 @@ record StringLiteralRecord<T>(String value)
         implements StringLiteral<T> {
 
     StringLiteralRecord {
-        Objects.requireNonNull(value, "Value is required");
+        Objects.requireNonNull(value, "The value is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/expression/StringLiteralRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/StringLiteralRecord.java
@@ -23,7 +23,7 @@ record StringLiteralRecord<T>(String value)
         implements StringLiteral<T> {
 
     StringLiteralRecord {
-        Objects.requireNonNull(value, "Value is required.");
+        Objects.requireNonNull(value, "Value is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/expression/TemporalLiteralRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/TemporalLiteralRecord.java
@@ -29,7 +29,7 @@ record TemporalLiteralRecord<T, V extends Temporal & Comparable<? extends Tempor
         implements TemporalLiteral<T, V> {
 
     TemporalLiteralRecord {
-        Objects.requireNonNull(value, "Value is required");
+        Objects.requireNonNull(value, "The value is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/expression/TemporalLiteralRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/TemporalLiteralRecord.java
@@ -29,7 +29,7 @@ record TemporalLiteralRecord<T, V extends Temporal & Comparable<? extends Tempor
         implements TemporalLiteral<T, V> {
 
     TemporalLiteralRecord {
-        Objects.requireNonNull(value, "Value is required.");
+        Objects.requireNonNull(value, "Value is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/expression/TextFunctionExpression.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/TextFunctionExpression.java
@@ -21,6 +21,7 @@ import jakarta.data.metamodel.ComparableExpression;
 import jakarta.data.metamodel.TextExpression;
 
 import java.util.List;
+import java.util.Objects;
 
 public interface TextFunctionExpression<T>
         extends FunctionExpression<T,String>, TextExpression<T> {
@@ -32,18 +33,27 @@ public interface TextFunctionExpression<T>
     String RIGHT = "right";
 
     static <T> TextFunctionExpression<T> of(String name, TextExpression<? super T> argument) {
+        Objects.requireNonNull(argument, "The argument is required");
         return new TextFunctionExpressionRecord<>(name, List.of(argument));
     }
     static <T> TextFunctionExpression<T> of(String name, TextExpression<? super T> left, String right) {
+        Objects.requireNonNull(left, "The left expression is required");
+        Objects.requireNonNull(right, "The right value is required");
         return new TextFunctionExpressionRecord<>(name, List.of(left, StringLiteral.of(right)));
     }
     static <T> TextFunctionExpression<T> of(String name, String left, TextExpression<? super T> right) {
+        Objects.requireNonNull(right, "The left value is required");
+        Objects.requireNonNull(left, "The right expression is required");
         return new TextFunctionExpressionRecord<>(name, List.of(StringLiteral.of(left), right));
     }
     static <T> TextFunctionExpression<T> of(String name, TextExpression<? super T> left, TextExpression<? super T> right) {
+        Objects.requireNonNull(left, "The left expression is required");
+        Objects.requireNonNull(left, "The right expression is required");
         return new TextFunctionExpressionRecord<>(name, List.of(left, right));
     }
     static <T> TextFunctionExpression<T> of(String name, TextExpression<? super T> left, int literal) {
+        Objects.requireNonNull(left, "The left expression is required");
+        Objects.requireNonNull(literal, "The literal value is required");
         return new TextFunctionExpressionRecord<>(name, List.of(left, NumericLiteral.of(literal)));
     }
 

--- a/api/src/main/java/jakarta/data/metamodel/expression/TextFunctionExpressionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/TextFunctionExpressionRecord.java
@@ -28,8 +28,7 @@ record TextFunctionExpressionRecord<T>(
         implements TextFunctionExpression<T> {
 
     TextFunctionExpressionRecord {
-        Objects.requireNonNull(name, "Function name is required");
-        Objects.requireNonNull(arguments, "Function arguments is required");
+        Objects.requireNonNull(name, "The name is required");
     }
 
 }

--- a/api/src/main/java/jakarta/data/metamodel/expression/TextFunctionExpressionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/expression/TextFunctionExpressionRecord.java
@@ -28,8 +28,8 @@ record TextFunctionExpressionRecord<T>(
         implements TextFunctionExpression<T> {
 
     TextFunctionExpressionRecord {
-        Objects.requireNonNull(name, "Function name is required.");
-        Objects.requireNonNull(arguments, "Function arguments is required.");
+        Objects.requireNonNull(name, "Function name is required");
+        Objects.requireNonNull(arguments, "Function arguments is required");
     }
 
 }

--- a/api/src/main/java/jakarta/data/metamodel/path/ComparablePathRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/path/ComparablePathRecord.java
@@ -27,8 +27,8 @@ record ComparablePathRecord<T,U,C extends Comparable<?>>
         implements ComparablePath<T,U,C> {
 
     ComparablePathRecord {
-        Objects.requireNonNull(expression, "Expression is required.");
-        Objects.requireNonNull(attribute, "Entity attribute is required.");
+        Objects.requireNonNull(expression, "Expression is required");
+        Objects.requireNonNull(attribute, "Entity attribute is required");
     }
 
 }

--- a/api/src/main/java/jakarta/data/metamodel/path/ComparablePathRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/path/ComparablePathRecord.java
@@ -27,8 +27,8 @@ record ComparablePathRecord<T,U,C extends Comparable<?>>
         implements ComparablePath<T,U,C> {
 
     ComparablePathRecord {
-        Objects.requireNonNull(expression, "Expression is required");
-        Objects.requireNonNull(attribute, "Entity attribute is required");
+        Objects.requireNonNull(expression, "The expression is required");
+        Objects.requireNonNull(attribute, "The attribute is required");
     }
 
 }

--- a/api/src/main/java/jakarta/data/metamodel/path/NavigablePathRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/path/NavigablePathRecord.java
@@ -27,8 +27,8 @@ record NavigablePathRecord<T,U,V>
         implements NavigablePath<T,U,V> {
 
     NavigablePathRecord {
-        Objects.requireNonNull(expression, "Expression is required");
-        Objects.requireNonNull(attribute, "Entity attribute is required");
+        Objects.requireNonNull(expression, "The expression is required");
+        Objects.requireNonNull(attribute, "The attribute is required");
     }
 
 }

--- a/api/src/main/java/jakarta/data/metamodel/path/NavigablePathRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/path/NavigablePathRecord.java
@@ -27,8 +27,8 @@ record NavigablePathRecord<T,U,V>
         implements NavigablePath<T,U,V> {
 
     NavigablePathRecord {
-        Objects.requireNonNull(expression, "Expression is required.");
-        Objects.requireNonNull(attribute, "Entity attribute is required.");
+        Objects.requireNonNull(expression, "Expression is required");
+        Objects.requireNonNull(attribute, "Entity attribute is required");
     }
 
 }

--- a/api/src/main/java/jakarta/data/metamodel/path/NumericPathRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/path/NumericPathRecord.java
@@ -27,8 +27,8 @@ record NumericPathRecord<T,U,N extends Number & Comparable<N>>
         implements NumericPath<T,U,N> {
 
     NumericPathRecord {
-        Objects.requireNonNull(expression, "Expression is required.");
-        Objects.requireNonNull(attribute, "Entity attribute is required.");
+        Objects.requireNonNull(expression, "Expression is required");
+        Objects.requireNonNull(attribute, "Entity attribute is required");
     }
 
 }

--- a/api/src/main/java/jakarta/data/metamodel/path/NumericPathRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/path/NumericPathRecord.java
@@ -27,8 +27,8 @@ record NumericPathRecord<T,U,N extends Number & Comparable<N>>
         implements NumericPath<T,U,N> {
 
     NumericPathRecord {
-        Objects.requireNonNull(expression, "Expression is required");
-        Objects.requireNonNull(attribute, "Entity attribute is required");
+        Objects.requireNonNull(expression, "The expression is required");
+        Objects.requireNonNull(attribute, "The attribute is required");
     }
 
 }

--- a/api/src/main/java/jakarta/data/metamodel/path/TemporalPathRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/path/TemporalPathRecord.java
@@ -18,6 +18,7 @@
 package jakarta.data.metamodel.path;
 
 import java.time.temporal.Temporal;
+import java.util.Objects;
 
 import jakarta.data.metamodel.NavigableExpression;
 import jakarta.data.metamodel.TemporalAttribute;
@@ -25,4 +26,9 @@ import jakarta.data.metamodel.TemporalAttribute;
 record TemporalPathRecord<T,U,V extends Temporal & Comparable<? extends Temporal>>(
         NavigableExpression<T,U> expression,
         TemporalAttribute<U,V> attribute) implements TemporalPath<T,U,V> {
+
+    TemporalPathRecord {
+        Objects.requireNonNull(expression, "The expression is required");
+        Objects.requireNonNull(attribute, "The attribute is required");
+    }
 }

--- a/api/src/main/java/jakarta/data/metamodel/path/TextPathRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/path/TextPathRecord.java
@@ -27,8 +27,8 @@ record TextPathRecord<T,U>
         implements TextPath<T,U> {
 
     TextPathRecord {
-        Objects.requireNonNull(expression, "Expression is required");
-        Objects.requireNonNull(attribute, "Entity attribute is required");
+        Objects.requireNonNull(expression, "The expression is required");
+        Objects.requireNonNull(attribute, "The attribute is required");
     }
 
 }

--- a/api/src/main/java/jakarta/data/metamodel/path/TextPathRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/path/TextPathRecord.java
@@ -27,8 +27,8 @@ record TextPathRecord<T,U>
         implements TextPath<T,U> {
 
     TextPathRecord {
-        Objects.requireNonNull(expression, "Expression is required.");
-        Objects.requireNonNull(attribute, "Entity attribute is required.");
+        Objects.requireNonNull(expression, "Expression is required");
+        Objects.requireNonNull(attribute, "Entity attribute is required");
     }
 
 }

--- a/api/src/main/java/jakarta/data/metamodel/restrict/BasicRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/BasicRestrictionRecord.java
@@ -31,8 +31,8 @@ record BasicRestrictionRecord<T, V>(Expression<T,V> expression, Constraint<V> co
         implements BasicRestriction<T, V> {
 
     BasicRestrictionRecord {
-        Objects.requireNonNull(expression, "Expression is required");
-        Objects.requireNonNull(constraint, "Constraint is required");
+        Objects.requireNonNull(expression, "The expression is required");
+        Objects.requireNonNull(constraint, "The constraint is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/restrict/BasicRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/BasicRestrictionRecord.java
@@ -31,8 +31,8 @@ record BasicRestrictionRecord<T, V>(Expression<T,V> expression, Constraint<V> co
         implements BasicRestriction<T, V> {
 
     BasicRestrictionRecord {
-        Objects.requireNonNull(expression, "Expression must not be null");
-        Objects.requireNonNull(constraint, "Constraint must not be null");
+        Objects.requireNonNull(expression, "Expression is required.");
+        Objects.requireNonNull(constraint, "Constraint is required.");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/restrict/BasicRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/BasicRestrictionRecord.java
@@ -31,8 +31,8 @@ record BasicRestrictionRecord<T, V>(Expression<T,V> expression, Constraint<V> co
         implements BasicRestriction<T, V> {
 
     BasicRestrictionRecord {
-        Objects.requireNonNull(expression, "Expression is required.");
-        Objects.requireNonNull(constraint, "Constraint is required.");
+        Objects.requireNonNull(expression, "Expression is required");
+        Objects.requireNonNull(constraint, "Constraint is required");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/metamodel/restrict/CompositeRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/CompositeRestrictionRecord.java
@@ -39,7 +39,8 @@ record CompositeRestrictionRecord<T>(
             throw new IllegalArgumentException(
                     "Cannot create a composite restriction without any restrictions to combine.");
         }
-        restrictions.forEach(r -> Objects.requireNonNull(r, "Restriction must not be null"));
+        restrictions.forEach(
+                r -> Objects.requireNonNull(r, "Restriction is required."));
     }
 
     CompositeRestrictionRecord(Type type, List<Restriction<T>> restrictions) {

--- a/api/src/main/java/jakarta/data/metamodel/restrict/CompositeRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/CompositeRestrictionRecord.java
@@ -40,7 +40,7 @@ record CompositeRestrictionRecord<T>(
                     "Cannot create a composite restriction without any restrictions to combine");
         }
         restrictions.forEach(
-                r -> Objects.requireNonNull(r, "Restriction is required"));
+                r -> Objects.requireNonNull(r, "Restriction must not be null"));
     }
 
     CompositeRestrictionRecord(Type type, List<Restriction<T>> restrictions) {

--- a/api/src/main/java/jakarta/data/metamodel/restrict/CompositeRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/CompositeRestrictionRecord.java
@@ -37,10 +37,10 @@ record CompositeRestrictionRecord<T>(
     CompositeRestrictionRecord {
         if (restrictions == null || restrictions.isEmpty()) {
             throw new IllegalArgumentException(
-                    "Cannot create a composite restriction without any restrictions to combine.");
+                    "Cannot create a composite restriction without any restrictions to combine");
         }
         restrictions.forEach(
-                r -> Objects.requireNonNull(r, "Restriction is required."));
+                r -> Objects.requireNonNull(r, "Restriction is required"));
     }
 
     CompositeRestrictionRecord(Type type, List<Restriction<T>> restrictions) {

--- a/api/src/main/java/jakarta/data/metamodel/restrict/Restrict.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/Restrict.java
@@ -43,7 +43,7 @@ public class Restrict {
 
     // convenience method for those who would prefer to avoid .negate()
     public static <T> Restriction<T> not(Restriction<T> restriction) {
-        Objects.requireNonNull(restriction, "Restriction is required");
+        Objects.requireNonNull(restriction, "The restriction is required");
         return restriction.negate();
     }
 

--- a/api/src/main/java/jakarta/data/metamodel/restrict/Restrict.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/Restrict.java
@@ -43,7 +43,7 @@ public class Restrict {
 
     // convenience method for those who would prefer to avoid .negate()
     public static <T> Restriction<T> not(Restriction<T> restriction) {
-        Objects.requireNonNull(restriction, "Restriction must not be null");
+        Objects.requireNonNull(restriction, "Restriction is required.");
         return restriction.negate();
     }
 

--- a/api/src/main/java/jakarta/data/metamodel/restrict/Restrict.java
+++ b/api/src/main/java/jakarta/data/metamodel/restrict/Restrict.java
@@ -43,7 +43,7 @@ public class Restrict {
 
     // convenience method for those who would prefer to avoid .negate()
     public static <T> Restriction<T> not(Restriction<T> restriction) {
-        Objects.requireNonNull(restriction, "Restriction is required.");
+        Objects.requireNonNull(restriction, "Restriction is required");
         return restriction.negate();
     }
 

--- a/api/src/main/java/jakarta/data/page/PageRequestCursor.java
+++ b/api/src/main/java/jakarta/data/page/PageRequestCursor.java
@@ -39,7 +39,7 @@ class PageRequestCursor implements PageRequest.Cursor {
     PageRequestCursor(Object... key) {
         this.key = key;
         if (key == null || key.length == 0){
-            throw new IllegalArgumentException("No values were provided.");
+            throw new IllegalArgumentException("No values were provided");
         }
     }
 

--- a/api/src/main/java/jakarta/data/page/Pagination.java
+++ b/api/src/main/java/jakarta/data/page/Pagination.java
@@ -32,7 +32,7 @@ record Pagination(long page, int size, Mode mode, Cursor type, boolean requestTo
         }
 
         if (mode != Mode.OFFSET && (type == null || type.size() == 0)) {
-            throw new IllegalArgumentException("No key values were provided.");
+            throw new IllegalArgumentException("No key values were provided");
         }
     }
 

--- a/api/src/test/java/jakarta/data/metamodel/AttributeTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/AttributeTest.java
@@ -91,7 +91,7 @@ class AttributeTest {
     void shouldThrowExceptionForEmptyInRestriction() {
         assertThatThrownBy(() -> testAttribute.in(Set.of()))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Values are required.");
+                .hasMessage("Values are required");
     }
 
     @Test
@@ -112,7 +112,7 @@ class AttributeTest {
     void shouldThrowExceptionForEmptyNotInRestriction() {
         assertThatThrownBy(() -> testAttribute.notIn(Set.of()))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Values are required.");
+                .hasMessage("Values are required");
     }
 
     @Test

--- a/api/src/test/java/jakarta/data/metamodel/AttributeTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/AttributeTest.java
@@ -91,7 +91,7 @@ class AttributeTest {
     void shouldThrowExceptionForEmptyInRestriction() {
         assertThatThrownBy(() -> testAttribute.in(Set.of()))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("values are required");
+                .hasMessage("Values are required.");
     }
 
     @Test
@@ -112,7 +112,7 @@ class AttributeTest {
     void shouldThrowExceptionForEmptyNotInRestriction() {
         assertThatThrownBy(() -> testAttribute.notIn(Set.of()))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("values are required");
+                .hasMessage("Values are required.");
     }
 
     @Test

--- a/api/src/test/java/jakarta/data/metamodel/AttributeTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/AttributeTest.java
@@ -91,7 +91,7 @@ class AttributeTest {
     void shouldThrowExceptionForEmptyInRestriction() {
         assertThatThrownBy(() -> testAttribute.in(Set.of()))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Values are required");
+                .hasMessage("The values are required");
     }
 
     @Test
@@ -112,7 +112,7 @@ class AttributeTest {
     void shouldThrowExceptionForEmptyNotInRestriction() {
         assertThatThrownBy(() -> testAttribute.notIn(Set.of()))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Values are required");
+                .hasMessage("The values are required");
     }
 
     @Test

--- a/api/src/test/java/jakarta/data/metamodel/restrict/BasicRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/BasicRestrictionRecordTest.java
@@ -124,7 +124,7 @@ class BasicRestrictionRecordTest {
     void shouldThrowExceptionWhenAttributeIsNull() {
         assertThatThrownBy(() -> BasicAttribute.of(Book.class, null, Object.class).equalTo("testValue"))
                 .isInstanceOf(NullPointerException.class)
-                .hasMessage("entity attribute name is required");
+                .hasMessage("Entity attribute name is required.");
     }
 
     @Test

--- a/api/src/test/java/jakarta/data/metamodel/restrict/BasicRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/BasicRestrictionRecordTest.java
@@ -124,7 +124,7 @@ class BasicRestrictionRecordTest {
     void shouldThrowExceptionWhenAttributeIsNull() {
         assertThatThrownBy(() -> BasicAttribute.of(Book.class, null, Object.class).equalTo("testValue"))
                 .isInstanceOf(NullPointerException.class)
-                .hasMessage("Entity attribute name is required.");
+                .hasMessage("Entity attribute name is required");
     }
 
     @Test
@@ -132,7 +132,7 @@ class BasicRestrictionRecordTest {
     void shouldThrowExceptionWhenValueIsNull() {
         assertThatThrownBy(() -> _Book.title.equalTo((String) null))
                 .isInstanceOf(NullPointerException.class)
-                .hasMessage("Value is required.");
+                .hasMessage("Value is required");
     }
 
     @Test

--- a/api/src/test/java/jakarta/data/metamodel/restrict/BasicRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/BasicRestrictionRecordTest.java
@@ -124,7 +124,7 @@ class BasicRestrictionRecordTest {
     void shouldThrowExceptionWhenAttributeIsNull() {
         assertThatThrownBy(() -> BasicAttribute.of(Book.class, null, Object.class).equalTo("testValue"))
                 .isInstanceOf(NullPointerException.class)
-                .hasMessage("Entity attribute name is required");
+                .hasMessage("The name is required");
     }
 
     @Test
@@ -132,7 +132,7 @@ class BasicRestrictionRecordTest {
     void shouldThrowExceptionWhenValueIsNull() {
         assertThatThrownBy(() -> _Book.title.equalTo((String) null))
                 .isInstanceOf(NullPointerException.class)
-                .hasMessage("Value is required");
+                .hasMessage("The value is required");
     }
 
     @Test

--- a/api/src/test/java/jakarta/data/metamodel/restrict/CompositeRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/CompositeRestrictionRecordTest.java
@@ -112,7 +112,8 @@ class CompositeRestrictionRecordTest {
     void shouldFailIfEmptyRestrictions() {
         assertThatThrownBy(() -> new CompositeRestrictionRecord<>(CompositeRestriction.Type.ALL, List.of()))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Cannot create a composite restriction without any restrictions to combine.");
+                .hasMessage("Cannot create a composite restriction without" +
+                            " any restrictions to combine");
     }
 
     @Test

--- a/api/src/test/java/jakarta/data/metamodel/restrict/RestrictTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/RestrictTest.java
@@ -294,6 +294,6 @@ class RestrictTest {
     void shouldThrowExceptionForInvalidWildcard() {
         assertThatThrownBy(() -> _Employee.name.like("pattern_value", '_', '_'))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Cannot use the same character (_) for both wildcards.");
+                .hasMessage("Cannot use the same character (_) for both wildcards");
     }
 }

--- a/api/src/test/java/jakarta/data/metamodel/restrict/TextRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/TextRestrictionRecordTest.java
@@ -224,6 +224,6 @@ class TextRestrictionRecordTest {
     void shouldThrowExceptionWhenAttributeIsNullInTextRestriction() {
         assertThatThrownBy(() -> TextAttribute.of(_Book.class, null).equalTo("testValue"))
                 .isInstanceOf(NullPointerException.class)
-                .hasMessage("Entity attribute name is required.");
+                .hasMessage("Entity attribute name is required");
     }
 }

--- a/api/src/test/java/jakarta/data/metamodel/restrict/TextRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/TextRestrictionRecordTest.java
@@ -224,6 +224,6 @@ class TextRestrictionRecordTest {
     void shouldThrowExceptionWhenAttributeIsNullInTextRestriction() {
         assertThatThrownBy(() -> TextAttribute.of(_Book.class, null).equalTo("testValue"))
                 .isInstanceOf(NullPointerException.class)
-                .hasMessage("Entity attribute name is required");
+                .hasMessage("The name is required");
     }
 }

--- a/api/src/test/java/jakarta/data/metamodel/restrict/TextRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/restrict/TextRestrictionRecordTest.java
@@ -224,6 +224,6 @@ class TextRestrictionRecordTest {
     void shouldThrowExceptionWhenAttributeIsNullInTextRestriction() {
         assertThatThrownBy(() -> TextAttribute.of(_Book.class, null).equalTo("testValue"))
                 .isInstanceOf(NullPointerException.class)
-                .hasMessage("entity attribute name is required");
+                .hasMessage("Entity attribute name is required.");
     }
 }


### PR DESCRIPTION
While reviewing code, I noticed the way in which our error messages is written is all over the place.

I did a search and found that Objects.requireNonNull appears 87 times in our API. Here are some of the different styles that I spotted when browsing through the search results:

- value must not be null
- Value must not be null.
- value is required
- Value is required.
- no message at all in a few cases

For messages that we supply to IllegalArgumentException that we construct for the metamodel, we do a better job of being consistent. In a few cases the message is all lower case with no punctuation, like "values are required", but in most cases it is a sentence beginning with a capital letter and ending with a period, such as "Values must not be empty."

This PR aims to make all of the messages consistent.