### PR TITLE
more on typing of literals

### DIFF
--- a/api/src/main/java/jakarta/data/constraint/Like.java
+++ b/api/src/main/java/jakarta/data/constraint/Like.java
@@ -33,7 +33,7 @@ public interface Like extends Constraint<String> {
                     Messages.get("001.arg.required", "pattern"));
         }
 
-        StringLiteral<Object> expression = StringLiteral.of(pattern);
+        StringLiteral expression = StringLiteral.of(pattern);
         return new LikeRecord(expression, null);
     }
 
@@ -47,7 +47,7 @@ public interface Like extends Constraint<String> {
                     Messages.get("001.arg.required", "pattern"));
         }
 
-        StringLiteral<Object> expression = StringLiteral.of(
+        StringLiteral expression = StringLiteral.of(
                 translate(pattern, charWildcard, stringWildcard, escape));
         return new LikeRecord(expression, escape);
     }
@@ -67,7 +67,7 @@ public interface Like extends Constraint<String> {
                     Messages.get("001.arg.required", "prefix"));
         }
 
-        StringLiteral<Object> expression = StringLiteral.of(
+        StringLiteral expression = StringLiteral.of(
                 LikeRecord.escape(prefix) + STRING_WILDCARD);
         return new LikeRecord(expression, ESCAPE);
     }
@@ -78,7 +78,7 @@ public interface Like extends Constraint<String> {
                     Messages.get("001.arg.required", "substring"));
         }
 
-        StringLiteral<Object> expression = StringLiteral.of(
+        StringLiteral expression = StringLiteral.of(
                 STRING_WILDCARD + LikeRecord.escape(substring) + STRING_WILDCARD);
         return new LikeRecord(expression, ESCAPE);
     }
@@ -89,7 +89,7 @@ public interface Like extends Constraint<String> {
                     Messages.get("001.arg.required", "suffix"));
         }
 
-        StringLiteral<Object> expression = StringLiteral.of(
+        StringLiteral expression = StringLiteral.of(
                 STRING_WILDCARD + LikeRecord.escape(suffix));
         return new LikeRecord(expression, ESCAPE);
     }
@@ -100,7 +100,7 @@ public interface Like extends Constraint<String> {
                     Messages.get("001.arg.required", "value"));
         }
 
-        StringLiteral<Object> expression = StringLiteral.of(
+        StringLiteral expression = StringLiteral.of(
                 LikeRecord.escape(value));
         return new LikeRecord(expression, ESCAPE);
     }

--- a/api/src/main/java/jakarta/data/constraint/NotLike.java
+++ b/api/src/main/java/jakarta/data/constraint/NotLike.java
@@ -33,7 +33,7 @@ public interface NotLike extends Constraint<String> {
                     Messages.get("001.arg.required", "pattern"));
         }
 
-        StringLiteral<Object> expression = StringLiteral.of(pattern);
+        StringLiteral expression = StringLiteral.of(pattern);
         return new NotLikeRecord(expression, null);
     }
 
@@ -47,7 +47,7 @@ public interface NotLike extends Constraint<String> {
                     Messages.get("001.arg.required", "pattern"));
         }
 
-        StringLiteral<Object> expression = StringLiteral.of(
+        StringLiteral expression = StringLiteral.of(
                 translate(pattern, charWildcard, stringWildcard, escape));
         return new NotLikeRecord(expression, escape);
     }
@@ -67,7 +67,7 @@ public interface NotLike extends Constraint<String> {
                     Messages.get("001.arg.required", "prefix"));
         }
 
-        StringLiteral<Object> expression = StringLiteral.of(
+        StringLiteral expression = StringLiteral.of(
                 LikeRecord.escape(prefix) + STRING_WILDCARD);
         return new NotLikeRecord(expression, ESCAPE);
     }
@@ -78,7 +78,7 @@ public interface NotLike extends Constraint<String> {
                     Messages.get("001.arg.required", "substring"));
         }
 
-        StringLiteral<Object> expression = StringLiteral.of(
+        StringLiteral expression = StringLiteral.of(
                 STRING_WILDCARD + LikeRecord.escape(substring) + STRING_WILDCARD);
         return new NotLikeRecord(expression, ESCAPE);
     }
@@ -89,7 +89,7 @@ public interface NotLike extends Constraint<String> {
                     Messages.get("001.arg.required", "suffix"));
         }
 
-        StringLiteral<Object> expression = StringLiteral.of(
+        StringLiteral expression = StringLiteral.of(
                 STRING_WILDCARD + LikeRecord.escape(suffix));
         return new NotLikeRecord(expression, ESCAPE);
     }
@@ -100,7 +100,7 @@ public interface NotLike extends Constraint<String> {
                     Messages.get("001.arg.required", "value"));
         }
 
-        StringLiteral<Object> expression = StringLiteral.of(
+        StringLiteral expression = StringLiteral.of(
                 LikeRecord.escape(value));
         return new NotLikeRecord(expression, ESCAPE);
     }

--- a/api/src/main/java/jakarta/data/expression/NumericExpression.java
+++ b/api/src/main/java/jakarta/data/expression/NumericExpression.java
@@ -184,7 +184,8 @@ public interface NumericExpression<T, N extends Number & Comparable<N>>
      * @return an expression for the function that computes the sum.
      * @throws NullPointerException if the supplied value is null.
      */
-    default NumericExpression<T, N> plus(NumericExpression<T, N> expression) {
+    default NumericExpression<T, N> plus(
+            NumericExpression<? super T, N> expression) {
         return NumericOperatorExpression.of(PLUS, this, expression);
     }
 
@@ -205,7 +206,8 @@ public interface NumericExpression<T, N extends Number & Comparable<N>>
      * @return an expression for the function that computes the difference.
      * @throws NullPointerException if the supplied expression is null.
      */
-    default NumericExpression<T, N> minus(NumericExpression<T, N> expression) {
+    default NumericExpression<T, N> minus(
+            NumericExpression<? super T, N> expression) {
         return NumericOperatorExpression.of(MINUS, this, expression);
     }
 
@@ -228,7 +230,7 @@ public interface NumericExpression<T, N extends Number & Comparable<N>>
      * @throws NullPointerException if the supplied factor expression is null.
      */
     default NumericExpression<T, N> times(
-            NumericExpression<T, N> factorExpression) {
+            NumericExpression<? super T, N> factorExpression) {
         return NumericOperatorExpression.of(TIMES, this, factorExpression);
     }
 
@@ -251,7 +253,7 @@ public interface NumericExpression<T, N extends Number & Comparable<N>>
      * @throws NullPointerException if the supplied divisor expression is null.
      */
     default NumericExpression<T, N> divide(
-            NumericExpression<T, N> divisorExpression) {
+            NumericExpression<? super T, N> divisorExpression) {
         return NumericOperatorExpression.of(DIVIDE, this, divisorExpression);
     }
 

--- a/api/src/main/java/jakarta/data/expression/TextExpression.java
+++ b/api/src/main/java/jakarta/data/expression/TextExpression.java
@@ -120,7 +120,8 @@ public interface TextExpression<T> extends ComparableExpression<T, String> {
      *         value.
      * @throws NullPointerException if the suffix expression is {@code null}.
      */
-    default TextExpression<T> append(TextExpression<? super T> suffixExpression) {
+    default TextExpression<T> append(
+            TextExpression<? super T> suffixExpression) {
         return TextFunctionExpression.of(CONCAT, suffixExpression, this);
     }
 

--- a/api/src/main/java/jakarta/data/expression/function/NumericOperatorExpression.java
+++ b/api/src/main/java/jakarta/data/expression/function/NumericOperatorExpression.java
@@ -50,7 +50,7 @@ public interface NumericOperatorExpression<T, N extends Number & Comparable<N>>
     static <T, N extends Number & Comparable<N>> NumericOperatorExpression<T, N> of(
             Operator operator,
             NumericExpression<T, N> left,
-            NumericExpression<T, N> right) {
+            NumericExpression<? super T, N> right) {
         return new NumericOperatorExpressionRecord<>(operator, left, right);
     }
 }

--- a/api/src/main/java/jakarta/data/expression/literal/ComparableLiteral.java
+++ b/api/src/main/java/jakarta/data/expression/literal/ComparableLiteral.java
@@ -32,12 +32,11 @@ import jakarta.data.expression.ComparableExpression;
  * {@link Boolean}, {@link Character}, enumerated, or {@link UUID} value.
  * </p>
  *
- * @param <T> entity type.
  * @param <V> entity attribute type.
  * @since 1.1
  */
-public interface ComparableLiteral<T, V extends Comparable<?>>
-        extends ComparableExpression<T, V>, Literal<T, V> {
+public interface ComparableLiteral<V extends Comparable<?>>
+        extends ComparableExpression<Object, V>, Literal<V> {
 
     /**
      * <p>Creates a {@code ComparableLiteral} or subtype of
@@ -57,37 +56,37 @@ public interface ComparableLiteral<T, V extends Comparable<?>>
      * @throws NullPointerException if the value is {@code null}.
      */
     @SuppressWarnings("unchecked")
-    static <V extends Comparable<?>> ComparableLiteral<Object, V> of(V value) {
+    static <V extends Comparable<?>> ComparableLiteral<V> of(V value) {
         // Subtypes of Number and Temporal are needed here because
         // NumericExperssion has N extends Number & Comparable<N>
         // and
         // TemporalExpression has V extends Temporal & Comparable<? extends Temporal>
         if (value instanceof String s) {
-            return (ComparableLiteral<Object, V>) StringLiteral.of(s);
+            return (ComparableLiteral<V>) StringLiteral.of(s);
         } else if (value instanceof Integer i) {
-            return (ComparableLiteral<Object, V>) NumericLiteral.of(i);
+            return (ComparableLiteral<V>) NumericLiteral.of(i);
         } else if (value instanceof Long l) {
-            return (ComparableLiteral<Object, V>) NumericLiteral.of(l);
+            return (ComparableLiteral<V>) NumericLiteral.of(l);
         } else if (value instanceof Float f) {
-            return (ComparableLiteral<Object, V>) NumericLiteral.of(f);
+            return (ComparableLiteral<V>) NumericLiteral.of(f);
         } else if (value instanceof Double d) {
-            return (ComparableLiteral<Object, V>) NumericLiteral.of(d);
+            return (ComparableLiteral<V>) NumericLiteral.of(d);
         } else if (value instanceof Byte b) {
-            return (ComparableLiteral<Object, V>) NumericLiteral.of(b);
+            return (ComparableLiteral<V>) NumericLiteral.of(b);
         } else if (value instanceof Short s) {
-            return (ComparableLiteral<Object, V>) NumericLiteral.of(s);
+            return (ComparableLiteral<V>) NumericLiteral.of(s);
         } else if (value instanceof BigInteger i) {
-            return (ComparableLiteral<Object, V>) NumericLiteral.of(i);
+            return (ComparableLiteral<V>) NumericLiteral.of(i);
         } else if (value instanceof BigDecimal d) {
-            return (ComparableLiteral<Object, V>) NumericLiteral.of(d);
+            return (ComparableLiteral<V>) NumericLiteral.of(d);
         } else if (value instanceof Instant i) {
-            return (ComparableLiteral<Object, V>) TemporalLiteral.of(i);
+            return (ComparableLiteral<V>) TemporalLiteral.of(i);
         } else if (value instanceof LocalDate d) {
-            return (ComparableLiteral<Object, V>) TemporalLiteral.of(d);
+            return (ComparableLiteral<V>) TemporalLiteral.of(d);
         } else if (value instanceof LocalDateTime d) {
-            return (ComparableLiteral<Object, V>) TemporalLiteral.of(d);
+            return (ComparableLiteral<V>) TemporalLiteral.of(d);
         } else if (value instanceof LocalTime t) {
-            return (ComparableLiteral<Object, V>) TemporalLiteral.of(t);
+            return (ComparableLiteral<V>) TemporalLiteral.of(t);
         } else {
             return new ComparableLiteralRecord<>(value);
         }

--- a/api/src/main/java/jakarta/data/expression/literal/ComparableLiteralRecord.java
+++ b/api/src/main/java/jakarta/data/expression/literal/ComparableLiteralRecord.java
@@ -20,7 +20,7 @@ package jakarta.data.expression.literal;
 import jakarta.data.messages.Messages;
 
 record ComparableLiteralRecord<T, V extends Comparable<?>>(V value)
-        implements ComparableLiteral<T, V> {
+        implements ComparableLiteral<V> {
 
     ComparableLiteralRecord {
         if (value == null) {

--- a/api/src/main/java/jakarta/data/expression/literal/Literal.java
+++ b/api/src/main/java/jakarta/data/expression/literal/Literal.java
@@ -47,11 +47,10 @@ import jakarta.data.restrict.Restriction;
  * _Car.price.asDouble().times(0.1).lessThan(discount)
  * </pre>
  *
- * @param <T> entity type.
  * @param <V> entity attribute type.
  * @since 1.1
  */
-public interface Literal<T, V> extends Expression<T, V> {
+public interface Literal<V> extends Expression<Object, V> {
     /**
      * <p>Returns the value represented by this {@code Literal}.
      * The value will never be {@code null}.</p>
@@ -71,7 +70,6 @@ public interface Literal<T, V> extends Expression<T, V> {
      * or {@link ComparableLiteral#of(Comparable) ComparableLiteral},
      * should be used instead wherever possible.</p>
      *
-     * @param <T>   entity type.
      * @param <V>   entity attribute type.
      * @param value an immutable value or a mutable value that must never be
      *              modified after it is supplied to this method. Must never be
@@ -80,9 +78,9 @@ public interface Literal<T, V> extends Expression<T, V> {
      * @throws NullPointerException if the value is {@code null}.
      */
     @SuppressWarnings("unchecked")
-    static <T, V> Literal<T, V> of(V value) {
-        if (value instanceof Comparable c) {
-            return (Literal<T, V>) ComparableLiteral.of(c);
+    static <V> Literal<V> of(V value) {
+        if (value instanceof Comparable<?> c) {
+            return (Literal<V>) ComparableLiteral.of(c);
         } else {
             return new LiteralRecord<>(value);
         }

--- a/api/src/main/java/jakarta/data/expression/literal/LiteralRecord.java
+++ b/api/src/main/java/jakarta/data/expression/literal/LiteralRecord.java
@@ -19,7 +19,7 @@ package jakarta.data.expression.literal;
 
 import jakarta.data.messages.Messages;
 
-record LiteralRecord<T, V>(V value) implements Literal<T, V> {
+record LiteralRecord<V>(V value) implements Literal<V> {
 
     LiteralRecord {
         if (value == null) {

--- a/api/src/main/java/jakarta/data/expression/literal/NumericLiteral.java
+++ b/api/src/main/java/jakarta/data/expression/literal/NumericLiteral.java
@@ -27,12 +27,11 @@ import jakarta.data.metamodel.NumericAttribute;
  * <p>A {@linkplain Literal literal} for a
  * {@linkplain NumericAttribute numeric} value.</p>
  *
- * @param <T> entity type.
  * @param <N> entity attribute type.
  * @since 1.1
  */
-public interface NumericLiteral<T, N extends Number & Comparable<N>>
-        extends ComparableLiteral<T, N>, NumericExpression<T, N> {
+public interface NumericLiteral<N extends Number & Comparable<N>>
+        extends ComparableLiteral<N>, NumericExpression<Object, N> {
 
     /**
      * <p>Creates a {@code NumericLiteral} that represents the given value.</p>
@@ -42,7 +41,7 @@ public interface NumericLiteral<T, N extends Number & Comparable<N>>
      * @return a {@code NumericLiteral} representing the value.
      * @throws NullPointerException if the value is {@code null}.
      */
-    static <N extends Number & Comparable<N>> NumericLiteral<Object,N> of(N value) {
+    static <N extends Number & Comparable<N>> NumericLiteral<N> of(N value) {
         return new NumericLiteralRecord<>(value);
     }
 

--- a/api/src/main/java/jakarta/data/expression/literal/NumericLiteralRecord.java
+++ b/api/src/main/java/jakarta/data/expression/literal/NumericLiteralRecord.java
@@ -21,8 +21,10 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 
 import jakarta.data.messages.Messages;
-record NumericLiteralRecord<T, N extends Number & Comparable<N>>
-        (N value) implements NumericLiteral<T, N> {
+
+record NumericLiteralRecord<N extends Number & Comparable<N>>
+        (N value)
+        implements NumericLiteral<N> {
 
     NumericLiteralRecord {
         if (value == null) {

--- a/api/src/main/java/jakarta/data/expression/literal/StringLiteral.java
+++ b/api/src/main/java/jakarta/data/expression/literal/StringLiteral.java
@@ -22,22 +22,20 @@ import jakarta.data.expression.TextExpression;
 /**
  * <p>A {@linkplain Literal literal} for a {@link String} value.</p>
  *
- * @param <T> entity type.
  * @since 1.1
  */
-public interface StringLiteral<T>
-        extends ComparableLiteral<T, String>, TextExpression<T> {
+public interface StringLiteral
+        extends ComparableLiteral<String>, TextExpression<Object> {
 
     /**
      * <p>Creates a {@code StringLiteral} that represents the given value.</p>
      *
-     * @param <T>   entity type.
      * @param value a {@code String} value. Must never be {@code null}.
      * @return a {@code StringLiteral} representing the value.
      * @throws NullPointerException if the value is {@code null}.
      */
-    static <T> StringLiteral<T> of(String value) {
-        return new StringLiteralRecord<T>(value);
+    static StringLiteral of(String value) {
+        return new StringLiteralRecord(value);
     }
 
     /**

--- a/api/src/main/java/jakarta/data/expression/literal/StringLiteralRecord.java
+++ b/api/src/main/java/jakarta/data/expression/literal/StringLiteralRecord.java
@@ -19,8 +19,8 @@ package jakarta.data.expression.literal;
 
 import jakarta.data.messages.Messages;
 
-record StringLiteralRecord<T>(String value)
-        implements StringLiteral<T> {
+record StringLiteralRecord(String value)
+        implements StringLiteral {
 
     StringLiteralRecord {
         if (value == null) {

--- a/api/src/main/java/jakarta/data/expression/literal/TemporalLiteral.java
+++ b/api/src/main/java/jakarta/data/expression/literal/TemporalLiteral.java
@@ -31,12 +31,11 @@ import jakarta.data.metamodel.TemporalAttribute;
  * <p>A {@linkplain Literal literal} for a
  * {@linkplain TemporalAttribute temporal} value.</p>
  *
- * @param <T> entity type.
  * @param <V> entity attribute type.
  * @since 1.1
  */
-public interface TemporalLiteral<T, V extends Temporal & Comparable<? extends Temporal>>
-        extends ComparableLiteral<T, V>, TemporalExpression<T, V> {
+public interface TemporalLiteral<V extends Temporal & Comparable<? extends Temporal>>
+        extends ComparableLiteral<V>, TemporalExpression<Object, V> {
 
     /**
      * <p>Creates a {@code TemporalLiteral} that represents the given value.
@@ -47,7 +46,7 @@ public interface TemporalLiteral<T, V extends Temporal & Comparable<? extends Te
      * @return a {@code TemporalLiteral} representing the value.
      * @throws NullPointerException if the value is {@code null}.
      */
-    static <V extends Temporal & Comparable<? extends Temporal>> TemporalLiteral<Object, V>
+    static <V extends Temporal & Comparable<? extends Temporal>> TemporalLiteral<V>
     of(V value) {
         return new TemporalLiteralRecord<>(value);
     }

--- a/api/src/main/java/jakarta/data/expression/literal/TemporalLiteralRecord.java
+++ b/api/src/main/java/jakarta/data/expression/literal/TemporalLiteralRecord.java
@@ -26,9 +26,9 @@ import java.time.temporal.Temporal;
 
 import jakarta.data.messages.Messages;
 
-record TemporalLiteralRecord<T, V extends Temporal & Comparable<? extends Temporal>>(
-        V value)
-        implements TemporalLiteral<T, V> {
+record TemporalLiteralRecord<V extends Temporal & Comparable<? extends Temporal>>
+        (V value)
+        implements TemporalLiteral<V> {
 
     TemporalLiteralRecord {
         if (value == null) {

--- a/api/src/test/java/jakarta/data/expression/ExpressionTest.java
+++ b/api/src/test/java/jakarta/data/expression/ExpressionTest.java
@@ -70,7 +70,7 @@ class ExpressionTest {
             (BasicRestriction<Book, String>) titleWithEE;
 
         EqualTo<String> constraint = (EqualTo<String>) restriction.constraint();
-        StringLiteral<?> literal = (StringLiteral<?>) constraint.expression();
+        StringLiteral literal = (StringLiteral) constraint.expression();
 
         TextFunctionExpression<Book> upperExpression =
             (TextFunctionExpression<Book>) restriction.expression();
@@ -88,8 +88,8 @@ class ExpressionTest {
         assertInstanceOf(NumericLiteral.class, rightArgs.get(1));
 
         @SuppressWarnings("unchecked")
-        NumericLiteral<Book, Integer> rightArg1 =
-            (NumericLiteral<Book, Integer>) rightArgs.get(1);
+        NumericLiteral<Integer> rightArg1 =
+            (NumericLiteral<Integer>) rightArgs.get(1);
 
         @SuppressWarnings("unchecked")
         TextFunctionExpression<Book> leftExpression =
@@ -101,8 +101,8 @@ class ExpressionTest {
         assertInstanceOf(NumericLiteral.class, leftArgs.get(1));
 
         @SuppressWarnings("unchecked")
-        NumericLiteral<Book, Integer> leftArg1 =
-            (NumericLiteral<Book, Integer>) leftArgs.get(1);
+        NumericLiteral<Integer> leftArg1 =
+            (NumericLiteral<Integer>) leftArgs.get(1);
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(leftExpression.name())
@@ -140,8 +140,8 @@ class ExpressionTest {
         LessThanOrEqual<Integer> constraint =
             (LessThanOrEqual<Integer>) restriction.constraint();
 
-        NumericLiteral<?, Integer> literal =
-            (NumericLiteral<?, Integer>) constraint.bound();
+        NumericLiteral<?> literal =
+            (NumericLiteral<?>) constraint.bound();
 
         NumericFunctionExpression<Book, Integer> lengthExpression =
             (NumericFunctionExpression<Book, Integer>) restriction.expression();

--- a/api/src/test/java/jakarta/data/expression/TemporalExpressionTest.java
+++ b/api/src/test/java/jakarta/data/expression/TemporalExpressionTest.java
@@ -78,11 +78,11 @@ class TemporalExpressionTest {
         Between<LocalDate> constraint =
             (Between<LocalDate>) restriction.constraint();
 
-        TemporalLiteral<?, LocalDate> lowerLiteral =
-            (TemporalLiteral<?, LocalDate>) constraint.lowerBound();
+        TemporalLiteral<?> lowerLiteral =
+            (TemporalLiteral<?>) constraint.lowerBound();
 
-        TemporalLiteral<?, LocalDate> upperLiteral =
-            (TemporalLiteral<?, LocalDate>) constraint.upperBound();
+        TemporalLiteral<?> upperLiteral =
+            (TemporalLiteral<?>) constraint.upperBound();
 
         TemporalExpression<Book, LocalDate> betweenExpression =
             (TemporalExpression<Book, LocalDate>) restriction.expression();

--- a/api/src/test/java/jakarta/data/expression/function/FunctionTest.java
+++ b/api/src/test/java/jakarta/data/expression/function/FunctionTest.java
@@ -69,7 +69,7 @@ class FunctionTest {
             soft.assertThat(expr.arguments().get(1))
                 .isInstanceOf(NumericLiteral.class);
 
-            soft.assertThat(((NumericLiteral<?, ?>) expr.arguments().get(1))
+            soft.assertThat(((NumericLiteral<?>) expr.arguments().get(1))
                     .value())
                 .isEqualTo(0);
         });
@@ -105,7 +105,7 @@ class FunctionTest {
             soft.assertThat(expr.arguments().get(1))
                 .isInstanceOf(NumericLiteral.class);
 
-            soft.assertThat(((NumericLiteral<?, ?>) expr.arguments().get(1))
+            soft.assertThat(((NumericLiteral<?>) expr.arguments().get(1))
                     .value())
                 .isEqualTo(0);
         });

--- a/api/src/test/java/jakarta/data/expression/literal/LiteralRecordTest.java
+++ b/api/src/test/java/jakarta/data/expression/literal/LiteralRecordTest.java
@@ -24,8 +24,8 @@ import org.junit.jupiter.api.Test;
 class LiteralRecordTest {
     // Static metamodel using LiteralRecord
     interface _SimpleEntity {
-        Literal<SimpleEntity, String> name = new LiteralRecord<>("name");
-        Literal<SimpleEntity, Integer> age = new LiteralRecord<>(42);
+        Literal<String> name = new LiteralRecord<>("name");
+        Literal<Integer> age = new LiteralRecord<>(42);
     }
 
     // Simple mock entity
@@ -37,7 +37,7 @@ class LiteralRecordTest {
     @Test
     @DisplayName("should create LiteralRecord and return its value")
     void shouldCreateLiteralRecord() {
-        var literal = new LiteralRecord<SimpleEntity, String>("literal-value");
+        var literal = new LiteralRecord<>("literal-value");
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(literal.value()).isEqualTo("literal-value");
@@ -48,8 +48,8 @@ class LiteralRecordTest {
     @Test
     @DisplayName("should support equals and hashCode for identical values")
     void shouldSupportEqualsAndHashCode() {
-        var first = new LiteralRecord<SimpleEntity, Integer>(10);
-        var second = new LiteralRecord<SimpleEntity, Integer>(10);
+        var first = new LiteralRecord<>(10);
+        var second = new LiteralRecord<>(10);
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(first).isEqualTo(second);
@@ -60,8 +60,8 @@ class LiteralRecordTest {
     @Test
     @DisplayName("should not be equal for different values")
     void shouldNotEqualDifferentValues() {
-        var one = new LiteralRecord<SimpleEntity, String>("one");
-        var two = new LiteralRecord<SimpleEntity, String>("two");
+        var one = new LiteralRecord<>("one");
+        var two = new LiteralRecord<>("two");
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(one).isNotEqualTo(two);
@@ -72,7 +72,7 @@ class LiteralRecordTest {
     @DisplayName("should throw NullPointerException when value is null")
     void shouldThrowWhenValueIsNull() {
         org.junit.jupiter.api.Assertions.assertThrows(NullPointerException.class, () -> {
-            new LiteralRecord<SimpleEntity, Object>(null);
+            new LiteralRecord<>(null);
         }, "The value argument is required");
     }
 }

--- a/api/src/test/java/jakarta/data/expression/literal/LiteralToStringTest.java
+++ b/api/src/test/java/jakarta/data/expression/literal/LiteralToStringTest.java
@@ -37,19 +37,19 @@ class LiteralToStringTest {
     @DisplayName("ComparableLiteral.toString must output expected value")
     void testComparableLiteralToString() {
         final String TEST_UUID = "73d518c4-b7f6-4c3b-9f63-60a045a43bb8";
-        ComparableLiteral<?, Boolean> booleanLiteral =
+        ComparableLiteral<Boolean> booleanLiteral =
                 ComparableLiteral.of(true);
 
-        ComparableLiteral<?, Character> charLiteral =
+        ComparableLiteral<Character> charLiteral =
                 ComparableLiteral.of('D');
 
-        ComparableLiteral<?, Character> singleQuoteLiteral =
+        ComparableLiteral<Character> singleQuoteLiteral =
                 ComparableLiteral.of('\'');
 
-        ComparableLiteral<?, Month> monthLiteral =
+        ComparableLiteral<Month> monthLiteral =
                 ComparableLiteral.of(Month.MAY);
 
-        ComparableLiteral<?, UUID> uuidLiteral =
+        ComparableLiteral<UUID> uuidLiteral =
                 ComparableLiteral.of(UUID.fromString(TEST_UUID));
 
         SoftAssertions.assertSoftly(soft -> {
@@ -74,16 +74,16 @@ class LiteralToStringTest {
     @Test
     @DisplayName("NumericLiteral.toString must output expected value")
     void testNumericLiteralToString() {
-        NumericLiteral<?, Integer> intLiteral = NumericLiteral.of(12);
+        NumericLiteral<Integer> intLiteral = NumericLiteral.of(12);
 
-        NumericLiteral<?, Long> longLiteral = NumericLiteral.of(123456789L);
+        NumericLiteral<Long> longLiteral = NumericLiteral.of(123456789L);
 
-        NumericLiteral<?, Byte> byteLiteral = NumericLiteral.of((byte) 68);
+        NumericLiteral<Byte> byteLiteral = NumericLiteral.of((byte) 68);
 
-        NumericLiteral<?, BigInteger> bigIntegerLiteral =
+        NumericLiteral<BigInteger> bigIntegerLiteral =
                 NumericLiteral.of(BigInteger.valueOf(10203040506L));
 
-        NumericLiteral<?, BigDecimal> bigDecimalLiteral =
+        NumericLiteral<BigDecimal> bigDecimalLiteral =
                 NumericLiteral.of(BigDecimal.valueOf(123456789, 2));
 
         SoftAssertions.assertSoftly(soft -> {
@@ -107,7 +107,7 @@ class LiteralToStringTest {
     @Test
     @DisplayName("Literal.toString must output expected value")
     void testObjectLiteralToString() {
-        Literal<?, ZoneId> literal = Literal.of(ZoneId.of("America/Chicago"));
+        Literal<ZoneId> literal = Literal.of(ZoneId.of("America/Chicago"));
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(literal.toString())
@@ -120,8 +120,8 @@ class LiteralToStringTest {
     @Test
     @DisplayName("Stringiteral.toString must output expected value")
     void testStringLiteralToString() {
-        StringLiteral<?> literal = StringLiteral.of("Hello!");
-        StringLiteral<?> singleQuoteLiteral =
+        StringLiteral literal = StringLiteral.of("Hello!");
+        StringLiteral singleQuoteLiteral =
                 StringLiteral.of("Jakarta Data's second release");
 
         SoftAssertions.assertSoftly(soft -> {
@@ -136,16 +136,16 @@ class LiteralToStringTest {
     @Test
     @DisplayName("TemporalLiteral.toString must output expected value")
     void testTemporalLiteralToString() {
-        TemporalLiteral<?, Instant> instantLiteral =
+        TemporalLiteral<Instant> instantLiteral =
                 TemporalLiteral.of(Instant.ofEpochMilli(1746825482575L));
 
-        TemporalLiteral<?, LocalDate> dateLiteral =
+        TemporalLiteral<LocalDate> dateLiteral =
                 TemporalLiteral.of(LocalDate.of(2025, 5, 8));
 
-        TemporalLiteral<?, LocalDateTime> datetimeLiteral =
+        TemporalLiteral<LocalDateTime> datetimeLiteral =
                 TemporalLiteral.of(LocalDateTime.of(2025, 5, 9, 16, 15, 42));
 
-        TemporalLiteral<?, LocalTime> timeLiteral =
+        TemporalLiteral<LocalTime> timeLiteral =
                 TemporalLiteral.of(LocalTime.of(18, 8, 30));
 
         SoftAssertions.assertSoftly(soft -> {

--- a/api/src/test/java/jakarta/data/metamodel/TextAttributeTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/TextAttributeTest.java
@@ -48,7 +48,7 @@ class TextAttributeTest {
         var restriction = (BasicRestriction<?, ?>) _Author.testAttribute.contains("testValue");
 
         Like like = (Like) restriction.constraint();
-        StringLiteral<?> literal = ((StringLiteral<?>) like.pattern());
+        StringLiteral literal = ((StringLiteral) like.pattern());
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.expression()).isEqualTo(_Author.testAttribute);
             soft.assertThat(literal.value()).isEqualTo("%testValue%");
@@ -63,7 +63,7 @@ class TextAttributeTest {
     void shouldCreateStartsWithRestriction() {
         var restriction = (BasicRestriction<?, ?>) _Author.testAttribute.startsWith("testValue");
         Like like = (Like) restriction.constraint();
-        StringLiteral<?> literal = ((StringLiteral<?>) like.pattern());
+        StringLiteral literal = ((StringLiteral) like.pattern());
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.expression()).isEqualTo(_Author.testAttribute);
             soft.assertThat(literal.value()).isEqualTo("testValue%");
@@ -78,7 +78,7 @@ class TextAttributeTest {
     void shouldCreateEndsWithRestriction() {
         var restriction = (BasicRestriction<?, ?>) _Author.testAttribute.endsWith("testValue");
         Like like = (Like) restriction.constraint();
-        StringLiteral<?> literal = ((StringLiteral<?>) like.pattern());
+        StringLiteral literal = ((StringLiteral) like.pattern());
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.constraint()).isInstanceOf(Like.class);
             soft.assertThat(restriction.expression()).isEqualTo(_Author.testAttribute);
@@ -94,7 +94,7 @@ class TextAttributeTest {
         var restriction = (BasicRestriction<?, ?>) _Author.testAttribute.like("%test%");
 
         Like like = (Like) restriction.constraint();
-        StringLiteral<?> literal = ((StringLiteral<?>) like.pattern());
+        StringLiteral literal = ((StringLiteral) like.pattern());
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.expression()).isEqualTo(_Author.testAttribute);
             soft.assertThat(literal.value()).isEqualTo("%test%");
@@ -109,7 +109,7 @@ class TextAttributeTest {
     void shouldCreateNotContainsRestriction() {
         var restriction = (BasicRestriction<?, ?>) _Author.testAttribute.notContains("testValue");
         NotLike notLike = (NotLike) restriction.constraint();
-        StringLiteral<?> literal = ((StringLiteral<?>) notLike.pattern());
+        StringLiteral literal = ((StringLiteral) notLike.pattern());
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.expression()).isEqualTo(_Author.testAttribute);
             soft.assertThat(literal.value()).isEqualTo("%testValue%");
@@ -125,7 +125,7 @@ class TextAttributeTest {
         var restriction = (BasicRestriction<?, ?>) _Author.testAttribute.notLike("%test%");
 
         NotLike notLike = (NotLike) restriction.constraint();
-        StringLiteral<?> literal = ((StringLiteral<?>) notLike.pattern());
+        StringLiteral literal = ((StringLiteral) notLike.pattern());
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.expression()).isEqualTo(_Author.testAttribute);
             soft.assertThat(literal.value()).isEqualTo("%test%");
@@ -140,7 +140,7 @@ class TextAttributeTest {
     void shouldCreateNotStartsWithRestriction() {
         var restriction = (BasicRestriction<?, ?>) _Author.testAttribute.notStartsWith("testValue");
         NotLike notLike = (NotLike) restriction.constraint();
-        StringLiteral<?> literal = ((StringLiteral<?>) notLike.pattern());
+        StringLiteral literal = ((StringLiteral) notLike.pattern());
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.expression()).isEqualTo(_Author.testAttribute);
             soft.assertThat(literal.value()).isEqualTo("testValue%");
@@ -156,7 +156,7 @@ class TextAttributeTest {
         var restriction = (BasicRestriction<?, ?>) _Author.testAttribute.notEndsWith("testValue");
 
         NotLike notLike = (NotLike) restriction.constraint();
-        StringLiteral<?> literal = ((StringLiteral<?>) notLike.pattern());
+        StringLiteral literal = ((StringLiteral) notLike.pattern());
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.expression()).isEqualTo(_Author.testAttribute);
             soft.assertThat(literal.value()).isEqualTo("%testValue");

--- a/api/src/test/java/jakarta/data/restrict/RestrictTest.java
+++ b/api/src/test/java/jakarta/data/restrict/RestrictTest.java
@@ -144,7 +144,7 @@ class RestrictTest {
                 (BasicRestriction<Employee, String>) _Employee.position.contains("Manager");
 
         Like constraint = (Like) restriction.constraint();
-        StringLiteral<?> literal = (StringLiteral<?>) constraint.pattern();
+        StringLiteral literal = (StringLiteral) constraint.pattern();
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.expression()).isEqualTo(_Employee.position);
@@ -159,7 +159,7 @@ class RestrictTest {
                 (BasicRestriction<Employee, String>) _Employee.position.notContains("Director");
 
         NotLike constraint = (NotLike) restriction.constraint();
-        StringLiteral<?> literal = (StringLiteral<?>) constraint.pattern();
+        StringLiteral literal = (StringLiteral) constraint.pattern();
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.expression()).isEqualTo(_Employee.position);
@@ -174,7 +174,7 @@ class RestrictTest {
                 (BasicRestriction<Employee, String>) _Employee.position.startsWith("Director");
 
         Like constraint = (Like) restriction.constraint();
-        StringLiteral<?> literal = (StringLiteral<?>) constraint.pattern();
+        StringLiteral literal = (StringLiteral) constraint.pattern();
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.expression()).isEqualTo(_Employee.position);
@@ -189,7 +189,7 @@ class RestrictTest {
                 (BasicRestriction<Employee, String>) _Employee.position.notStartsWith("Manager");
 
         NotLike constraint = (NotLike) restriction.constraint();
-        StringLiteral<?> literal = (StringLiteral<?>) constraint.pattern();
+        StringLiteral literal = (StringLiteral) constraint.pattern();
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.expression()).isEqualTo(_Employee.position);
@@ -204,7 +204,7 @@ class RestrictTest {
                 (BasicRestriction<Employee,String>) _Employee.position.endsWith("Manager");
 
         Like constraint = (Like) restriction.constraint();
-        StringLiteral<?> literal = (StringLiteral<?>) constraint.pattern();
+        StringLiteral literal = (StringLiteral) constraint.pattern();
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.expression()).isEqualTo(_Employee.position);
@@ -219,7 +219,7 @@ class RestrictTest {
                 (BasicRestriction<Employee, String>) _Employee.position.notEndsWith("Supervisor");
 
         NotLike constraint = (NotLike) restriction.constraint();
-        StringLiteral<?> literal = (StringLiteral<?>) constraint.pattern();
+        StringLiteral literal = (StringLiteral) constraint.pattern();
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.expression()).isEqualTo(_Employee.position);
@@ -265,7 +265,7 @@ class RestrictTest {
         @SuppressWarnings("unchecked")
         Like like = (Like) ((BasicRestriction<Employee,String>)
                 _Employee.position.endsWith("test_value")).constraint();
-        StringLiteral<?> literal = (StringLiteral<?>) like.pattern();
+        StringLiteral literal = (StringLiteral) like.pattern();
 
         assertThat(literal.value()).isEqualTo("%test\\_value");
     }

--- a/api/src/test/java/jakarta/data/restrict/TextRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/restrict/TextRestrictionRecordTest.java
@@ -40,7 +40,7 @@ class TextRestrictionRecordTest {
                 (BasicRestriction<Book, String>) _Book.title.like("%Java%");
 
         Like constraint = (Like) restriction.constraint();
-        StringLiteral<?> literal = (StringLiteral<?>) constraint.pattern();
+        StringLiteral literal = (StringLiteral) constraint.pattern();
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.expression()).isEqualTo(_Book.title);
@@ -58,7 +58,7 @@ class TextRestrictionRecordTest {
                 (BasicRestriction<Book, String>) _Book.title.like("%Java%").negate();
 
         NotLike constraint = (NotLike) restriction.constraint();
-        StringLiteral<?> literal = (StringLiteral<?>) constraint.pattern();
+        StringLiteral literal = (StringLiteral) constraint.pattern();
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.expression()).isEqualTo(_Book.title);
@@ -78,7 +78,7 @@ class TextRestrictionRecordTest {
         // TODO TextRestriction.ignoreCase vs TextAttribute.upper/lowercased
         //BasicRestriction<Book,String> caseInsensitiveRestriction = restriction.ignoreCase();
         Like constraint = (Like) restriction.constraint();
-        StringLiteral<?> literal = (StringLiteral<?>) constraint.pattern();
+        StringLiteral literal = (StringLiteral) constraint.pattern();
 
         SoftAssertions.assertSoftly(soft -> {
         //    soft.assertThat(caseInsensitiveRestriction.expression()).isEqualTo(_Book.title);
@@ -95,7 +95,7 @@ class TextRestrictionRecordTest {
                 (BasicRestriction<Book, String>) _Book.title.like("%Java%");
 
         Like constraint = (Like) restriction.constraint();
-        StringLiteral<?> literal = (StringLiteral<?>) constraint.pattern();
+        StringLiteral literal = (StringLiteral) constraint.pattern();
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.expression()).isEqualTo(_Book.title);
@@ -113,7 +113,7 @@ class TextRestrictionRecordTest {
                 (BasicRestriction<Book, String>) _Book.title.like("*Java??", '?', '*', '$');
 
         Like constraint = (Like) restriction.constraint();
-        StringLiteral<?> literal = (StringLiteral<?>) constraint.pattern();
+        StringLiteral literal = (StringLiteral) constraint.pattern();
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.expression()).isEqualTo(_Book.title);
@@ -165,14 +165,14 @@ class TextRestrictionRecordTest {
         Like notNotEndsWithJakartaEEConstraint =
                 (Like) notNotEndsWithJakartaEE.constraint();
 
-        StringLiteral<?> endsWithJakartaEELiteral =
-                (StringLiteral<?>) endsWithJakartaEEConstraint.pattern();
+        StringLiteral endsWithJakartaEELiteral =
+                (StringLiteral) endsWithJakartaEEConstraint.pattern();
 
-        StringLiteral<?> notEndsWithJakartaEELiteral =
-                (StringLiteral<?>) notEndsWithJakartaEEConstraint.pattern();
+        StringLiteral notEndsWithJakartaEELiteral =
+                (StringLiteral) notEndsWithJakartaEEConstraint.pattern();
 
-        StringLiteral<?> notNotEndsWithJakartaEELiteral =
-                (StringLiteral<?>) notNotEndsWithJakartaEEConstraint.pattern();
+        StringLiteral notNotEndsWithJakartaEELiteral =
+                (StringLiteral) notNotEndsWithJakartaEEConstraint.pattern();
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(endsWithJakartaEELiteral.value())
@@ -216,7 +216,7 @@ class TextRestrictionRecordTest {
 
         NotEqualTo<String> constraint =
                 (NotEqualTo<String>) restriction.constraint();
-        StringLiteral<?> literal = (StringLiteral<?>) constraint.expression();
+        StringLiteral literal = (StringLiteral) constraint.expression();
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.expression()).isEqualTo(_Book.author);


### PR DESCRIPTION
Two things:

1. Pull request #1114 was merged really quickly, and there were a couple of things missing from it.
2. Also, I think we should fix all `Literal`s to `Expression<Object, Whatever>`.