### PR TITLE
reify the attribute type

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/Attribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/Attribute.java
@@ -75,4 +75,24 @@ public interface Attribute<T> {
                  to provide the entity class.\
                 """);
     }
+
+    /**
+     * Obtain the Java class which declares this entity attribute.
+     *
+     * @return the declaring class
+     * @throws UnsupportedOperationException if the declaring type is not
+     *                                       known.
+     * @apiNote This is only guaranteed to be known if a static <code>of</code>
+     * method, such as {@link BasicAttribute#of(Class, String, Class)}, was used
+     * to obtain the instance.
+     * @since 1.1
+     */
+    default Class<?> attributeType() {
+        throw new UnsupportedOperationException(getClass().getName() + """
+                 was obtained in a way that does not identify the type\
+                 of the attribute. Static metamodel classes should\
+                 use the .of method that is defined on the Attribute subtype\
+                 to provide the entity class.\
+                """);
+    }
 }

--- a/api/src/main/java/jakarta/data/metamodel/BasicAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/BasicAttribute.java
@@ -30,6 +30,16 @@ import jakarta.data.expression.Expression;
  */
 public interface BasicAttribute<T, V> extends Attribute<T>, Expression<T, V> {
 
+    @Override
+    default Class<V> attributeType() {
+        throw new UnsupportedOperationException(getClass().getName() + """
+                 was obtained in a way that does not identify the type\
+                 of the attribute. Static metamodel classes should\
+                 use the .of method that is defined on the Attribute subtype\
+                 to provide the entity class.\
+                """);
+    }
+
     /**
      * <p>Creates a static metamodel {@code BasicAttribute} representing the
      * entity attribute with the specified name.</p>
@@ -49,7 +59,7 @@ public interface BasicAttribute<T, V> extends Attribute<T>, Expression<T, V> {
         Objects.requireNonNull(name, "The name is required");
         Objects.requireNonNull(attributeType, "The attributeType is required");
 
-        return new BasicAttributeRecord<>(entityClass, name);
+        return new BasicAttributeRecord<>(entityClass, name, attributeType);
     }
 }
 

--- a/api/src/main/java/jakarta/data/metamodel/BasicAttributeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/BasicAttributeRecord.java
@@ -17,6 +17,7 @@
  */
 package jakarta.data.metamodel;
 
-record BasicAttributeRecord<T, V>(Class<T> declaringType, String name)
+record BasicAttributeRecord<T, V>
+        (Class<T> declaringType, String name, Class<V> attributeType)
         implements BasicAttribute<T, V> {
 }

--- a/api/src/main/java/jakarta/data/metamodel/ComparableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/ComparableAttribute.java
@@ -80,7 +80,7 @@ public interface ComparableAttribute<T, V extends Comparable<?>>
         Objects.requireNonNull(name, "The name is required");
         Objects.requireNonNull(attributeType, "The attributeType is required");
 
-        return new ComparableAttributeRecord<>(entityClass, name);
+        return new ComparableAttributeRecord<>(entityClass, name, attributeType);
     }
 }
 

--- a/api/src/main/java/jakarta/data/metamodel/ComparableAttributeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/ComparableAttributeRecord.java
@@ -18,6 +18,6 @@
 package jakarta.data.metamodel;
 
 record ComparableAttributeRecord<T, V extends Comparable<?>>
-        (Class<T> declaringType, String name)
+        (Class<T> declaringType, String name, Class<V> attributeType)
         implements ComparableAttribute<T, V> {
 }

--- a/api/src/main/java/jakarta/data/metamodel/NavigableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/NavigableAttribute.java
@@ -33,6 +33,9 @@ import jakarta.data.expression.NavigableExpression;
 public interface NavigableAttribute<T, U>
         extends Attribute<T>, NavigableExpression<T, U> {
 
+    @Override
+    Class<U> attributeType();
+
     /**
      * <p>Creates a static metamodel {@code NavigableAttribute} representing
      * the
@@ -52,7 +55,7 @@ public interface NavigableAttribute<T, U>
         Objects.requireNonNull(name, "The name is required");
         Objects.requireNonNull(attributeType, "The attributeType is required");
 
-        return new NavigableAttributeRecord<>(entityClass, name);
+        return new NavigableAttributeRecord<>(entityClass, name, attributeType);
     }
 }
 

--- a/api/src/main/java/jakarta/data/metamodel/NavigableAttributeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/NavigableAttributeRecord.java
@@ -17,6 +17,7 @@
  */
 package jakarta.data.metamodel;
 
-record NavigableAttributeRecord<T, U>(Class<T> declaringType, String name)
+record NavigableAttributeRecord<T, U>
+        (Class<T> declaringType, String name, Class<U> attributeType)
         implements NavigableAttribute<T, U> {
 }

--- a/api/src/main/java/jakarta/data/metamodel/NumericAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/NumericAttribute.java
@@ -68,7 +68,7 @@ public interface NumericAttribute<T, N extends Number & Comparable<N>>
         Objects.requireNonNull(name, "The name is required");
         Objects.requireNonNull(attributeType, "The attributeType is required");
 
-        return new NumericAttributeRecord<>(entityClass, name);
+        return new NumericAttributeRecord<>(entityClass, name, attributeType);
     }
 }
 

--- a/api/src/main/java/jakarta/data/metamodel/NumericAttributeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/NumericAttributeRecord.java
@@ -18,6 +18,6 @@
 package jakarta.data.metamodel;
 
 record NumericAttributeRecord<T, V extends Number & Comparable<V>>
-        (Class<T> declaringType, String name)
+        (Class<T> declaringType, String name, Class<V> attributeType)
         implements NumericAttribute<T, V> {
 }

--- a/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java
@@ -77,6 +77,6 @@ public interface SortableAttribute<T> extends Attribute<T> {
         Objects.requireNonNull(name, "The name is required");
         Objects.requireNonNull(attributeType, "The attributeType is required");
 
-        return new SortableAttributeRecord<>(entityClass, name);
+        return new SortableAttributeRecord<>(entityClass, name, attributeType);
     }
 }

--- a/api/src/main/java/jakarta/data/metamodel/SortableAttributeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/SortableAttributeRecord.java
@@ -17,7 +17,8 @@
  */
 package jakarta.data.metamodel;
 
-record SortableAttributeRecord<T>(Class<T> declaringType, String name)
+record SortableAttributeRecord<T>
+        (Class<T> declaringType, String name, Class<?> attributeType)
         implements SortableAttribute<T> {
 }
 

--- a/api/src/main/java/jakarta/data/metamodel/TemporalAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/TemporalAttribute.java
@@ -65,7 +65,7 @@ public interface TemporalAttribute<T, V extends Temporal & Comparable<? extends 
         Objects.requireNonNull(name, "The name is required");
         Objects.requireNonNull(attributeType, "The attributeType is required");
 
-        return new TemporalAttributeRecord<T, V>(entityClass, name);
+        return new TemporalAttributeRecord<>(entityClass, name, attributeType);
     }
 }
 

--- a/api/src/main/java/jakarta/data/metamodel/TemporalAttributeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/TemporalAttributeRecord.java
@@ -19,8 +19,7 @@ package jakarta.data.metamodel;
 
 import java.time.temporal.Temporal;
 
-record TemporalAttributeRecord<T, V extends Temporal & Comparable<? extends Temporal>>(
-        Class<T> declaringType,
-        String name)
+record TemporalAttributeRecord<T, V extends Temporal & Comparable<? extends Temporal>>
+        (Class<T> declaringType, String name, Class<V> attributeType)
         implements TemporalAttribute<T, V> {
 }

--- a/api/src/main/java/jakarta/data/metamodel/TextAttributeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/TextAttributeRecord.java
@@ -19,4 +19,8 @@ package jakarta.data.metamodel;
 
 record TextAttributeRecord<T>(Class<T> declaringType, String name)
         implements TextAttribute<T> {
+    @Override
+    public Class<String> attributeType() {
+        return String.class;
+    }
 }

--- a/api/src/test/java/jakarta/data/metamodel/ComparableExpressionTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/ComparableExpressionTest.java
@@ -40,7 +40,7 @@ class ComparableExpressionTest {
     interface _Person {
         String AGE = "age";
         ComparableExpression<Person, Integer> age =
-                new ComparableAttributeRecord<>(Person.class, AGE);
+                ComparableAttribute.of(Person.class, AGE, Integer.class);
     }
 
     @Test


### PR DESCRIPTION
It's extremely useful to be able to reflect on the metamodel.

(Among other things, it lets you check correctness before doing an unchecked type cast.)