### PR TITLE
Update CI build and jruby dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,9 @@ permissions:
 jobs:
   build:
 
-    # TODO update once 25-ea is available
     strategy:
       matrix:
-        java-version: [ '17', '21' ]
+        java-version: [ '21', '25' ]
 
     runs-on: ubuntu-latest
 
@@ -44,7 +43,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'temurin'
           cache: maven
       - name: Analyze starters

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           java-version: 21

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [ '21', '25' ]
+        java-version: [ '21', '25-ea' ]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/specification.yml
+++ b/.github/workflows/specification.yml
@@ -17,10 +17,10 @@ jobs:
     steps:
     - name: Checkout source
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
       with:
-        java-version: 17
+        java-version: 21
         distribution: 'temurin'
         cache: maven
     - name: Generate specification docs

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -8,11 +8,10 @@ jobs:
   update:
     runs-on: ubuntu-latest
 
-    # TODO update once 25-ea is available
     strategy:
       max-parallel: 1
       matrix:
-        java-version: [ '17', '21' ]
+        java-version: [ '21', '25' ]
 
     steps:
     - name: Checkout source

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        java-version: [ '21', '25' ]
+        java-version: [ '21', '25-ea' ]
 
     steps:
     - name: Checkout source

--- a/README.adoc
+++ b/README.adoc
@@ -171,13 +171,13 @@ This project is governed by the Eclipse Foundation Community Code of Conduct. By
 
 == Getting Help
 
-Having trouble with Jakarta Data? We’d love to help!
+Having trouble with Jakarta Data? We'd love to help!
 
 Report Jakarta Data bugs at https://github.com/jakartaee/data/issues.
 
 == Building from Source
 
-You don’t need to build from source to use the project, but you can do so with Maven and Java 17 or higher.
+You don't need to build from source to use the project, but you can do so with Maven and Java 21 or higher.
 
 [source, Bash]
 ----

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -91,7 +91,7 @@
                             <goal>jar</goal>
                         </goals>
                         <configuration>
-                            <source>17</source>
+                            <source>21</source>
                             <quiet>true</quiet>
                             <additionalJOption>-Xdoclint:none</additionalJOption>
                             <description>Jakarta Data API documentation</description>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -68,8 +68,8 @@
     </developers>
 
     <properties>
-        <maven.compiler.release>17</maven.compiler.release>
-        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.source>21</maven.compiler.source>
         <maven.compile.version>3.14.0</maven.compile.version>
         <maven.surefire.plugin.version>3.5.3</maven.surefire.plugin.version>
         <maven-javadoc-plugin.vesion>3.4.1</maven-javadoc-plugin.vesion>

--- a/spec/README.adoc
+++ b/spec/README.adoc
@@ -6,7 +6,7 @@ This module contains AsciiDoc sources and configuration to generate Jakarta Data
 
 === Prerequisites:
 
-* JDK 17+
+* JDK 21+
 * Maven 3.0.5+
 
 === Execute the full build:

--- a/tck-dist/pom.xml
+++ b/tck-dist/pom.xml
@@ -50,7 +50,7 @@
   <asciidoctor.maven.plugin.version>3.2.0</asciidoctor.maven.plugin.version>
   <asciidoctorj.version>3.0.0</asciidoctorj.version>
   <asciidoctorj.pdf.version>2.3.19</asciidoctorj.pdf.version>
-  <jruby.version>9.4.12.0</jruby.version>
+  <jruby.version>10.0.0.0</jruby.version>
  </properties>
 
  <dependencies>

--- a/tck-dist/src/main/asciidoc/data-tck-reference-guide.adoc
+++ b/tck-dist/src/main/asciidoc/data-tck-reference-guide.adoc
@@ -17,8 +17,8 @@
 :SigPluginVersion: 2.3
 :SigPluginGAV: jakarta.tck:sigtest-maven-plugin:{SigPluginVersion}
 
-:JavaVersion1: 17
-:JavaVersion2: 21
+:JavaVersion1: 21
+:JavaVersion2: 25
 
 :license: Eclipse Foundation Technology Compatibility Kit License
 :licenseURL: https://www.eclipse.org/legal/tck.php

--- a/tck-dist/src/main/starter/ee-pom.xml
+++ b/tck-dist/src/main/starter/ee-pom.xml
@@ -29,8 +29,8 @@
   <!-- General properties -->
   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-  <maven.compiler.release>17</maven.compiler.release>
-  <maven.compiler.testRelease>17</maven.compiler.testRelease>
+  <maven.compiler.release>21</maven.compiler.release>
+  <maven.compiler.testRelease>21</maven.compiler.testRelease>
 
   <!-- Dependency and Plugin Versions -->
   <jakarta.data.version>1.0.1</jakarta.data.version>

--- a/tck-dist/src/main/starter/se-pom.xml
+++ b/tck-dist/src/main/starter/se-pom.xml
@@ -28,8 +28,8 @@
  <properties>
   <!-- General properties -->
   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  <maven.compiler.release>17</maven.compiler.release>
-  <maven.compiler.testRelease>17</maven.compiler.testRelease>
+  <maven.compiler.release>21</maven.compiler.release>
+  <maven.compiler.testRelease>21</maven.compiler.testRelease>
 
   <!-- Dependency and Plugin Versions -->
   <jakarta.data.version>1.0.1</jakarta.data.version>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -178,8 +178,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven.compile.version}</version>
         <configuration>
-          <source>17</source>
-          <target>17</target>
+          <source>21</source>
+          <target>21</target>
           <compilerArgs>
             <arg>-parameters</arg>
           </compilerArgs>
@@ -209,7 +209,7 @@
               <goal>jar</goal>
             </goals>
             <configuration>
-              <source>17</source>
+              <source>21</source>
               <quiet>true</quiet>
               <additionalJOption>-Xdoclint:none</additionalJOption>
             </configuration>
@@ -234,7 +234,7 @@
       </activation>
       <properties>
         <!--Default assumed JDK version, can be overriden via -Dmajor.jdk.version=X -->
-        <jdk.major.version>17</jdk.major.version>
+        <jdk.major.version>21</jdk.major.version>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
Fixes #1066

Updates CI builds to use the minimum Java 21 version
Update the jruby plugin which is now compiled at Java 21