### PR TITLE
Reuse same error messages instead of duplicating

### DIFF
--- a/api/src/main/java/jakarta/data/Sort.java
+++ b/api/src/main/java/jakarta/data/Sort.java
@@ -17,10 +17,9 @@
  */
 package jakarta.data;
 
+import jakarta.data.messages.Messages;
 import jakarta.data.metamodel.StaticMetamodel;
 import jakarta.data.repository.OrderBy;
-
-import java.util.Objects;
 
 /**
  * <p>Requests sorting on a given entity attribute.</p>
@@ -89,7 +88,6 @@ import java.util.Objects;
  */
 public record Sort<T>(String property, boolean isAscending,
                       boolean ignoreCase) {
-
     /**
      * <p>Defines sort criteria for an entity attribute. For more descriptive
      * code, use:</p>
@@ -111,7 +109,10 @@ public record Sort<T>(String property, boolean isAscending,
      *                    from a database with case sensitive collation.
      */
     public Sort {
-        Objects.requireNonNull(property, "The property is required");
+        if (property == null) {
+            throw new NullPointerException(
+                Messages.get("001.arg.required", "attribute"));
+        }
     }
 
     // Override to provide method documentation:
@@ -173,7 +174,11 @@ public record Sort<T>(String property, boolean isAscending,
      * @throws NullPointerException when there is a null parameter
      */
     public static <T> Sort<T> of(String attribute, Direction direction, boolean ignoreCase) {
-        Objects.requireNonNull(direction, "The direction is required");
+        if (direction == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "direction"));
+        }
+
         return new Sort<>(attribute, Direction.ASC.equals(direction), ignoreCase);
     }
 

--- a/api/src/main/java/jakarta/data/constraint/BetweenRecord.java
+++ b/api/src/main/java/jakarta/data/constraint/BetweenRecord.java
@@ -17,19 +17,22 @@
  */
 package jakarta.data.constraint;
 
-import java.util.Objects;
-
 import jakarta.data.expression.ComparableExpression;
+import jakarta.data.messages.Messages;
 
 record BetweenRecord<V extends Comparable<?>>(
         ComparableExpression<?, V> lowerBound,
         ComparableExpression<?, V> upperBound)
         implements Between<V> {
     public BetweenRecord {
-        Objects.requireNonNull(lowerBound,
-                "The lower value or expression is required");
-        Objects.requireNonNull(upperBound,
-                "The upper value or expression is required");
+        if (lowerBound == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "lower"));
+        }
+        if (upperBound == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "upper"));
+        }
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/constraint/EqualTo.java
+++ b/api/src/main/java/jakarta/data/constraint/EqualTo.java
@@ -17,20 +17,27 @@
  */
 package jakarta.data.constraint;
 
-import java.util.Objects;
 
 import jakarta.data.expression.Expression;
 import jakarta.data.expression.literal.Literal;
-
+import jakarta.data.messages.Messages;
 public interface EqualTo<V> extends Constraint<V> {
 
     static <V> EqualTo<V> expression(Expression<?, V> expression) {
-        Objects.requireNonNull(expression, "The expression is required");
+        if (expression == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "expression"));
+        }
+
         return new EqualToRecord<>(expression);
     }
 
     static <V> EqualTo<V> value(V value) {
-        Objects.requireNonNull(value, "The value is required");
+        if (value == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "value"));
+        }
+
         return new EqualToRecord<>(Literal.of(value));
     }
 

--- a/api/src/main/java/jakarta/data/constraint/GreaterThanOrEqualRecord.java
+++ b/api/src/main/java/jakarta/data/constraint/GreaterThanOrEqualRecord.java
@@ -17,15 +17,17 @@
  */
 package jakarta.data.constraint;
 
-import java.util.Objects;
-
 import jakarta.data.expression.ComparableExpression;
+import jakarta.data.messages.Messages;
 
 record GreaterThanOrEqualRecord<V extends Comparable<?>>(
         ComparableExpression<?, V> bound)
         implements GreaterThanOrEqual<V> {
     public GreaterThanOrEqualRecord {
-        Objects.requireNonNull(bound, "The minimum is required");
+        if (bound == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "minimum"));
+        }
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/constraint/GreaterThanRecord.java
+++ b/api/src/main/java/jakarta/data/constraint/GreaterThanRecord.java
@@ -17,15 +17,17 @@
  */
 package jakarta.data.constraint;
 
-import java.util.Objects;
-
 import jakarta.data.expression.ComparableExpression;
+import jakarta.data.messages.Messages;
 
 record GreaterThanRecord<V extends Comparable<?>>(
         ComparableExpression<?, V> bound)
         implements GreaterThan<V> {
     public GreaterThanRecord {
-        Objects.requireNonNull(bound, "The lowerBound is required");
+        if (bound == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "lowerBound"));
+        }
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/constraint/In.java
+++ b/api/src/main/java/jakarta/data/constraint/In.java
@@ -19,11 +19,11 @@ package jakarta.data.constraint;
 
 import jakarta.data.expression.Expression;
 import jakarta.data.expression.literal.Literal;
+import jakarta.data.messages.Messages;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 
 import static java.util.Collections.unmodifiableList;
 
@@ -31,15 +31,23 @@ public interface In<V> extends Constraint<V> {
 
     @SafeVarargs
     static <V> In<V> values(V... values) {
-        Objects.requireNonNull(values, "The values are required");
+        if (values == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "values"));
+        }
 
         if (values.length == 0) {
-            throw new IllegalArgumentException("The values must not be empty");
+            throw new IllegalArgumentException(
+                    Messages.get("002.no.elements", "values"));
         }
 
         List<Expression<?, V>> expressions = new ArrayList<>(values.length);
         for (V value : values) {
-            Objects.requireNonNull(value, "The value must not be null");
+            if (value == null) {
+                throw new NullPointerException(
+                        Messages.get("003.null.element", "values"));
+            }
+
             expressions.add(Literal.of(value));
         }
 
@@ -47,15 +55,23 @@ public interface In<V> extends Constraint<V> {
     }
 
     static <V> In<V> values(Collection<V> values) {
-        Objects.requireNonNull(values, "The values are required");
+        if (values == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "values"));
+        }
 
         if (values.isEmpty()) {
-            throw new IllegalArgumentException("The values must not be empty");
+            throw new IllegalArgumentException(
+                    Messages.get("002.no.elements", "values"));
         }
 
         List<Expression<?, V>> expressions = new ArrayList<>(values.size());
         for (V value : values) {
-            Objects.requireNonNull(value, "The value must not be null");
+            if (value == null) {
+                throw new NullPointerException(
+                        Messages.get("003.null.element", "values"));
+            }
+
             expressions.add(Literal.of(value));
         }
 
@@ -63,15 +79,21 @@ public interface In<V> extends Constraint<V> {
     }
 
     static <V> In<V> expressions(List<Expression<?, V>> expressions) {
-        Objects.requireNonNull(expressions, "The expressions are required");
+        if (expressions == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "expressions"));
+        }
 
         if (expressions.isEmpty()) {
             throw new IllegalArgumentException(
-                    "The expressions must not be empty");
+                    Messages.get("002.no.elements", "expressions"));
         }
 
         for (Expression<?, V> expression : expressions) {
-            Objects.requireNonNull(expression, "The expression must not be null");
+            if (expression == null) {
+                throw new NullPointerException(
+                        Messages.get("003.null.element", "expressions"));
+            }
         }
 
         return new InRecord<>(List.copyOf(expressions));
@@ -79,15 +101,21 @@ public interface In<V> extends Constraint<V> {
 
     @SafeVarargs
     static <V> In<V> expressions(Expression<?, V>... expressions) {
-        Objects.requireNonNull(expressions, "The expressions are required");
+        if (expressions == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "expressions"));
+        }
 
         if (expressions.length == 0) {
             throw new IllegalArgumentException(
-                    "The expressions must not be empty");
+                    Messages.get("002.no.elements", "expressions"));
         }
 
         for (Expression<?, V> expression : expressions) {
-            Objects.requireNonNull(expression, "The expression must not be null");
+            if (expression == null) {
+                throw new NullPointerException(
+                        Messages.get("003.null.element", "expressions"));
+            }
         }
 
         return new InRecord<>(List.of(expressions));

--- a/api/src/main/java/jakarta/data/constraint/LessThanOrEqualRecord.java
+++ b/api/src/main/java/jakarta/data/constraint/LessThanOrEqualRecord.java
@@ -17,15 +17,17 @@
  */
 package jakarta.data.constraint;
 
-import java.util.Objects;
-
 import jakarta.data.expression.ComparableExpression;
+import jakarta.data.messages.Messages;
 
 record LessThanOrEqualRecord<V extends Comparable<?>>(
         ComparableExpression<?, V> bound)
         implements LessThanOrEqual<V> {
     public LessThanOrEqualRecord {
-        Objects.requireNonNull(bound, "The maximum is required");
+        if (bound == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "maximum"));
+        }
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/constraint/LessThanRecord.java
+++ b/api/src/main/java/jakarta/data/constraint/LessThanRecord.java
@@ -17,14 +17,16 @@
  */
 package jakarta.data.constraint;
 
-import java.util.Objects;
-
 import jakarta.data.expression.ComparableExpression;
+import jakarta.data.messages.Messages;
 
 record LessThanRecord<V extends Comparable<?>>(ComparableExpression<?, V> bound)
         implements LessThan<V> {
     public LessThanRecord {
-        Objects.requireNonNull(bound, "The upperBound is required");
+        if (bound == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "upperBound"));
+        }
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/constraint/Like.java
+++ b/api/src/main/java/jakarta/data/constraint/Like.java
@@ -21,15 +21,18 @@ import static jakarta.data.constraint.LikeRecord.ESCAPE;
 import static jakarta.data.constraint.LikeRecord.STRING_WILDCARD;
 import static jakarta.data.constraint.LikeRecord.translate;
 
-import java.util.Objects;
-
 import jakarta.data.expression.TextExpression;
 import jakarta.data.expression.literal.StringLiteral;
+import jakarta.data.messages.Messages;
 
 public interface Like extends Constraint<String> {
 
     static Like pattern(String pattern) {
-        Objects.requireNonNull(pattern, "The pattern is required");
+        if (pattern == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "pattern"));
+        }
+
         StringLiteral<Object> expression = StringLiteral.of(pattern);
         return new LikeRecord(expression, null);
     }
@@ -39,40 +42,64 @@ public interface Like extends Constraint<String> {
     }
 
     static Like pattern(String pattern, char charWildcard, char stringWildcard, char escape) {
-        Objects.requireNonNull(pattern, "The pattern is required");
+        if (pattern == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "pattern"));
+        }
+
         StringLiteral<Object> expression = StringLiteral.of(
                 translate(pattern, charWildcard, stringWildcard, escape));
         return new LikeRecord(expression, escape);
     }
 
     static Like pattern(TextExpression<?> pattern, char escape) {
-        Objects.requireNonNull(pattern, "The pattern is required");
+        if (pattern == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "pattern"));
+        }
+
         return new LikeRecord(pattern, escape);
     }
 
     static Like prefix(String prefix) {
-        Objects.requireNonNull(prefix, "The prefix is required");
+        if (prefix == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "prefix"));
+        }
+
         StringLiteral<Object> expression = StringLiteral.of(
                 LikeRecord.escape(prefix) + STRING_WILDCARD);
         return new LikeRecord(expression, ESCAPE);
     }
 
     static Like substring(String substring) {
-        Objects.requireNonNull(substring, "The substring is required");
+        if (substring == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "substring"));
+        }
+
         StringLiteral<Object> expression = StringLiteral.of(
                 STRING_WILDCARD + LikeRecord.escape(substring) + STRING_WILDCARD);
         return new LikeRecord(expression, ESCAPE);
     }
 
     static Like suffix(String suffix) {
-        Objects.requireNonNull(suffix, "The suffix is required");
+        if (suffix == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "suffix"));
+        }
+
         StringLiteral<Object> expression = StringLiteral.of(
                 STRING_WILDCARD + LikeRecord.escape(suffix));
         return new LikeRecord(expression, ESCAPE);
     }
 
     static Like literal(String value) {
-        Objects.requireNonNull(value, "The value is required");
+        if (value == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "value"));
+        }
+
         StringLiteral<Object> expression = StringLiteral.of(
                 LikeRecord.escape(value));
         return new LikeRecord(expression, ESCAPE);

--- a/api/src/main/java/jakarta/data/constraint/LikeRecord.java
+++ b/api/src/main/java/jakarta/data/constraint/LikeRecord.java
@@ -18,6 +18,7 @@
 package jakarta.data.constraint;
 
 import jakarta.data.expression.TextExpression;
+import jakarta.data.messages.Messages;
 
 record LikeRecord(TextExpression<?> pattern, Character escape)
         implements Like {
@@ -52,13 +53,11 @@ record LikeRecord(TextExpression<?> pattern, Character escape)
     static String translate(String pattern, char charWildcard, char stringWildcard, char escape) {
         if (charWildcard == stringWildcard) {
             throw new IllegalArgumentException(
-                    "Cannot use the same character (" + charWildcard +
-                            ") for both wildcards");
+                    Messages.get("007.wildcard.conflict", charWildcard));
         }
         if (charWildcard == escape || stringWildcard == escape) {
             throw new IllegalArgumentException(
-                    "Cannot use the same character (" + escape +
-                            ") for both a wildcard and escape character");
+                    Messages.get("008.escape.conflict", escape));
         }
         final var result = new StringBuilder();
         for (int i = 0; i < pattern.length(); i++) {

--- a/api/src/main/java/jakarta/data/constraint/NotBetweenRecord.java
+++ b/api/src/main/java/jakarta/data/constraint/NotBetweenRecord.java
@@ -17,20 +17,23 @@
  */
 package jakarta.data.constraint;
 
-import java.util.Objects;
 
 import jakarta.data.expression.ComparableExpression;
-
+import jakarta.data.messages.Messages;
 record NotBetweenRecord<V extends Comparable<?>>(
         ComparableExpression<?, V> lowerBound,
         ComparableExpression<?, V> upperBound)
         implements NotBetween<V> {
 
     NotBetweenRecord {
-        Objects.requireNonNull(lowerBound,
-                "The lower value or expression is required");
-        Objects.requireNonNull(upperBound,
-                "The upper value or expression is required");
+        if (lowerBound == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "lower"));
+        }
+        if (upperBound == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "upper"));
+        }
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/constraint/NotEqualTo.java
+++ b/api/src/main/java/jakarta/data/constraint/NotEqualTo.java
@@ -17,20 +17,27 @@
  */
 package jakarta.data.constraint;
 
-import java.util.Objects;
 
 import jakarta.data.expression.Expression;
 import jakarta.data.expression.literal.Literal;
-
+import jakarta.data.messages.Messages;
 public interface NotEqualTo<V> extends Constraint<V> {
 
     static <V> NotEqualTo<V> expression(Expression<?, V> expression) {
-        Objects.requireNonNull(expression, "The expression is required");
+        if (expression == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "expression"));
+        }
+
         return new NotEqualToRecord<>(expression);
     }
 
     static <V> NotEqualTo<V> value(V value) {
-        Objects.requireNonNull(value, "The value is required");
+        if (value == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "value"));
+        }
+
         return new NotEqualToRecord<>(Literal.of(value));
     }
 

--- a/api/src/main/java/jakarta/data/constraint/NotIn.java
+++ b/api/src/main/java/jakarta/data/constraint/NotIn.java
@@ -20,10 +20,10 @@ package jakarta.data.constraint;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
 
 import jakarta.data.expression.Expression;
 import jakarta.data.expression.literal.Literal;
+import jakarta.data.messages.Messages;
 
 import static java.util.Collections.unmodifiableList;
 
@@ -31,15 +31,23 @@ public interface NotIn<V> extends Constraint<V> {
 
     @SafeVarargs
     static <V> NotIn<V> values(V... values) {
-        Objects.requireNonNull(values, "The values are required");
+        if (values == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "values"));
+        }
 
         if (values.length == 0) {
-            throw new IllegalArgumentException("The values must not be empty");
+            throw new IllegalArgumentException(
+                    Messages.get("002.no.elements", "values"));
         }
 
         final List<Expression<?, V>> expressions = new ArrayList<>(values.length);
         for (V value : values) {
-            Objects.requireNonNull(value, "Value must not be null");
+            if (value == null) {
+                throw new NullPointerException(
+                        Messages.get("003.null.element", "values"));
+            }
+
             expressions.add(Literal.of(value));
         }
 
@@ -47,15 +55,23 @@ public interface NotIn<V> extends Constraint<V> {
     }
 
     static <V> NotIn<V> values(Collection<V> values) {
-        Objects.requireNonNull(values, "The values are required");
+        if (values == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "values"));
+        }
 
         if (values.isEmpty()) {
-            throw new IllegalArgumentException("The values must not be empty");
+            throw new IllegalArgumentException(
+                    Messages.get("002.no.elements", "values"));
         }
 
         final List<Expression<?, V>> expressions = new ArrayList<>(values.size());
         for (V value : values) {
-            Objects.requireNonNull(value, "The value must not be null");
+            if (value == null) {
+                throw new NullPointerException(
+                        Messages.get("003.null.element", "values"));
+            }
+
             expressions.add(Literal.of(value));
         }
 
@@ -63,14 +79,21 @@ public interface NotIn<V> extends Constraint<V> {
     }
 
     static <V> NotIn<V> expressions(List<Expression<?, V>> expressions) {
-        Objects.requireNonNull(expressions, "The expressions are required");
+        if (expressions == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "expressions"));
+        }
 
         if (expressions.isEmpty()) {
-            throw new IllegalArgumentException("The expressions must not be empty");
+            throw new IllegalArgumentException(
+                    Messages.get("002.no.elements", "expressions"));
         }
 
         for (Expression<?, V> expression : expressions) {
-            Objects.requireNonNull(expression, "The expression must not be null");
+            if (expression == null) {
+                throw new NullPointerException(
+                        Messages.get("003.null.element", "expressions"));
+            }
         }
 
         return new NotInRecord<>(List.copyOf(expressions));
@@ -78,15 +101,21 @@ public interface NotIn<V> extends Constraint<V> {
 
     @SafeVarargs
     static <V> NotIn<V> expressions(Expression<?, V>... expressions) {
-        Objects.requireNonNull(expressions, "The expressions are required");
+        if (expressions == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "expressions"));
+        }
 
         if (expressions.length == 0) {
             throw new IllegalArgumentException(
-                    "The expressions must not be empty");
+                    Messages.get("002.no.elements", "expressions"));
         }
 
         for (Expression<?, V> expression : expressions) {
-            Objects.requireNonNull(expression, "The expression must not be null");
+            if (expression == null) {
+                throw new NullPointerException(
+                        Messages.get("003.null.element", "expressions"));
+            }
         }
 
         return new NotInRecord<>(List.of(expressions));

--- a/api/src/main/java/jakarta/data/constraint/NotLike.java
+++ b/api/src/main/java/jakarta/data/constraint/NotLike.java
@@ -21,15 +21,18 @@ import static jakarta.data.constraint.LikeRecord.ESCAPE;
 import static jakarta.data.constraint.LikeRecord.STRING_WILDCARD;
 import static jakarta.data.constraint.LikeRecord.translate;
 
-import java.util.Objects;
-
 import jakarta.data.expression.TextExpression;
 import jakarta.data.expression.literal.StringLiteral;
+import jakarta.data.messages.Messages;
 
 public interface NotLike extends Constraint<String> {
 
     static NotLike pattern(String pattern) {
-        Objects.requireNonNull(pattern, "The pattern is required");
+        if (pattern == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "pattern"));
+        }
+
         StringLiteral<Object> expression = StringLiteral.of(pattern);
         return new NotLikeRecord(expression, null);
     }
@@ -39,40 +42,64 @@ public interface NotLike extends Constraint<String> {
     }
 
     static NotLike pattern(String pattern, char charWildcard, char stringWildcard, char escape) {
-        Objects.requireNonNull(pattern, "The pattern is required");
+        if (pattern == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "pattern"));
+        }
+
         StringLiteral<Object> expression = StringLiteral.of(
                 translate(pattern, charWildcard, stringWildcard, escape));
         return new NotLikeRecord(expression, escape);
     }
 
     static NotLike pattern(TextExpression<?> pattern, char escape) {
-        Objects.requireNonNull(pattern, "The pattern is required");
+        if (pattern == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "pattern"));
+        }
+
         return new NotLikeRecord(pattern, escape);
     }
 
     static NotLike prefix(String prefix) {
-        Objects.requireNonNull(prefix, "The prefix is required");
+        if (prefix == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "prefix"));
+        }
+
         StringLiteral<Object> expression = StringLiteral.of(
                 LikeRecord.escape(prefix) + STRING_WILDCARD);
         return new NotLikeRecord(expression, ESCAPE);
     }
 
     static NotLike substring(String substring) {
-        Objects.requireNonNull(substring, "The substring is required");
+        if (substring == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "substring"));
+        }
+
         StringLiteral<Object> expression = StringLiteral.of(
                 STRING_WILDCARD + LikeRecord.escape(substring) + STRING_WILDCARD);
         return new NotLikeRecord(expression, ESCAPE);
     }
 
     static NotLike suffix(String suffix) {
-        Objects.requireNonNull(suffix, "The suffix is required");
+        if (suffix == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "suffix"));
+        }
+
         StringLiteral<Object> expression = StringLiteral.of(
                 STRING_WILDCARD + LikeRecord.escape(suffix));
         return new NotLikeRecord(expression, ESCAPE);
     }
 
     static NotLike literal(String value) {
-        Objects.requireNonNull(value, "The value is required");
+        if (value == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "value"));
+        }
+
         StringLiteral<Object> expression = StringLiteral.of(
                 LikeRecord.escape(value));
         return new NotLikeRecord(expression, ESCAPE);

--- a/api/src/main/java/jakarta/data/expression/Expression.java
+++ b/api/src/main/java/jakarta/data/expression/Expression.java
@@ -287,9 +287,6 @@ public interface Expression<T, V> {
      *                                  element.
      */
     default Restriction<T> notIn(Collection<V> values) {
-        if (values == null || values.isEmpty())
-            throw new IllegalArgumentException("The values are required");
-
         return BasicRestriction.of(this, NotIn.values(values));
     }
 

--- a/api/src/main/java/jakarta/data/expression/function/NumericCastRecord.java
+++ b/api/src/main/java/jakarta/data/expression/function/NumericCastRecord.java
@@ -18,16 +18,22 @@
 package jakarta.data.expression.function;
 
 import jakarta.data.expression.NumericExpression;
-
-import java.util.Objects;
+import jakarta.data.messages.Messages;
 
 record NumericCastRecord<T, N extends Number & Comparable<N>>
         (NumericExpression<T, ?> expression, Class<N> type)
         implements NumericCast<T, N> {
 
     NumericCastRecord {
-        Objects.requireNonNull(expression, "The expression is required");
-        Objects.requireNonNull(type, "The type is required");
+        if (expression == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "expression"));
+        }
+
+        if (type == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "type"));
+        }
     }
 
 }

--- a/api/src/main/java/jakarta/data/expression/function/NumericFunctionExpression.java
+++ b/api/src/main/java/jakarta/data/expression/function/NumericFunctionExpression.java
@@ -20,9 +20,9 @@ package jakarta.data.expression.function;
 import jakarta.data.expression.ComparableExpression;
 import jakarta.data.expression.NumericExpression;
 import jakarta.data.expression.TextExpression;
+import jakarta.data.messages.Messages;
 
 import java.util.List;
-import java.util.Objects;
 
 public interface NumericFunctionExpression<T, N extends Number & Comparable<N>>
         extends FunctionExpression<T, N>, NumericExpression<T, N> {
@@ -32,15 +32,23 @@ public interface NumericFunctionExpression<T, N extends Number & Comparable<N>>
     String LENGTH = "length";
 
     static <T, N extends Number & Comparable<N>> NumericFunctionExpression<T, N>
-    of(String name, TextExpression<? super T> argument) {
-        Objects.requireNonNull(argument, "The argument is required");
-        return new NumericFunctionExpressionRecord<>(name, List.of(argument));
+    of(String name, TextExpression<? super T> expression) {
+        if (expression == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "expression"));
+        }
+
+        return new NumericFunctionExpressionRecord<>(name, List.of(expression));
     }
 
     static <T, N extends Number & Comparable<N>> NumericFunctionExpression<T, N>
-    of(String name, NumericExpression<? super T, N> argument) {
-        Objects.requireNonNull(argument, "The argument is required");
-        return new NumericFunctionExpressionRecord<>(name, List.of(argument));
+    of(String name, NumericExpression<? super T, N> expression) {
+        if (expression == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "expression"));
+        }
+
+        return new NumericFunctionExpressionRecord<>(name, List.of(expression));
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/expression/function/NumericFunctionExpressionRecord.java
+++ b/api/src/main/java/jakarta/data/expression/function/NumericFunctionExpressionRecord.java
@@ -18,9 +18,9 @@
 package jakarta.data.expression.function;
 
 import jakarta.data.expression.ComparableExpression;
+import jakarta.data.messages.Messages;
 
 import java.util.List;
-import java.util.Objects;
 
 record NumericFunctionExpressionRecord<T, N extends Number & Comparable<N>>(
         String name,
@@ -28,7 +28,10 @@ record NumericFunctionExpressionRecord<T, N extends Number & Comparable<N>>(
         implements NumericFunctionExpression<T, N> {
 
     NumericFunctionExpressionRecord {
-        Objects.requireNonNull(name, "The name is required");
+        if (name == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "name"));
+        }
     }
 
 }

--- a/api/src/main/java/jakarta/data/expression/function/NumericOperatorExpression.java
+++ b/api/src/main/java/jakarta/data/expression/function/NumericOperatorExpression.java
@@ -21,8 +21,7 @@ import jakarta.data.expression.Expression;
 import jakarta.data.expression.NumericExpression;
 
 import jakarta.data.expression.literal.NumericLiteral;
-
-import java.util.Objects;
+import jakarta.data.messages.Messages;
 
 public interface NumericOperatorExpression<T, N extends Number & Comparable<N>>
         extends NumericExpression<T, N> {
@@ -36,14 +35,22 @@ public interface NumericOperatorExpression<T, N extends Number & Comparable<N>>
 
     Expression<T, N> right();
 
-    static <T, N extends Number & Comparable<N>>
-    NumericOperatorExpression<T, N> of(Operator operator, NumericExpression<T, N> left, N right) {
-        Objects.requireNonNull(right, "The right value is required");
+    static <T, N extends Number & Comparable<N>> NumericOperatorExpression<T, N> of(
+            Operator operator,
+            NumericExpression<T, N> left,
+            N right) {
+        if (right == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "right"));
+        }
+
         return new NumericOperatorExpressionRecord<>(operator, left, NumericLiteral.of(right));
     }
 
-    static <T, N extends Number & Comparable<N>>
-    NumericOperatorExpression<T, N> of(Operator operator, NumericExpression<T, N> left, NumericExpression<T, N> right) {
+    static <T, N extends Number & Comparable<N>> NumericOperatorExpression<T, N> of(
+            Operator operator,
+            NumericExpression<T, N> left,
+            NumericExpression<T, N> right) {
         return new NumericOperatorExpressionRecord<>(operator, left, right);
     }
 }

--- a/api/src/main/java/jakarta/data/expression/function/NumericOperatorExpressionRecord.java
+++ b/api/src/main/java/jakarta/data/expression/function/NumericOperatorExpressionRecord.java
@@ -18,12 +18,11 @@
 package jakarta.data.expression.function;
 
 import jakarta.data.expression.NumericExpression;
-import jakarta.data.expression.function.NumericOperatorExpression.Operator;
 import jakarta.data.expression.literal.NumericLiteral;
+import jakarta.data.messages.Messages;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Objects;
 
 record NumericOperatorExpressionRecord<T, N extends Number & Comparable<N>>
         (Operator operator, NumericExpression<T, N> left,
@@ -31,14 +30,26 @@ record NumericOperatorExpressionRecord<T, N extends Number & Comparable<N>>
         implements NumericOperatorExpression<T, N> {
 
     NumericOperatorExpressionRecord {
-        Objects.requireNonNull(operator, "The operator is required");
-        Objects.requireNonNull(left, "The left expression is required");
-        Objects.requireNonNull(left, "The right expression is required");
+        if (operator == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "operator"));
+        }
+
+        if (left == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "left"));
+        }
+
+        if (right == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "right"));
+        }
 
         if (operator == Operator.DIVIDE &&
             right instanceof NumericLiteral l &&
             isZero((Number) l.value())) {
-            throw new IllegalArgumentException("The divisor value must not be 0.");
+            throw new IllegalArgumentException(
+                    Messages.get("005.zero.not.allowed"));
         }
     }
 
@@ -59,7 +70,8 @@ record NumericOperatorExpressionRecord<T, N extends Number & Comparable<N>>
             case Byte b       -> b.byteValue() == (byte) 0;
             case Short s      -> s.shortValue() == (short) 0;
             default -> throw new IllegalArgumentException(
-                    "Unexpected number type: " + number.getClass().getName());
+                    Messages.get("009.unknown.number.type",
+                                 number.getClass().getName()));
         };
     }
 }

--- a/api/src/main/java/jakarta/data/expression/function/TextFunctionExpression.java
+++ b/api/src/main/java/jakarta/data/expression/function/TextFunctionExpression.java
@@ -21,9 +21,9 @@ import jakarta.data.expression.ComparableExpression;
 import jakarta.data.expression.TextExpression;
 import jakarta.data.expression.literal.NumericLiteral;
 import jakarta.data.expression.literal.StringLiteral;
+import jakarta.data.messages.Messages;
 
 import java.util.List;
-import java.util.Objects;
 
 public interface TextFunctionExpression<T>
         extends FunctionExpression<T, String>, TextExpression<T> {
@@ -34,34 +34,84 @@ public interface TextFunctionExpression<T>
     String LEFT = "left";
     String RIGHT = "right";
 
-    static <T> TextFunctionExpression<T> of(String name, TextExpression<? super T> argument) {
-        Objects.requireNonNull(argument, "The argument is required");
-        return new TextFunctionExpressionRecord<>(name, List.of(argument));
+    static <T> TextFunctionExpression<T> of(
+            String name,
+            TextExpression<? super T> expression) {
+        if (expression == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", expression));
+        }
+
+        return new TextFunctionExpressionRecord<>(name, List.of(expression));
     }
 
-    static <T> TextFunctionExpression<T> of(String name, TextExpression<? super T> left, String right) {
-        Objects.requireNonNull(left, "The left expression is required");
-        Objects.requireNonNull(right, "The right value is required");
-        return new TextFunctionExpressionRecord<>(name, List.of(left, StringLiteral.of(right)));
+    static <T> TextFunctionExpression<T> of(
+            String name,
+            TextExpression<? super T> left,
+            String right) {
+        if (left == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "left"));
+        }
+
+        if (right == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "right"));
+        }
+
+        return new TextFunctionExpressionRecord<>(
+                name,
+                List.of(left, StringLiteral.of(right)));
     }
 
-    static <T> TextFunctionExpression<T> of(String name, String left, TextExpression<? super T> right) {
-        Objects.requireNonNull(right, "The left value is required");
-        Objects.requireNonNull(left, "The right expression is required");
-        return new TextFunctionExpressionRecord<>(name, List.of(StringLiteral.of(left), right));
+    static <T> TextFunctionExpression<T> of(
+            String name,
+            String left,
+            TextExpression<? super T> right) {
+        if (left == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "left"));
+        }
+
+        if (right == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "right"));
+        }
+
+        return new TextFunctionExpressionRecord<>(
+                name,
+                List.of(StringLiteral.of(left), right));
     }
 
-    static <T> TextFunctionExpression<T> of(String name, TextExpression<? super T> left,
-                                            TextExpression<? super T> right) {
-        Objects.requireNonNull(left, "The left expression is required");
-        Objects.requireNonNull(left, "The right expression is required");
+    static <T> TextFunctionExpression<T> of(
+            String name,
+            TextExpression<? super T> left,
+            TextExpression<? super T> right) {
+        if (left == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "left"));
+        }
+
+        if (right == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "right"));
+        }
+
         return new TextFunctionExpressionRecord<>(name, List.of(left, right));
     }
 
-    static <T> TextFunctionExpression<T> of(String name, TextExpression<? super T> left, int literal) {
-        Objects.requireNonNull(left, "The left expression is required");
-        Objects.requireNonNull(literal, "The literal value is required");
-        return new TextFunctionExpressionRecord<>(name, List.of(left, NumericLiteral.of(literal)));
+    static <T> TextFunctionExpression<T> of(
+            String name,
+            TextExpression<? super T> left,
+            int literal) {
+        if (left == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "left"));
+        }
+
+        return new TextFunctionExpressionRecord<>(
+                name,
+                List.of(left, NumericLiteral.of(literal)));
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/expression/function/TextFunctionExpressionRecord.java
+++ b/api/src/main/java/jakarta/data/expression/function/TextFunctionExpressionRecord.java
@@ -19,9 +19,9 @@ package jakarta.data.expression.function;
 
 import jakarta.data.expression.ComparableExpression;
 import jakarta.data.expression.literal.NumericLiteral;
+import jakarta.data.messages.Messages;
 
 import java.util.List;
-import java.util.Objects;
 
 record TextFunctionExpressionRecord<T>(
         String name,
@@ -29,7 +29,10 @@ record TextFunctionExpressionRecord<T>(
         implements TextFunctionExpression<T> {
 
     TextFunctionExpressionRecord {
-        Objects.requireNonNull(name, "The name is required");
+        if (name == null) {
+            throw new NullPointerException(
+                Messages.get("001.arg.required", "name"));
+        }
 
         if (TextFunctionExpression.LEFT == name ||
             TextFunctionExpression.RIGHT == name) {
@@ -38,7 +41,7 @@ record TextFunctionExpressionRecord<T>(
                 sizeLiteral.value() instanceof Integer size &&
                 size < 0) {
                 throw new IllegalArgumentException(
-                        "The size value must not be negative.");
+                        Messages.get("004.arg.negative"));
             }
         }
     }

--- a/api/src/main/java/jakarta/data/expression/literal/ComparableLiteralRecord.java
+++ b/api/src/main/java/jakarta/data/expression/literal/ComparableLiteralRecord.java
@@ -17,13 +17,16 @@
  */
 package jakarta.data.expression.literal;
 
-import java.util.Objects;
+import jakarta.data.messages.Messages;
 
 record ComparableLiteralRecord<T, V extends Comparable<?>>(V value)
         implements ComparableLiteral<T, V> {
 
     ComparableLiteralRecord {
-        Objects.requireNonNull(value, "The value is required");
+        if (value == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "value"));
+        }
     }
 
     @Override
@@ -31,7 +34,7 @@ record ComparableLiteralRecord<T, V extends Comparable<?>>(V value)
         return switch (value) {
             case Boolean b -> b == Boolean.TRUE ? "TRUE" : "FALSE";
             case Character c -> c == '\'' ? "''''" : "'" + c + "'";
-            case Enum e -> e.getClass().getName() + '.' + e.name();
+            case Enum<?> e -> e.getClass().getName() + '.' + e.name();
             default -> "{ComparableLiteral "
                         + value.getClass().getName()
                         + " '" + value.toString() + "'}";

--- a/api/src/main/java/jakarta/data/expression/literal/LiteralRecord.java
+++ b/api/src/main/java/jakarta/data/expression/literal/LiteralRecord.java
@@ -17,12 +17,15 @@
  */
 package jakarta.data.expression.literal;
 
-import java.util.Objects;
+import jakarta.data.messages.Messages;
 
 record LiteralRecord<T, V>(V value) implements Literal<T, V> {
 
     LiteralRecord {
-        Objects.requireNonNull(value, "The value is required");
+        if (value == null) {
+            throw new NullPointerException(
+                Messages.get("001.arg.required", "value"));
+        }
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/expression/literal/NumericLiteralRecord.java
+++ b/api/src/main/java/jakarta/data/expression/literal/NumericLiteralRecord.java
@@ -19,13 +19,16 @@ package jakarta.data.expression.literal;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Objects;
 
+import jakarta.data.messages.Messages;
 record NumericLiteralRecord<T, N extends Number & Comparable<N>>
         (N value) implements NumericLiteral<T, N> {
 
     NumericLiteralRecord {
-        Objects.requireNonNull(value, "The value is required");
+        if (value == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "value"));
+        }
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/expression/literal/StringLiteralRecord.java
+++ b/api/src/main/java/jakarta/data/expression/literal/StringLiteralRecord.java
@@ -17,13 +17,16 @@
  */
 package jakarta.data.expression.literal;
 
-import java.util.Objects;
+import jakarta.data.messages.Messages;
 
 record StringLiteralRecord<T>(String value)
         implements StringLiteral<T> {
 
     StringLiteralRecord {
-        Objects.requireNonNull(value, "The value is required");
+        if (value == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "value"));
+        }
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/expression/literal/TemporalLiteralRecord.java
+++ b/api/src/main/java/jakarta/data/expression/literal/TemporalLiteralRecord.java
@@ -23,14 +23,18 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.time.temporal.Temporal;
-import java.util.Objects;
+
+import jakarta.data.messages.Messages;
 
 record TemporalLiteralRecord<T, V extends Temporal & Comparable<? extends Temporal>>(
         V value)
         implements TemporalLiteral<T, V> {
 
     TemporalLiteralRecord {
-        Objects.requireNonNull(value, "The value is required");
+        if (value == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "value"));
+        }
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/messages/Messages.java
+++ b/api/src/main/java/jakarta/data/messages/Messages.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data.messages;
+
+import java.text.MessageFormat;
+import java.util.ResourceBundle;
+
+// This class is for internal use only and is not documented as API
+// and its package is not exported by the module.
+public class Messages {
+    private static final ResourceBundle MESSAGES =
+            ResourceBundle.getBundle("jakarta.data.messages.Messages");
+
+    // Prevent instantiation
+    private Messages() {
+    }
+
+    /**
+     * Obtain a message and substitute in the supplied arguments.
+     *
+     * @param key  a message key from the Messages.properties file.
+     * @param args arguments corresponding to {0}, {1}, ... in the message.
+     * @return the message.
+     */
+    public static String get(String key, Object... args) {
+        return MessageFormat.format(MESSAGES.getString(key),
+                                    args);
+    }
+}

--- a/api/src/main/java/jakarta/data/page/PageRequestCursor.java
+++ b/api/src/main/java/jakarta/data/page/PageRequestCursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ package jakarta.data.page;
 import java.util.Arrays;
 import java.util.List;
 
+import jakarta.data.messages.Messages;
+
 /**
  * Built-in implementation of Cursor for cursor-based pagination.
  */
@@ -39,7 +41,8 @@ class PageRequestCursor implements PageRequest.Cursor {
     PageRequestCursor(Object... key) {
         this.key = key;
         if (key == null || key.length == 0) {
-            throw new IllegalArgumentException("No values were provided");
+            throw new IllegalArgumentException(
+                    Messages.get("006.zero.size.key"));
         }
     }
 

--- a/api/src/main/java/jakarta/data/page/Pagination.java
+++ b/api/src/main/java/jakarta/data/page/Pagination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package jakarta.data.page;
 
 import java.util.Optional;
 
+import jakarta.data.messages.Messages;
+
 /**
  * Built-in implementation of PageRequest.
  */
@@ -33,7 +35,8 @@ record Pagination(long page, int size, Mode mode, Cursor type,
         }
 
         if (mode != Mode.OFFSET && (type == null || type.size() == 0)) {
-            throw new IllegalArgumentException("No key values were provided");
+            throw new IllegalArgumentException(
+                    Messages.get("006.zero.size.key"));
         }
     }
 

--- a/api/src/main/java/jakarta/data/page/impl/CursoredPageRecord.java
+++ b/api/src/main/java/jakarta/data/page/impl/CursoredPageRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
  */
 package jakarta.data.page.impl;
 
+import jakarta.data.messages.Messages;
 import jakarta.data.page.CursoredPage;
 import jakarta.data.page.PageRequest;
 
@@ -129,7 +130,7 @@ public record CursoredPageRecord<T>
     @Override
     public long totalElements() {
         if (totalElements < 0) {
-            throw new IllegalStateException("total elements are not available");
+            throw new IllegalStateException(Messages.get("010.unknown.total"));
         }
         return totalElements;
     }
@@ -137,7 +138,7 @@ public record CursoredPageRecord<T>
     @Override
     public long totalPages() {
         if (totalElements < 0) {
-            throw new IllegalStateException("total elements are not available");
+            throw new IllegalStateException(Messages.get("010.unknown.total"));
         }
         int size = pageRequest.size();
         return (totalElements + size - 1) / size;

--- a/api/src/main/java/jakarta/data/page/impl/PageRecord.java
+++ b/api/src/main/java/jakarta/data/page/impl/PageRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
  */
 package jakarta.data.page.impl;
 
+import jakarta.data.messages.Messages;
 import jakarta.data.page.Page;
 import jakarta.data.page.PageRequest;
 
@@ -120,7 +121,7 @@ public record PageRecord<T>(PageRequest pageRequest, List<T> content,
     @Override
     public long totalElements() {
         if (totalElements < 0) {
-            throw new IllegalStateException("total elements are not available");
+            throw new IllegalStateException(Messages.get("010.unknown.total"));
         }
         return totalElements;
     }
@@ -128,7 +129,7 @@ public record PageRecord<T>(PageRequest pageRequest, List<T> content,
     @Override
     public long totalPages() {
         if (totalElements < 0) {
-            throw new IllegalStateException("total elements are not available");
+            throw new IllegalStateException(Messages.get("010.unknown.total"));
         }
         int size = pageRequest.size();
         return (totalElements + size - 1) / size;

--- a/api/src/main/java/jakarta/data/restrict/BasicRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/restrict/BasicRestrictionRecord.java
@@ -19,6 +19,7 @@ package jakarta.data.restrict;
 
 import jakarta.data.constraint.Constraint;
 import jakarta.data.expression.Expression;
+import jakarta.data.messages.Messages;
 
 // Internal implementation class.
 // The proper way for users to obtain instances is via
@@ -26,15 +27,20 @@ import jakarta.data.expression.Expression;
 
 import jakarta.data.metamodel.Attribute;
 
-import java.util.Objects;
-
 record BasicRestrictionRecord<T, V>(Expression<T, V> expression,
                                     Constraint<V> constraint)
         implements BasicRestriction<T, V> {
 
     BasicRestrictionRecord {
-        Objects.requireNonNull(expression, "The expression is required");
-        Objects.requireNonNull(constraint, "The constraint is required");
+        if (expression == null) {
+            throw new NullPointerException(Messages.get("001.arg.required",
+                                           "expression"));
+        }
+        if (constraint == null) {
+            throw new NullPointerException(Messages.get("001.arg.required",
+                                           "constraint"));
+        }
+
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/restrict/CompositeRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/restrict/CompositeRestrictionRecord.java
@@ -18,7 +18,8 @@
 package jakarta.data.restrict;
 
 import java.util.List;
-import java.util.Objects;
+
+import jakarta.data.messages.Messages;
 
 // Internal implementation class.
 // The proper way for users to obtain instances is via
@@ -35,12 +36,20 @@ record CompositeRestrictionRecord<T>(
     private static final int SINGLE_RESTRICTION_LENGTH_ESTIMATE = 100;
 
     CompositeRestrictionRecord {
-        if (restrictions == null || restrictions.isEmpty()) {
+        if (restrictions == null) {
             throw new IllegalArgumentException(
-                    "Cannot create a composite restriction without any restrictions to combine");
+                    Messages.get("001.arg.required", "restrictions"));
         }
-        restrictions.forEach(
-                r -> Objects.requireNonNull(r, "Restriction must not be null"));
+        if (restrictions.isEmpty()) {
+            throw new IllegalArgumentException(
+                    Messages.get("002.no.elements", "restrictions"));
+        }
+        restrictions.forEach(r -> {
+            if (r == null) {
+                throw new NullPointerException(
+                        Messages.get("003.null.element", "restrictions"));
+            }
+        });
     }
 
     CompositeRestrictionRecord(Type type, List<Restriction<T>> restrictions) {

--- a/api/src/main/java/jakarta/data/restrict/Restrict.java
+++ b/api/src/main/java/jakarta/data/restrict/Restrict.java
@@ -17,10 +17,10 @@
  */
 package jakarta.data.restrict;
 
+import jakarta.data.messages.Messages;
 import jakarta.data.metamodel.Attribute;
 
 import java.util.List;
-import java.util.Objects;
 
 /**
  * <p>Creates composite restrictions.</p>
@@ -122,7 +122,11 @@ public class Restrict {
      *                              {@code null}.
      */
     public static <T> Restriction<T> not(Restriction<T> restriction) {
-        Objects.requireNonNull(restriction, "The restriction is required");
+        if (restriction == null) {
+            throw new NullPointerException(Messages.get("001.arg.required",
+                                           "restriction"));
+        }
+
         return restriction.negate();
     }
 

--- a/api/src/main/resources/jakarta/data/messages/Messages.properties
+++ b/api/src/main/resources/jakarta/data/messages/Messages.properties
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+001.arg.required=The {0} argument is required.
+002.no.elements=The {0} list cannot be empty.
+003.null.element=The {0} list cannot not have a null element.
+004.arg.negative=The {0} argument cannot be negative.
+005.zero.not.allowed=The {0} argument cannot be 0.
+006.zero.size.key=The key must consist of at least one element.
+007.wildcard.conflict=Cannot use the same character ({0}) for both wildcards.
+008.escape.conflict=Cannot use the same character ({0}) for both a wildcard \
+ and escape character.
+009.unknown.number.type=Unexpected subtype of Number: {0}.
+010.unknown.total=A total count of elements is not available.

--- a/api/src/test/java/jakarta/data/expression/literal/LiteralRecordTest.java
+++ b/api/src/test/java/jakarta/data/expression/literal/LiteralRecordTest.java
@@ -73,6 +73,6 @@ class LiteralRecordTest {
     void shouldThrowWhenValueIsNull() {
         org.junit.jupiter.api.Assertions.assertThrows(NullPointerException.class, () -> {
             new LiteralRecord<SimpleEntity, Object>(null);
-        });
+        }, "The value argument is required.");
     }
 }

--- a/api/src/test/java/jakarta/data/metamodel/AttributeTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/AttributeTest.java
@@ -90,7 +90,7 @@ class AttributeTest {
     void shouldThrowExceptionForEmptyInRestriction() {
         assertThatThrownBy(() -> testAttribute.in(Set.of()))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("The values must not be empty");
+                .hasMessage("The values list cannot be empty.");
     }
 
     @Test
@@ -111,7 +111,7 @@ class AttributeTest {
     void shouldThrowExceptionForEmptyNotInRestriction() {
         assertThatThrownBy(() -> testAttribute.notIn(Set.of()))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("The values are required");
+                .hasMessage("The values list cannot be empty.");
     }
 
     @Test

--- a/api/src/test/java/jakarta/data/restrict/BasicRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/restrict/BasicRestrictionRecordTest.java
@@ -146,7 +146,7 @@ class BasicRestrictionRecordTest {
     void shouldThrowExceptionWhenValueIsNull() {
         assertThatThrownBy(() -> _Book.title.equalTo((String) null))
                 .isInstanceOf(NullPointerException.class)
-                .hasMessage("The value is required");
+                .hasMessage("The value argument is required.");
     }
 
     @Test

--- a/api/src/test/java/jakarta/data/restrict/CompositeRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/restrict/CompositeRestrictionRecordTest.java
@@ -112,8 +112,7 @@ class CompositeRestrictionRecordTest {
     void shouldFailIfEmptyRestrictions() {
         assertThatThrownBy(() -> new CompositeRestrictionRecord<>(CompositeRestriction.Type.ALL, List.of()))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Cannot create a composite restriction without" +
-                            " any restrictions to combine");
+                .hasMessage("The restrictions list cannot be empty.");
     }
 
     @Test

--- a/api/src/test/java/jakarta/data/restrict/RestrictTest.java
+++ b/api/src/test/java/jakarta/data/restrict/RestrictTest.java
@@ -291,9 +291,17 @@ class RestrictTest {
     }
 
     @Test
+    void shouldThrowExceptionForInvalidEscape() {
+        assertThatThrownBy(() -> _Employee.name.like("Ja* Karta", '_', '*', '*'))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Cannot use the same character (*) for both a" +
+                            " wildcard and escape character.");
+    }
+
+    @Test
     void shouldThrowExceptionForInvalidWildcard() {
         assertThatThrownBy(() -> _Employee.name.like("pattern_value", '_', '_'))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("Cannot use the same character (_) for both wildcards");
+                .hasMessage("Cannot use the same character (_) for both wildcards.");
     }
 }


### PR DESCRIPTION
This addresses a comment from @otaviojava in a prior review to reuse our error messages across code.

To do this, I replaced occurrences of requireNonNull because that would have required looking up error messages in the resource bundle and substituting in the values to supply it to that method on the normal codepath when no error occurs. This seemed wasteful. We should only need incur that cost when an error is detected.

I chose to create a single utility class to centralize obtaining the messages and substituting in the values to make the code cleaner, which needed to be public so it could be accessed everywhere, but we will not generate Javadoc for it or export it from the module.  I'm not sure if this approach is acceptable.  If not, other options include having that class as package protected in each package, or omitting it entirely and having slightly more verbose code wherever we need to obtain error messages.