### PR TITLE
Module Javadoc should mention Restriction and prefer Constraints over Query by Method Name

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/package-info.java
+++ b/api/src/main/java/jakarta/data/metamodel/package-info.java
@@ -33,6 +33,8 @@
  *     public String name;
  *
  *     public float price;
+ *
+ *     public LocalDate producedOn;
  * }
  *
  * &#64;StaticMetamodel(Product.class)
@@ -40,6 +42,7 @@
  *     String ID = "id";
  *     String NAME = "name";
  *     String PRICE = "price";
+ *     String PRODUCEDON = "producedOn";
  *
  *     NumericAttribute&lt;Product,Long&gt; id = NumericAttribute.of(
  *             Product.class, ID, long.class);
@@ -47,6 +50,8 @@
  *             Product.class, NAME);
  *     NumericAttribute&lt;Product,Float&gt; price = NumericAttribute.of(
  *             Product.class, PRICE, float.class);
+ *     TemporalAttribute&lt;Product,LocalDate&gt; producedOn = TemporalAttribute.of(
+ *             Product.class, PRODUCEDON, LocalDate.class);
  * }
  *
  * ...


### PR DESCRIPTION
This PR does the following:

- Include Restriction on our main Javadoc page that gives an overview of the key spec features.
- Promote Find/Delete with Constraints over Query by Method Name by moving the section on the former ahead of the section on the latter.
- Update the section on Find/Delete to be consistent with the ability to have parameters of the Restriction and Constraint.

I have also switched one of the example entity attributes used by these sections from an int year value to a temporal type to be able to show a broader set of patterns in the examples.