### PR TITLE
add annotations for declaring lifecycle methods of stateful repositories

### DIFF
--- a/api/src/main/java/jakarta/data/repository/stateful/Detach.java
+++ b/api/src/main/java/jakarta/data/repository/stateful/Detach.java
@@ -17,7 +17,11 @@
  */
 package jakarta.data.repository.stateful;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * <p>Lifecycle annotation for repository methods of stateful repositories

--- a/api/src/main/java/jakarta/data/repository/stateful/Detach.java
+++ b/api/src/main/java/jakarta/data/repository/stateful/Detach.java
@@ -1,0 +1,46 @@
+package jakarta.data.repository.stateful;
+
+import java.lang.annotation.*;
+
+/**
+ * <p>Lifecycle annotation for repository methods of stateful repositories
+ * which perform detach operations. The {@code Detach} annotation must
+ * not be applied to a method of a stateless repository.
+ * </p>
+ * <p>The {@code Detach} annotation indicates that the annotated repository
+ * method immediately makes one or more entities unmanaged, removing them
+ * from the current persistence context associated with the repository.
+ * </p>
+ * <p>An {@code Detach} method accepts an instance or instances of an entity
+ * class. The method must have exactly one parameter whose type is either:
+ * </p>
+ * <ul>
+ *     <li>the class of the entity to be inserted, or</li>
+ *     <li>{@code List<E>} or {@code E[]} where {@code E} is the class of the
+ *     entities to be inserted.</li>
+ * </ul>
+ * <p>The annotated method must be declared {@code void}.
+ * </p>
+ * <p>If an unmanaged entity is passed to a {@code Detach} method, the call
+ * has no effect.
+ * </p>
+ * <p>Every Jakarta Data provider which supports stateful repositories is
+ * required to accept a {@code Detach} method which conforms to this signature.
+ * Application of the {@code Detach} annotation to a method with any other
+ * signature is not portable between Jakarta Data providers. Furthermore,
+ * support for stateful repositories is optional. A Jakarta Data provider
+ * is not required to support stateful repositories.
+ * </p>
+ * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Persist},
+ * {@code @Merge}, {@code @Remove}, {@code @Refresh}, and {@code Detach} are
+ * mutually-exclusive. A given method of a repository interface may have at
+ * most one {@code @Find} annotation, lifecycle annotation, or query annotation.
+ * </p>
+ *
+ * @since 1.1
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@interface Detach {
+}

--- a/api/src/main/java/jakarta/data/repository/stateful/Detach.java
+++ b/api/src/main/java/jakarta/data/repository/stateful/Detach.java
@@ -36,9 +36,9 @@ import java.lang.annotation.Target;
  * class. The method must have exactly one parameter whose type is either:
  * </p>
  * <ul>
- *     <li>the class of the entity to be inserted, or</li>
+ *     <li>the class of the entity to be detached, or</li>
  *     <li>{@code List<E>} or {@code E[]} where {@code E} is the class of the
- *     entities to be inserted.</li>
+ *     entities to be detached.</li>
  * </ul>
  * <p>The annotated method must be declared {@code void}.
  * </p>

--- a/api/src/main/java/jakarta/data/repository/stateful/Detach.java
+++ b/api/src/main/java/jakarta/data/repository/stateful/Detach.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
 package jakarta.data.repository.stateful;
 
 import java.lang.annotation.*;

--- a/api/src/main/java/jakarta/data/repository/stateful/Detach.java
+++ b/api/src/main/java/jakarta/data/repository/stateful/Detach.java
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
  * method immediately makes one or more entities unmanaged, removing them
  * from the current persistence context associated with the repository.
  * </p>
- * <p>An {@code Detach} method accepts an instance or instances of an entity
+ * <p>A {@code Detach} method accepts an instance or instances of an entity
  * class. The method must have exactly one parameter whose type is either:
  * </p>
  * <ul>

--- a/api/src/main/java/jakarta/data/repository/stateful/Merge.java
+++ b/api/src/main/java/jakarta/data/repository/stateful/Merge.java
@@ -17,7 +17,11 @@
  */
 package jakarta.data.repository.stateful;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * <p>Lifecycle annotation for repository methods of stateful repositories

--- a/api/src/main/java/jakarta/data/repository/stateful/Merge.java
+++ b/api/src/main/java/jakarta/data/repository/stateful/Merge.java
@@ -40,9 +40,9 @@ import java.lang.annotation.Target;
  * class. The method must have exactly one parameter whose type is either:
  * </p>
  * <ul>
- *     <li>the class of the entity to be inserted, or</li>
+ *     <li>the class of the entity to be merged, or</li>
  *     <li>{@code List<E>} or {@code E[]} where {@code E} is the class of the
- *     entities to be inserted.</li>
+ *     entities to be merged.</li>
  * </ul>
  * <p>The annotated method must have a return type that is the same as the
  * type of its parameter.

--- a/api/src/main/java/jakarta/data/repository/stateful/Merge.java
+++ b/api/src/main/java/jakarta/data/repository/stateful/Merge.java
@@ -1,0 +1,62 @@
+package jakarta.data.repository.stateful;
+
+import java.lang.annotation.*;
+
+/**
+ * <p>Lifecycle annotation for repository methods of stateful repositories
+ * which perform merge operations. The {@code Merge} annotation must
+ * not be applied to a method of a stateless repository.
+ * </p>
+ * <p>The {@code Merge} annotation indicates that the annotated repository
+ * method copies the state of one of more unmanaged entities to managed
+ * entities belonging to the current persistence context associated with the
+ * repository. The merge might change the persistent state of the managed
+ * entities, and might cause that state to be inserted or updated in the
+ * database. This typically occurs later, when the persistence context is
+ * flushed.
+ * </p>
+ * <p>A {@code Merge} method accepts an instance or instances of an entity
+ * class. The method must have exactly one parameter whose type is either:
+ * </p>
+ * <ul>
+ *     <li>the class of the entity to be inserted, or</li>
+ *     <li>{@code List<E>} or {@code E[]} where {@code E} is the class of the
+ *     entities to be inserted.</li>
+ * </ul>
+ * <p>The annotated method must have a return type that is the same as the
+ * type of its parameter.
+ * </p>
+ * <p>If an instance passed to the method is already managed, the call has no
+ * effect, and the method just returns the argument entity. Otherwise, if the
+ * instance is unmanaged, the method returns a managed entity instance which
+ * must be distinct from the argument entity, but which holds the same
+ * persistent state.
+ * </p>
+ * <p>Every Jakarta Data provider which supports stateful repositories is
+ * required to accept a {@code Merge} method which conforms to this signature.
+ * Application of the {@code Merge} annotation to a method with any other
+ * signature is not portable between Jakarta Data providers. Furthermore,
+ * support for stateful repositories is optional. A Jakarta Data provider is
+ * not required to support stateful repositories.
+ * </p>
+ * <p>An event of type {@link jakarta.data.event.PreInsertEvent} must be
+ * raised before each record is inserted in the database. An event of type
+ * {@link jakarta.data.event.PostInsertEvent} must be raised after each record
+ * is successfully inserted. Similarly, an event of type
+ * {@link jakarta.data.event.PreUpdateEvent} must be raised before each record
+ * is updated. An event of type {@link jakarta.data.event.PostUpdateEvent}
+ * must be raised after each record is successfully updated.
+ * </p>
+ * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Persist},
+ * {@code @Merge}, {@code @Remove}, and {@code @Refresh} are mutually-exclusive.
+ * A given method of a repository interface may have at most one {@code @Find}
+ * annotation, lifecycle annotation, or query annotation.
+ * </p>
+ *
+ * @since 1.1
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@interface Merge {
+}

--- a/api/src/main/java/jakarta/data/repository/stateful/Merge.java
+++ b/api/src/main/java/jakarta/data/repository/stateful/Merge.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
 package jakarta.data.repository.stateful;
 
 import java.lang.annotation.*;

--- a/api/src/main/java/jakarta/data/repository/stateful/Persist.java
+++ b/api/src/main/java/jakarta/data/repository/stateful/Persist.java
@@ -17,7 +17,11 @@
  */
 package jakarta.data.repository.stateful;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * <p>Lifecycle annotation for repository methods of stateful repositories

--- a/api/src/main/java/jakarta/data/repository/stateful/Persist.java
+++ b/api/src/main/java/jakarta/data/repository/stateful/Persist.java
@@ -35,13 +35,13 @@ import java.lang.annotation.Target;
  * when the annotated repository method is invoked, or it might occur later,
  * when the persistence context is flushed.
  * </p>
- * <p>An {@code Insert} method accepts an instance or instances of an entity
+ * <p>An {@code Persist} method accepts an instance or instances of an entity
  * class. The method must have exactly one parameter whose type is either:
  * </p>
  * <ul>
- *     <li>the class of the entity to be inserted, or</li>
+ *     <li>the class of the entity to be persisted, or</li>
  *     <li>{@code List<E>} or {@code E[]} where {@code E} is the class of the
- *     entities to be inserted.</li>
+ *     entities to be persisted.</li>
  * </ul>
  * <p>The annotated method must be declared {@code void}.
  * </p>

--- a/api/src/main/java/jakarta/data/repository/stateful/Persist.java
+++ b/api/src/main/java/jakarta/data/repository/stateful/Persist.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
 package jakarta.data.repository.stateful;
 
 import java.lang.annotation.*;

--- a/api/src/main/java/jakarta/data/repository/stateful/Persist.java
+++ b/api/src/main/java/jakarta/data/repository/stateful/Persist.java
@@ -1,0 +1,57 @@
+package jakarta.data.repository.stateful;
+
+import java.lang.annotation.*;
+
+/**
+ * <p>Lifecycle annotation for repository methods of stateful repositories
+ * which perform persist operations. The {@code Persist} annotation must
+ * not be applied to a method of a stateless repository.
+ * </p>
+ * <p>The {@code Persist} annotation indicates that the annotated repository
+ * method makes one or more entities managed, adding them to the current
+ * persistence context associated with the repository, and schedules the
+ * entities for insertion in the database. Insertion might occur immediately,
+ * when the annotated repository method is invoked, or it might occur later,
+ * when the persistence context is flushed.
+ * </p>
+ * <p>An {@code Insert} method accepts an instance or instances of an entity
+ * class. The method must have exactly one parameter whose type is either:
+ * </p>
+ * <ul>
+ *     <li>the class of the entity to be inserted, or</li>
+ *     <li>{@code List<E>} or {@code E[]} where {@code E} is the class of the
+ *     entities to be inserted.</li>
+ * </ul>
+ * <p>The annotated method must be declared {@code void}.
+ * </p>
+ * <p>If an instance passed to the {@code Persist} method is already managed,
+ * the call has no effect unless the instance was previously scheduled for
+ * deletion via a call to a {@link Remove} method. If the instance was
+ * scheduled for deletion, then the {@code Persist} method undoes the effect
+ * of the {@code Remove} method.
+ * </p>
+ * <p>Every Jakarta Data provider which supports stateful repositories is
+ * required to accept a {@code Persist} method which conforms to this signature.
+ * Application of the {@code Persist} annotation to a method with any other
+ * signature is not portable between Jakarta Data providers. Furthermore,
+ * support for stateful repositories is optional. A Jakarta Data provider
+ * is not required to support stateful repositories.
+ * </p>
+ * <p>An event of type {@link jakarta.data.event.PreInsertEvent} must be
+ * raised before each record is inserted in the database. An event of type
+ * {@link jakarta.data.event.PostInsertEvent} must be raised after each record
+ * is successfully inserted.
+ * </p>
+ * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Persist},
+ * {@code @Merge}, {@code @Remove}, and {@code @Refresh} are mutually-exclusive.
+ * A given method of a repository interface may have at most one {@code @Find}
+ * annotation, lifecycle annotation, or query annotation.
+ * </p>
+ *
+ * @since 1.1
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@interface Persist {
+}

--- a/api/src/main/java/jakarta/data/repository/stateful/Refresh.java
+++ b/api/src/main/java/jakarta/data/repository/stateful/Refresh.java
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
  * method immediately reloads the state of the given entity from the database,
  * overwriting the persistent state previously held by the entity.
  * </p>
- * <p>An {@code Refresh} method accepts a managed instance or instances of an
+ * <p>A {@code Refresh} method accepts a managed instance or instances of an
  * entity class. The method must have exactly one parameter whose type is
  * either:
  * </p>

--- a/api/src/main/java/jakarta/data/repository/stateful/Refresh.java
+++ b/api/src/main/java/jakarta/data/repository/stateful/Refresh.java
@@ -17,7 +17,11 @@
  */
 package jakarta.data.repository.stateful;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * <p>Lifecycle annotation for repository methods of stateful repositories

--- a/api/src/main/java/jakarta/data/repository/stateful/Refresh.java
+++ b/api/src/main/java/jakarta/data/repository/stateful/Refresh.java
@@ -37,9 +37,9 @@ import java.lang.annotation.Target;
  * either:
  * </p>
  * <ul>
- *     <li>the class of the entity to be inserted, or</li>
+ *     <li>the class of the entity to be refreshed, or</li>
  *     <li>{@code List<E>} or {@code E[]} where {@code E} is the class of the
- *     entities to be inserted.</li>
+ *     entities to be refreshed.</li>
  * </ul>
  * <p>The annotated method must be declared {@code void}.
  * </p>

--- a/api/src/main/java/jakarta/data/repository/stateful/Refresh.java
+++ b/api/src/main/java/jakarta/data/repository/stateful/Refresh.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
 package jakarta.data.repository.stateful;
 
 import java.lang.annotation.*;

--- a/api/src/main/java/jakarta/data/repository/stateful/Refresh.java
+++ b/api/src/main/java/jakarta/data/repository/stateful/Refresh.java
@@ -1,0 +1,47 @@
+package jakarta.data.repository.stateful;
+
+import java.lang.annotation.*;
+
+/**
+ * <p>Lifecycle annotation for repository methods of stateful repositories
+ * which perform refresh operations. The {@code Refresh} annotation must
+ * not be applied to a method of a stateless repository.
+ * </p>
+ * <p>The {@code Refresh} annotation indicates that the annotated repository
+ * method immediately reloads the state of the given entity from the database,
+ * overwriting the persistent state previously held by the entity.
+ * </p>
+ * <p>An {@code Refresh} method accepts a managed instance or instances of an
+ * entity class. The method must have exactly one parameter whose type is
+ * either:
+ * </p>
+ * <ul>
+ *     <li>the class of the entity to be inserted, or</li>
+ *     <li>{@code List<E>} or {@code E[]} where {@code E} is the class of the
+ *     entities to be inserted.</li>
+ * </ul>
+ * <p>The annotated method must be declared {@code void}.
+ * </p>
+ * <p>If an unmanaged entity is passed to a {@code Refresh} method, the method
+ * must throw {@link IllegalArgumentException}.
+ * </p>
+ * <p>Every Jakarta Data provider which supports stateful repositories is
+ * required to accept a {@code Refresh} method which conforms to this signature.
+ * Application of the {@code Refresh} annotation to a method with any other
+ * signature is not portable between Jakarta Data providers. Furthermore,
+ * support for stateful repositories is optional. A Jakarta Data provider
+ * is not required to support stateful repositories.
+ * </p>
+ * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Persist},
+ * {@code @Merge}, {@code @Remove}, and {@code @Refresh} are mutually-exclusive.
+ * A given method of a repository interface may have at most one {@code @Find}
+ * annotation, lifecycle annotation, or query annotation.
+ * </p>
+ *
+ * @since 1.1
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@interface Refresh {
+}

--- a/api/src/main/java/jakarta/data/repository/stateful/Remove.java
+++ b/api/src/main/java/jakarta/data/repository/stateful/Remove.java
@@ -17,7 +17,11 @@
  */
 package jakarta.data.repository.stateful;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * <p>Lifecycle annotation for repository methods of stateful repositories

--- a/api/src/main/java/jakarta/data/repository/stateful/Remove.java
+++ b/api/src/main/java/jakarta/data/repository/stateful/Remove.java
@@ -33,7 +33,7 @@ import java.lang.annotation.Target;
  * Deletion might occur immediately, when the annotated repository method is
  * invoked, or it might occur later, when the persistence context is flushed.
  * </p>
- * <p>An {@code Remove} method accepts a managed instance or instances of an
+ * <p>A {@code Remove} method accepts a managed instance or instances of an
  * entity class. The method must have exactly one parameter whose type is
  * either:
  * </p>
@@ -58,9 +58,9 @@ import java.lang.annotation.Target;
  * is not required to support stateful repositories.
  * </p>
  * <p>An event of type {@link jakarta.data.event.PreDeleteEvent} must be
- * raised before each record is inserted in the database. An event of type
+ * raised before each record is deleted from the database. An event of type
  * {@link jakarta.data.event.PreDeleteEvent} must be raised after each record
- * is successfully inserted.
+ * is successfully deleted.
  * </p>
  * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Persist},
  * {@code @Merge}, {@code @Remove}, and {@code @Refresh} are mutually-exclusive.

--- a/api/src/main/java/jakarta/data/repository/stateful/Remove.java
+++ b/api/src/main/java/jakarta/data/repository/stateful/Remove.java
@@ -1,0 +1,56 @@
+package jakarta.data.repository.stateful;
+
+import java.lang.annotation.*;
+
+/**
+ * <p>Lifecycle annotation for repository methods of stateful repositories
+ * which perform remove operations. The {@code Remove} annotation must
+ * not be applied to a method of a stateless repository.
+ * </p>
+ * <p>The {@code Remove} annotation indicates that the annotated repository
+ * method schedules one or more managed entities for deletion in the database.
+ * Deletion might occur immediately, when the annotated repository method is
+ * invoked, or it might occur later, when the persistence context is flushed.
+ * </p>
+ * <p>An {@code Remove} method accepts a managed instance or instances of an
+ * entity class. The method must have exactly one parameter whose type is
+ * either:
+ * </p>
+ * <ul>
+ *     <li>the class of the entity to be inserted, or</li>
+ *     <li>{@code List<E>} or {@code E[]} where {@code E} is the class of the
+ *     entities to be inserted.</li>
+ * </ul>
+ * <p>The annotated method must be declared {@code void}.
+ * </p>
+ * <p>If an unmanaged entity is passed to a {@code Refresh} method, the method
+ * must throw {@link IllegalArgumentException}. If the entity was scheduled for
+ * insertion in the database via a call to a {@link Persist} method, but was
+ * not yet inserted in the database, then the {@code Refresh} method undoes the
+ * effect of the {@code Persist} method.
+ * </p>
+ * <p>Every Jakarta Data provider which supports stateful repositories is
+ * required to accept a {@code Remove} method which conforms to this signature.
+ * Application of the {@code Remove} annotation to a method with any other
+ * signature is not portable between Jakarta Data providers. Furthermore,
+ * support for stateful repositories is optional. A Jakarta Data provider
+ * is not required to support stateful repositories.
+ * </p>
+ * <p>An event of type {@link jakarta.data.event.PreDeleteEvent} must be
+ * raised before each record is inserted in the database. An event of type
+ * {@link jakarta.data.event.PreDeleteEvent} must be raised after each record
+ * is successfully inserted.
+ * </p>
+ * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Persist},
+ * {@code @Merge}, {@code @Remove}, and {@code @Refresh} are mutually-exclusive.
+ * A given method of a repository interface may have at most one {@code @Find}
+ * annotation, lifecycle annotation, or query annotation.
+ * </p>
+ *
+ * @since 1.1
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@interface Remove {
+}

--- a/api/src/main/java/jakarta/data/repository/stateful/Remove.java
+++ b/api/src/main/java/jakarta/data/repository/stateful/Remove.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
 package jakarta.data.repository.stateful;
 
 import java.lang.annotation.*;

--- a/api/src/main/java/jakarta/data/repository/stateful/Remove.java
+++ b/api/src/main/java/jakarta/data/repository/stateful/Remove.java
@@ -38,9 +38,9 @@ import java.lang.annotation.Target;
  * either:
  * </p>
  * <ul>
- *     <li>the class of the entity to be inserted, or</li>
+ *     <li>the class of the entity to be removed, or</li>
  *     <li>{@code List<E>} or {@code E[]} where {@code E} is the class of the
- *     entities to be inserted.</li>
+ *     entities to be removed.</li>
  * </ul>
  * <p>The annotated method must be declared {@code void}.
  * </p>


### PR DESCRIPTION
see #470

Draft for these annotations. Open issues:

1. Do we need `@StatefulRepository` ?
2. How should a `@Remove` method treat an unmanaged entity? Choices are:
    -  error, as I've written here, or 
    - ignore it, if the repository can determine that the entity does not exist in the database, which is what JPA does.
