### PR TITLE
ignore: jruby 10.0.0.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,10 @@ updates:
     directory: /
     schedule:
       interval: daily
+    ignore:
+      #TODO wait until we are building with Java 21 and Asciidoctor is updated to support jruby 10
+      - dependency-name: "org.jruby:jruby"
+      - versions: [ ">10.0.0.0" ]
 
   - package-ecosystem: maven
     directory: /tck-dist/src/main/

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     ignore:
       #TODO wait until we are building with Java 21 and Asciidoctor is updated to support jruby 10
       - dependency-name: "org.jruby:jruby"
-      - versions: [ ">10.0.0.0" ]
+        versions: [ "[10,)" ]
 
   - package-ecosystem: maven
     directory: /tck-dist/src/main/


### PR DESCRIPTION
Fixes #1095

Asciidoctor does not yet support jruby 10.  See error: 

```
Error:  Failed to execute goal org.asciidoctor:asciidoctor-maven-plugin:3.2.0:process-asciidoc (asciidoc-to-pdf) on project jakarta.data-tck-dist: Execution asciidoc-to-pdf of goal org.asciidoctor:asciidoctor-maven-plugin:3.2.0:process-asciidoc failed: (ArgumentError) wrong number of arguments (given 3, expected 1..2): (LoadError) no such file to load -- asciidoctor-pdf -> [Help 1]
```