### PR TITLE
java.time.Year as a temporal attribute

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/TemporalAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/TemporalAttribute.java
@@ -36,6 +36,7 @@ import jakarta.data.expression.TemporalExpression;
  * <li>{@link java.time.LocalDate}</li>
  * <li>{@link java.time.LocalDateTime}</li>
  * <li>{@link java.time.LocalTime}</li>
+ * <li>{@link java.time.Year}</li>
  * </ul>
  *
  * <p>Where possible, {@code TemporalAttribute} is preferred over

--- a/api/src/main/java/jakarta/data/spi/expression/literal/ComparableLiteral.java
+++ b/api/src/main/java/jakarta/data/spi/expression/literal/ComparableLiteral.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.Year;
 import java.util.UUID;
 
 import jakarta.data.expression.ComparableExpression;
@@ -87,6 +88,8 @@ public interface ComparableLiteral<V extends Comparable<?>>
             return (ComparableLiteral<V>) TemporalLiteral.of(d);
         } else if (value instanceof LocalTime t) {
             return (ComparableLiteral<V>) TemporalLiteral.of(t);
+        } else if (value instanceof Year y) {
+            return (ComparableLiteral<V>) TemporalLiteral.of(y);
         } else {
             return new ComparableLiteralRecord<>(value);
         }

--- a/api/src/main/java/jakarta/data/spi/expression/literal/TemporalLiteral.java
+++ b/api/src/main/java/jakarta/data/spi/expression/literal/TemporalLiteral.java
@@ -21,6 +21,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.Year;
 import java.time.ZoneOffset;
 import java.time.temporal.Temporal;
 
@@ -63,7 +64,7 @@ public interface TemporalLiteral<V extends Temporal & Comparable<? extends Tempo
      * space character. The first term is</p>
      * <ul>
      * <li>{@code ts} for {@link Instant} and {@link LocalDateTime},</li>
-     * <li>{@code d} for {@link LocalDate},</li>
+     * <li>{@code d} for {@link LocalDate} and {@link Year},</li>
      * <li>{@code t} for {@link LocalTime}, or</li>
      * <li>{@code TemporalLiteral} for all other types, in which case a middle
      * term is included. The middle term is the fully qualified class name of

--- a/api/src/main/java/jakarta/data/spi/expression/literal/TemporalLiteralRecord.java
+++ b/api/src/main/java/jakarta/data/spi/expression/literal/TemporalLiteralRecord.java
@@ -21,6 +21,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.Year;
 import java.time.ZoneOffset;
 import java.time.temporal.Temporal;
 
@@ -51,6 +52,8 @@ record TemporalLiteralRecord<V extends Temporal & Comparable<? extends Temporal>
                 "{d '" + value + "'}";
             case LocalTime t ->
                 "{t '" + value + "'}";
+            case Year y ->
+                "{d '" + y.getValue() + "'}";
             default ->
                 "{TemporalLiteral '"
                         + value.getClass().getName() + " '"

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -278,7 +278,8 @@ import java.util.Set;
  * <td>{@link java.time.Instant}
  * <br>{@link java.time.LocalDate}
  * <br>{@link java.time.LocalDateTime}
- * <br>{@link java.time.LocalTime}</td>
+ * <br>{@link java.time.LocalTime}
+ * <br>{@link java.time.Year}</td>
  * <td></td></tr>
  *
  * <tr style="vertical-align: top; background-color:#eee"><td>Universally unique identifier</td>

--- a/api/src/test/java/jakarta/data/spi/expression/literal/LiteralToStringTest.java
+++ b/api/src/test/java/jakarta/data/spi/expression/literal/LiteralToStringTest.java
@@ -24,6 +24,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Month;
+import java.time.Year;
 import java.time.ZoneId;
 import java.util.UUID;
 
@@ -154,6 +155,9 @@ class LiteralToStringTest {
         TemporalLiteral<LocalTime> timeLiteral =
                 TemporalLiteral.of(LocalTime.of(18, 8, 30));
 
+        TemporalLiteral<Year> yearLiteral =
+                TemporalLiteral.of(Year.of(2025));
+
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(instantLiteral.toString())
                     .isEqualTo("{ts '2025-05-09 21:18:02.575'}");
@@ -166,6 +170,9 @@ class LiteralToStringTest {
 
             soft.assertThat(timeLiteral.toString())
                     .isEqualTo("{t '18:08:30'}");
+
+            soft.assertThat(yearLiteral.toString())
+                    .isEqualTo("{d '2025'}");
         });
     }
 }

--- a/spec/src/main/asciidoc/query-language.asciidoc
+++ b/spec/src/main/asciidoc/query-language.asciidoc
@@ -6,7 +6,7 @@ NOTE: A Jakarta Data provider backed by access to a relational database might ch
 
 === Type system
 
-Every expression in a JDQL query is assigned a Java type. An implementation of JDQL is required to support the Java types listed in <<Basic types>>, that is: primitive types, `String`, `LocalDate`, `LocalDateTime`, `LocalTime`, and `Instant`, `java.util.UUID`, `java.math.BigInteger` and `java.math.BigDecimal`, `byte[]`, and  `enum` types.
+Every expression in a JDQL query is assigned a Java type. An implementation of JDQL is required to support the Java types listed in <<Basic types>>, that is: primitive types, `String`, `LocalDate`, `LocalDateTime`, `LocalTime`, `Year`, and `Instant`, `java.util.UUID`, `java.math.BigInteger` and `java.math.BigDecimal`, `byte[]`, and  `enum` types.
 
 NOTE: An implementation of JDQL is permitted and encouraged to support additional types. Use of such types is not guaranteed to be portable between implementations.
 


### PR DESCRIPTION
#1124 added java.time.Year (which we discussed on the Jakarta Data call and agreed on) to the list of temporal types.

This PR adds the rest of the support for it to the spec.