### PR TITLE
1086 javadoc for literals

### DIFF
--- a/api/src/main/java/jakarta/data/expression/literal/ComparableLiteral.java
+++ b/api/src/main/java/jakarta/data/expression/literal/ComparableLiteral.java
@@ -23,12 +23,40 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.UUID;
 
 import jakarta.data.expression.ComparableExpression;
 
+/**
+ * <p>A {@linkplain Literal literal} for a sortable value, such as
+ * {@link Boolean}, {@link Character}, enumeration, and {@link UUID} values.
+ * </p>
+ *
+ * @param <T> entity type.
+ * @param <V> entity attribute type.
+ * @since 1.1
+ */
 public interface ComparableLiteral<T, V extends Comparable<?>>
         extends ComparableExpression<T, V>, Literal<T, V> {
 
+    /**
+     * <p>Creates a {@code ComparableLiteral} or subtype of
+     * {@code ComparableLiteral} that represents the given value.</p>
+     *
+     * <p>The most specific subtype of {@code ComparableLiteral}, such as
+     * {@link NumericLiteral#of(Number) NumericLiteral},
+     * {@link StringLiteral#of(String) StringLiteral}, or
+     * {@link TemporalLiteral#of(java.time.temporal.Temporal) TemporalLiteral},
+     * should be used instead wherever possible.</p>
+     *
+     * @param <T>   entity type.
+     * @param <V>   entity attribute type.
+     * @param value an immutable value or a mutable value that must never be
+     *              modified after it is supplied to this method. Must never be
+     *              {@code null}.
+     * @return a {@code ComparableLiteral} representing the value.
+     * @throws NullPointerException if the value is {@code null}.
+     */
     @SuppressWarnings("unchecked")
     static <T, V extends Comparable<?>> ComparableLiteral<T, V> of(V value) {
         // Subtypes of Number and Temporal are needed here because
@@ -65,4 +93,55 @@ public interface ComparableLiteral<T, V extends Comparable<?>>
             return new ComparableLiteralRecord<>(value);
         }
     }
+
+    /**
+     * <p>Returns a {@code String} representing the literal value.</p>
+     *
+     * <p>Subtypes of {@code ComparableLiteral} override this method to define
+     * more specific formats that more closely align with query language.</p>
+     *
+     * <p>If the value is of type {@link Boolean}, this method outputs
+     * {@code TRUE} for {@code Boolean.TRUE} and {@code FALSE} for
+     * {@code Boolean.FALSE}.</p>
+     *
+     * <p>If the value is of type {@link Character}, this method outputs a
+     * {@code String} that consists of the character enclosed in single quotes.
+     * If the character is the single quote character, an additional single
+     * quote character is included to escape it.</p>
+     *
+     * <p>If the value is an enumeration type, this method outputs the fully
+     * qualified class name of the type, followed by the {@code .} character,
+     * followed by the {@linkplain Enum#name() name} of the enumeration element
+     * to which the value is assigned.</p>
+     *
+     * <p>For all other types, this method outputs a {@code String} that begins
+     * with an opening curly brace and ends with a closing curly brace. Between
+     * the braces are 3 terms delimited by a space character. The first term is
+     * {@code ComparableLiteral}. The second term is the fully qualified class
+     * name of the value's type. The third term is the {@code toString()}
+     * output of the value, enclosed in single quotes.</p>
+     *
+     * <p>For example, the output of
+     * {@code ComparableLiteral.of(Month.MAY).toString()} is</p>
+     * <pre>
+     * java.time.Month.MAY
+     * </pre>
+     *
+     * <p>For example, the output of
+     * {@code ComparableLiteral.of('D').toString()} is</p>
+     * <pre>
+     * 'D'
+     * </pre>
+     *
+     * <p>The output of
+     * {@code ComparableLiteral.of(UUID.fromString("73d518c4-b7f6-4c3b-9f63-60a045a43bb8")).toString()}
+     * is</p>
+     * <pre>
+     * {ComparableLiteral java.util.UUID '73d518c4-b7f6-4c3b-9f63-60a045a43bb8'}
+     * </pre>
+     *
+     * @return a {@code String} representing the literal value.
+     */
+    @Override
+    public String toString();
 }

--- a/api/src/main/java/jakarta/data/expression/literal/ComparableLiteralRecord.java
+++ b/api/src/main/java/jakarta/data/expression/literal/ComparableLiteralRecord.java
@@ -28,7 +28,14 @@ record ComparableLiteralRecord<T, V extends Comparable<?>>(V value)
 
     @Override
     public String toString() {
-        return value.toString();
+        return switch (value) {
+            case Boolean b -> b == Boolean.TRUE ? "TRUE" : "FALSE";
+            case Character c -> c == '\'' ? "''''" : "'" + c + "'";
+            case Enum e -> e.getClass().getName() + '.' + e.name();
+            default -> "{ComparableLiteral "
+                        + value.getClass().getName()
+                        + " '" + value.toString() + "'}";
+        };
     }
 
 }

--- a/api/src/main/java/jakarta/data/expression/literal/Literal.java
+++ b/api/src/main/java/jakarta/data/expression/literal/Literal.java
@@ -18,10 +18,67 @@
 package jakarta.data.expression.literal;
 
 import jakarta.data.expression.Expression;
+import jakarta.data.metamodel.Attribute;
+import jakarta.data.restrict.Restriction;
 
+/**
+ * <p>A literal represents an immutable value within an {@link Expression}.
+ * A literal is a type of {@link Expression} and can be used to compose
+ * {@link Restriction}s.</p>
+ *
+ * <p>For example,</p>
+ * <pre>
+ * List&lt;Car&gt; discountedMoreThan10Percent =
+ *         cars.search(make,
+ *                     model,
+ *                     NumericLiteral.of(discount).greaterThan(_Car.price.asDouble().times(0.1));
+ * </pre>
+ *
+ * <p>The {@linkplain Attribute entity and static metamodel} for the code
+ * examples within this class are shown in the {@link Attribute} Javadoc.
+ * </p>
+ *
+ * <p>In many cases, it is possible for applications to avoid the use of
+ * {@code Literal} and its subtypes by supplying values to expression methods
+ * instead. For example, a {@code Restriction} that is equivalent to the
+ * example above can be written more concisely without {@code NumericLiteral}
+ * as:</p>
+ * <pre>
+ * _Car.price.asDouble().times(0.1).lessThan(discount)
+ * </pre>
+ *
+ * @param <T> entity type.
+ * @param <V> entity attribute type.
+ * @since 1.1
+ */
 public interface Literal<T, V> extends Expression<T, V> {
+    /**
+     * <p>Returns the value represented by this {@code Literal}.
+     * The value will never be {@code null}.</p>
+     *
+     * @return the value.
+     */
     V value();
 
+    /**
+     * <p>Creates a {@code Literal} or subtype of {@code Literal} that
+     * represents the given value.</p>
+     *
+     * <p>The most specific subtype of {@code Literal}, such as
+     * {@link NumericLiteral#of(Number) NumericLiteral},
+     * {@link StringLiteral#of(String) StringLiteral},
+     * {@link TemporalLiteral#of(java.time.temporal.Temporal) TemporalLiteral},
+     * or {@link ComparableLiteral#of(Comparable) ComparableLiteral},
+     * should be used instead wherever possible.</p>
+     *
+     * @param <T>   entity type.
+     * @param <V>   entity attribute type.
+     * @param value an immutable value or a mutable value that must never be
+     *              modified after it is supplied to this method. Must never be
+     *              {@code null}.
+     * @return a {@code Literal} representing the value.
+     * @throws NullPointerException if the value is {@code null}.
+     */
     @SuppressWarnings("unchecked")
     static <T, V> Literal<T, V> of(V value) {
         if (value instanceof Comparable c) {
@@ -31,4 +88,27 @@ public interface Literal<T, V> extends Expression<T, V> {
         }
     }
 
+    /**
+     * <p>Returns a {@code String} representing the literal value.</p>
+     *
+     * <p>Subtypes of {@code Literal} override this method to define more
+     * specific formats that more closely align with query language.</p>
+     *
+     * <p>This method outputs a {@code String} that begins with an opening
+     * curly brace and ends with a closing curly brace. Between the braces are
+     * 3 terms delimited by a space character. The first term is
+     * {@code Literal}. The second term is the fully qualified class name of
+     * the value's type. The third term is the {@code toString()} output of the
+     * value, enclosed in single quotes.</p>
+     *
+     * <p>For example, the output of
+     * {@code Literal.of(ZoneId.of("America/Chicago")).toString()} is</p>
+     * <pre>
+     * {Literal java.time.ZoneId 'America/Chicago'}
+     * </pre>
+     *
+     * @return a {@code String} representing the literal value.
+     */
+    @Override
+    public String toString();
 }

--- a/api/src/main/java/jakarta/data/expression/literal/LiteralRecord.java
+++ b/api/src/main/java/jakarta/data/expression/literal/LiteralRecord.java
@@ -27,7 +27,7 @@ record LiteralRecord<T, V>(V value) implements Literal<T, V> {
 
     @Override
     public String toString() {
-        return value.toString();
+        return "{Literal " + value.getClass().getName() + " '" + value + "'}";
     }
 
 }

--- a/api/src/main/java/jakarta/data/expression/literal/NumericLiteral.java
+++ b/api/src/main/java/jakarta/data/expression/literal/NumericLiteral.java
@@ -17,12 +17,76 @@
  */
 package jakarta.data.expression.literal;
 
-import jakarta.data.expression.NumericExpression;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 
+import jakarta.data.expression.NumericExpression;
+import jakarta.data.metamodel.NumericAttribute;
+
+/**
+ * <p>A {@linkplain Literal literal} for a
+ * {@linkplain NumericAttribute numeric} value.</p>
+ *
+ * @param <T> entity type.
+ * @param <N> entity attribute type.
+ * @since 1.1
+ */
 public interface NumericLiteral<T, N extends Number & Comparable<N>>
         extends ComparableLiteral<T, N>, NumericExpression<T, N> {
 
+    /**
+     * <p>Creates a {@code NumericLiteral} that represents the given value.</p>
+     *
+     * @param <T>   entity type.
+     * @param <N>   entity attribute type.
+     * @param value an immutable numeric value. Must never be {@code null}.
+     * @return a {@code NumericLiteral} representing the value.
+     * @throws NullPointerException if the value is {@code null}.
+     */
     static <T, N extends Number & Comparable<N>> NumericLiteral<T, N> of(N value) {
         return new NumericLiteralRecord<>(value);
     }
+
+    // TODO Is it a problem that toString for a NumericLiteral with an Integer
+    // value is indistinguishable from toString of an Integer/int value?
+    // I have already seen this in a test where it reported a failed assertion
+    // that appeared to be saying that a number was not equal to the same
+    // number. Actually it was erroneously comparing a NumericLiteral to an
+    // Integer value, but there was no indication of this given that both
+    // convert to the same String. We could switch the output to include a
+    // suffix, such as 'I' at the end, but the downside of that would be not
+    // matching JDQL.
+    /**
+     * <p>Returns a {@code String} representing the literal numeric value.</p>
+     *
+     * <p>For the following types, the {@code String} consists of the numeric
+     * value, followed by</p>
+     * <ul>
+     * <li>{@code L} for {@link Long},</li>
+     * <li>{@code F} for {@link Float},</li>
+     * <li>{@code D} for {@link Double},</li>
+     * <li>{@code BI} for {@link BigInteger}, or</li>
+     * <li>{@code BD} for {@link BigDecimal}.</li>
+     * </ul>
+     *
+     * <p>For values of type {@link Integer}, the {@code String} consists of
+     * the numeric value without any suffix.</p>
+     *
+     * <p>For all other types, the {@code String} begins with an opening curly
+     * brace and ends with a closing curly brace. Between the braces are 3
+     * terms delimited by a space character. The first term is
+     * {@code NumericLiteral}. The second term is the fully qualified class
+     * name of the value's type. The third term is the {@code toString()}
+     * output of the value, enclosed in single quotes.</p>
+     *
+     * <p>For example, the output of
+     * {@code NumericLiteral.of(BigDecimal.valueOf(123456789, 2)).toString()} is</p>
+     * <pre>
+     * 1234567.89BD
+     * </pre>
+     *
+     * @return a {@code String} representing the literal numeric value.
+     */
+    @Override
+    public String toString();
 }

--- a/api/src/main/java/jakarta/data/expression/literal/NumericLiteralRecord.java
+++ b/api/src/main/java/jakarta/data/expression/literal/NumericLiteralRecord.java
@@ -30,13 +30,16 @@ record NumericLiteralRecord<T, N extends Number & Comparable<N>>
 
     @Override
     public String toString() {
-        return value + switch (value) {
-            case Long l -> "L";
-            case Float v -> "F";
-            case Double v -> "D";
-            case BigInteger i -> "BI";
-            case BigDecimal d -> "BD";
-            default -> "";
+        return switch (value) {
+            case Integer i -> i.toString();
+            case Long l -> l + "L";
+            case Float f -> f + "F";
+            case Double d -> d + "D";
+            case BigInteger i -> i + "BI";
+            case BigDecimal d -> d + "BD";
+            default -> "{NumericLiteral "
+                          + value.getClass().getName()
+                          + " '" + value + "'}";
         };
     }
 }

--- a/api/src/main/java/jakarta/data/expression/literal/StringLiteral.java
+++ b/api/src/main/java/jakarta/data/expression/literal/StringLiteral.java
@@ -19,10 +19,41 @@ package jakarta.data.expression.literal;
 
 import jakarta.data.expression.TextExpression;
 
+/**
+ * <p>A {@linkplain Literal literal} for a {@link String} value.</p>
+ *
+ * @param <T> entity type.
+ * @since 1.1
+ */
 public interface StringLiteral<T>
         extends ComparableLiteral<T, String>, TextExpression<T> {
 
+    /**
+     * <p>Creates a {@code StringLiteral} that represents the given value.</p>
+     *
+     * @param <T>   entity type.
+     * @param value a {@code String} value. Must never be {@code null}.
+     * @return a {@code StringLiteral} representing the value.
+     * @throws NullPointerException if the value is {@code null}.
+     */
     static <T> StringLiteral<T> of(String value) {
         return new StringLiteralRecord<T>(value);
     }
+
+    /**
+     * <p>Returns a {@code String} representing the value. The {@code String}
+     * is the value enclosed in single quotes and with each single quote
+     * character in the value escaped with a single quote.</p>
+     *
+     * <p>For example, the output of
+     * {@code StringLiteral.of("Jakarta Data's second release").toString()} is
+     * </p>
+     * <pre>
+     * 'Jakarta Data''s second release'
+     * </pre>
+     *
+     * @return the {@code String} value escaped and enclosed in single quotes.
+     */
+    @Override
+    public String toString();
 }

--- a/api/src/main/java/jakarta/data/expression/literal/StringLiteralRecord.java
+++ b/api/src/main/java/jakarta/data/expression/literal/StringLiteralRecord.java
@@ -28,6 +28,6 @@ record StringLiteralRecord<T>(String value)
 
     @Override
     public String toString() {
-        return '\'' + value + '\'';
+        return '\'' + value.replace("'", "''") + '\'';
     }
 }

--- a/api/src/main/java/jakarta/data/expression/literal/TemporalLiteral.java
+++ b/api/src/main/java/jakarta/data/expression/literal/TemporalLiteral.java
@@ -17,16 +17,90 @@
  */
 package jakarta.data.expression.literal;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.time.temporal.Temporal;
 
 import jakarta.data.expression.TemporalExpression;
+import jakarta.data.metamodel.TemporalAttribute;
 
+/**
+ * <p>A {@linkplain Literal literal} for a
+ * {@linkplain TemporalAttribute temporal} value.</p>
+ *
+ * @param <T> entity type.
+ * @param <V> entity attribute type.
+ * @since 1.1
+ */
 public interface TemporalLiteral<T, V extends Temporal & Comparable<? extends Temporal>>
         extends ComparableLiteral<T, V>, TemporalExpression<T, V> {
 
+    /**
+     * <p>Creates a {@code TemporalLiteral} that represents the given value.
+     * </p>
+     *
+     * @param <T>   entity type.
+     * @param <V>   entity attribute type.
+     * @param value an immutable temporal value. Must never be {@code null}.
+     * @return a {@code TemporalLiteral} representing the value.
+     * @throws NullPointerException if the value is {@code null}.
+     */
     static <T, V extends Temporal & Comparable<? extends Temporal>> TemporalLiteral<T, V> of(
             V value) {
         return new TemporalLiteralRecord<>(value);
     }
 
+    // TODO Is there a possibility that other temporal types might be added in
+    // the future that might also need to use the format of
+    // timestamp/date/time? If so, we should state that the output for other
+    // types is currently undefined so it can be more completely defined in the
+    // future.
+    /**
+     * <p>Returns a {@code String} representing the literal temporal value. The
+     * {@code String} begins with an opening curly brace and ends with a
+     * closing curly brace. Between the braces are 2 or 3 terms delimited by a
+     * space character. The first term is</p>
+     * <ul>
+     * <li>{@code ts} for {@link Instant} and {@link LocalDateTime},</li>
+     * <li>{@code d} for {@link LocalDate},</li>
+     * <li>{@code t} for {@link LocalTime}, or</li>
+     * <li>{@code TemporalLiteral} for all other types, in which case a middle
+     * term is included. The middle term is the fully qualified class name of
+     * the value's type.</li>
+     * </ul>
+     *
+     * <p>For {@link Instant}, the final term is the
+     * {@link LocalDateTime#toLocalDate() LocalDate} and
+     * {@link LocalDateTime#toLocalTime() LocalTime} components of the
+     * {@code Instant} in {@link ZoneOffset#UTC UTC}, delimited by a space
+     * character and enclosed in single quotes.</p>
+     *
+     * <p>For {@link LocalDateTime}, the final term is the
+     * {@link LocalDateTime#toLocalDate() LocalDate} and
+     * {@link LocalDateTime#toLocalTime() LocalTime} components delimited by a
+     * space character and enclosed in single quotes.</p>
+     *
+     * <p>For all other types, the final term is the {@code toString()} output
+     * of the value enclosed in single quotes.</p>
+     *
+     * <p>For example, the output of
+     * {@code TemporalLiteral.of(LocalDate.of(2025, 5, 8)).toString()} is</p>
+     * <pre>
+     * {d '2025-05-08'}
+     * </pre>
+     *
+     * <p>The output of
+     * {@code TemporalLiteral.of(LocalDateTime.of(2025, 5, 9, 16, 25, 52)).toString()}
+     * is</p>
+     * <pre>
+     * {ts '2025-05-09 16:25:52'}
+     * </pre>
+     *
+     * @return a {@code String} representing the literal temporal value.
+     */
+    @Override
+    public String toString();
 }

--- a/api/src/main/java/jakarta/data/expression/literal/TemporalLiteralRecord.java
+++ b/api/src/main/java/jakarta/data/expression/literal/TemporalLiteralRecord.java
@@ -21,6 +21,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.time.temporal.Temporal;
 import java.util.Objects;
 
@@ -34,12 +35,21 @@ record TemporalLiteralRecord<T, V extends Temporal & Comparable<? extends Tempor
 
     @Override
     public String toString() {
-        return switch (value) {
-            case Instant i       -> "TIMESTAMP('" + i + "')";
-            case LocalDateTime d -> "TIMESTAMP('" + d + "')";
-            case LocalDate d     -> "DATE('" + d + "')";
-            case LocalTime t     -> "TIME('" + t + "')";
-            default              -> value.toString();
+        Temporal temporal = value instanceof Instant i
+                ? i.atOffset(ZoneOffset.UTC).toLocalDateTime()
+                : value;
+
+        return switch (temporal) {
+            case LocalDateTime d ->
+                "{ts '" + d.toLocalDate() + ' ' + d.toLocalTime() + "'}";
+            case LocalDate d ->
+                "{d '" + value + "'}";
+            case LocalTime t ->
+                "{t '" + value + "'}";
+            default ->
+                "{TemporalLiteral '"
+                        + value.getClass().getName() + " '"
+                        + value + "'}";
         };
     }
 

--- a/api/src/main/java/jakarta/data/metamodel/ComparableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/ComparableAttribute.java
@@ -45,10 +45,12 @@ import jakarta.data.expression.ComparableExpression;
  *
  * <ul>
  * <li>boolean attributes: {@code boolean} and {@link Boolean}</li>
+ * <li>character attributes: {@code char} and {@link Character}</li>
  * <li>enum attributes - Note that it is provider-specific whether order is
  *     based on {@link Enum#ordinal()} or {@link Enum#name()}.
  *     The Jakarta Persistence default of {@code ordinal} can be overridden
  *     with the {@code jakarta.persistence.Enumerated} annotation.</li>
+ * <li>{@link java.util.UUID} attributes</li>
  * </ul>
  *
  * <p>In the above cases, {@code ComparableAttribute}, which provides more

--- a/api/src/test/java/jakarta/data/expression/literal/ComparableLiteralTest.java
+++ b/api/src/test/java/jakarta/data/expression/literal/ComparableLiteralTest.java
@@ -30,7 +30,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.stream.Stream;
 
@@ -50,9 +49,11 @@ class ComparableLiteralTest {
                 new BigDecimal("123.45"),
                 new BigInteger("987654321"),
                 LocalDate.of(2024, 4, 23),
-                LocalTime.of(14, 30),
-                LocalDateTime.of(2024, 4, 23, 14, 30),
-                Instant.now()
+                LocalTime.of(14, 30)
+                // LocalDateTime and Instant are excluded because their
+                // literals match the query language syntax rather than
+                // following the LocalDateTime.toString and Instant.toString
+                // output exactly.
         );
     }
 

--- a/api/src/test/java/jakarta/data/expression/literal/LiteralToStringTest.java
+++ b/api/src/test/java/jakarta/data/expression/literal/LiteralToStringTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data.expression.literal;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.ZoneId;
+import java.util.UUID;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class LiteralToStringTest {
+
+    @Test
+    @DisplayName("ComparableLiteral.toString must output expected value")
+    void testComparableLiteralToString() {
+        final String TEST_UUID = "73d518c4-b7f6-4c3b-9f63-60a045a43bb8";
+        ComparableLiteral<?, Boolean> booleanLiteral =
+                ComparableLiteral.of(true);
+
+        ComparableLiteral<?, Character> charLiteral =
+                ComparableLiteral.of('D');
+
+        ComparableLiteral<?, Character> singleQuoteLiteral =
+                ComparableLiteral.of('\'');
+
+        ComparableLiteral<?, Month> monthLiteral =
+                ComparableLiteral.of(Month.MAY);
+
+        ComparableLiteral<?, UUID> uuidLiteral =
+                ComparableLiteral.of(UUID.fromString(TEST_UUID));
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(booleanLiteral.toString())
+                    .isEqualTo("TRUE");
+
+            soft.assertThat(charLiteral.toString())
+                    .isEqualTo("'D'");
+
+            soft.assertThat(singleQuoteLiteral.toString())
+                    .isEqualTo("''''");
+
+            soft.assertThat(monthLiteral.toString())
+                    .isEqualTo("java.time.Month.MAY");
+
+            soft.assertThat(uuidLiteral.toString())
+                    .isEqualTo("{ComparableLiteral java.util.UUID '" +
+                               TEST_UUID + "'}");
+        });
+    }
+
+    @Test
+    @DisplayName("NumericLiteral.toString must output expected value")
+    void testNumericLiteralToString() {
+        NumericLiteral<?, Integer> intLiteral = NumericLiteral.of(12);
+
+        NumericLiteral<?, Long> longLiteral = NumericLiteral.of(123456789L);
+
+        NumericLiteral<?, Byte> byteLiteral = NumericLiteral.of((byte) 68);
+
+        NumericLiteral<?, BigInteger> bigIntegerLiteral =
+                NumericLiteral.of(BigInteger.valueOf(10203040506L));
+
+        NumericLiteral<?, BigDecimal> bigDecimalLiteral =
+                NumericLiteral.of(BigDecimal.valueOf(123456789, 2));
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(intLiteral.toString())
+                    .isEqualTo("12");
+
+            soft.assertThat(longLiteral.toString())
+                    .isEqualTo("123456789L");
+
+            soft.assertThat(byteLiteral.toString())
+                    .isEqualTo("{NumericLiteral java.lang.Byte '68'}");
+
+            soft.assertThat(bigIntegerLiteral.toString())
+                    .isEqualTo("10203040506BI");
+
+            soft.assertThat(bigDecimalLiteral.toString())
+                    .isEqualTo("1234567.89BD");
+        });
+    }
+
+    @Test
+    @DisplayName("Literal.toString must output expected value")
+    void testObjectLiteralToString() {
+        Literal<?, ZoneId> literal = Literal.of(ZoneId.of("America/Chicago"));
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(literal.toString())
+                    .startsWith("{Literal ");
+            soft.assertThat(literal.toString())
+                    .endsWith(" 'America/Chicago'}");
+        });
+    }
+
+    @Test
+    @DisplayName("Stringiteral.toString must output expected value")
+    void testStringLiteralToString() {
+        StringLiteral<?> literal = StringLiteral.of("Hello!");
+        StringLiteral<?> singleQuoteLiteral =
+                StringLiteral.of("Jakarta Data's second release");
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(literal.toString())
+                    .isEqualTo("'Hello!'");
+
+            soft.assertThat(singleQuoteLiteral.toString())
+                    .isEqualTo("'Jakarta Data''s second release'");
+        });
+    }
+
+    @Test
+    @DisplayName("TemporalLiteral.toString must output expected value")
+    void testTemporalLiteralToString() {
+        TemporalLiteral<?, Instant> instantLiteral =
+                TemporalLiteral.of(Instant.ofEpochMilli(1746825482575L));
+
+        TemporalLiteral<?, LocalDate> dateLiteral =
+                TemporalLiteral.of(LocalDate.of(2025, 5, 8));
+
+        TemporalLiteral<?, LocalDateTime> datetimeLiteral =
+                TemporalLiteral.of(LocalDateTime.of(2025, 5, 9, 16, 15, 42));
+
+        TemporalLiteral<?, LocalTime> timeLiteral =
+                TemporalLiteral.of(LocalTime.of(18, 8, 30));
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(instantLiteral.toString())
+                    .isEqualTo("{ts '2025-05-09 21:18:02.575'}");
+
+            soft.assertThat(dateLiteral.toString())
+                    .isEqualTo("{d '2025-05-08'}");
+
+            soft.assertThat(datetimeLiteral.toString())
+                    .isEqualTo("{ts '2025-05-09 16:15:42'}");
+
+            soft.assertThat(timeLiteral.toString())
+                    .isEqualTo("{t '18:08:30'}");
+        });
+    }
+}


### PR DESCRIPTION
This PR adds JavaDoc for Literal and all of its subtypes.  While adding the Javadoc for the toString methods of these literals, I noticed that the output was inconsistent in some cases with query language, so I added updates to correct that and some unit tests.