### PR TITLE
fix: toolchain error java 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [ '21', '25-ea' ]
+        java-version: [ '21' ] # TODO add 25
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        java-version: [ '21', '25-ea' ]
+        java-version: [ '21' ] # TODO add 25
 
     steps:
     - name: Checkout source


### PR DESCRIPTION
My original PR passed using the Java 25-ea build of temurin here: 
https://github.com/jakartaee/data/actions/runs/14888194513/job/41813364483?pr=1094

Which correctly downloaded the JDK from the location: 
https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B20-ea-beta/OpenJDK-jdk_x64_linux_hotspot_25_20-ea.tar.gz

After merging all subsequent builds have failed, like so: 
https://github.com/jakartaee/data/actions/runs/14909422899/job/41879770970

It looks like the setup-java step downloaded the `jmod` archive instead of the `jdk` from: 
https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25%2B21-ea-beta/OpenJDK-jmods_x64_linux_hotspot_25_21-ea.tar.gz

Which cannot be used by Maven to run a build.

I guess I was too quick.  Let's revert this until Java 25 is released. 
