### PR TITLE
Fix typo in CrudRepository example entity

### DIFF
--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -46,7 +46,7 @@ import java.util.List;
  *
  * <pre>
  * &#64;Entity
- * public class Cars {
+ * public class Car {
  *     &#64;Id
  *     public long vin;
  *     public String make;


### PR DESCRIPTION
CrudRepository has a minor typo where the name of the entity class is the same as the name of the repository class used in that same example.