### PR TITLE
Restrict.all/any methods that accept a list of restrictions

### DIFF
--- a/api/src/main/java/jakarta/data/Order.java
+++ b/api/src/main/java/jakarta/data/Order.java
@@ -104,7 +104,9 @@ public class Order<T> implements Iterable<Sort<? super T>> {
 
     /**
      * <p>Defines a list of {@link Sort} criteria, ordered from highest
-     * precedence to lowest precedence.</p>
+     * precedence to lowest precedence. The instance returned by this method
+     * keeps a {@link List#copyOf(java.util.Collection) copy} of the supplied
+     * {@code List} rather than the original if the list is modifiable.</p>
      *
      * @param <T>   entity class of the attributes that are used as sort
      *              criteria.
@@ -113,7 +115,7 @@ public class Order<T> implements Iterable<Sort<? super T>> {
      * @return a new instance indicating the order of precedence for sort
      * criteria. This method never returns {@code null}.
      */
-    public static <T> Order<T> by(List<Sort<? super T>> sorts) {
+    public static <T> Order<T> by(List<? extends Sort<? super T>> sorts) {
         return new Order<T>(List.copyOf(sorts));
     }
 

--- a/api/src/main/java/jakarta/data/restrict/CompositeRestriction.java
+++ b/api/src/main/java/jakarta/data/restrict/CompositeRestriction.java
@@ -56,7 +56,7 @@ public interface CompositeRestriction<T> extends Restriction<T> {
      *
      * @return the ordered list of restriction.
      */
-    List<Restriction<T>> restrictions();
+    List<Restriction<? super T>> restrictions();
 
     /**
      * <p>Indicates how to combine the list of {@link #restrictions()}.</p>

--- a/api/src/main/java/jakarta/data/restrict/CompositeRestrictionRecord.java
+++ b/api/src/main/java/jakarta/data/restrict/CompositeRestrictionRecord.java
@@ -27,7 +27,7 @@ import jakarta.data.messages.Messages;
 
 record CompositeRestrictionRecord<T>(
         Type type,
-        List<Restriction<T>> restrictions,
+        List<Restriction<? super T>> restrictions,
         boolean isNegated) implements CompositeRestriction<T> {
 
     /**
@@ -52,7 +52,7 @@ record CompositeRestrictionRecord<T>(
         });
     }
 
-    CompositeRestrictionRecord(Type type, List<Restriction<T>> restrictions) {
+    CompositeRestrictionRecord(Type type, List<Restriction<? super T>> restrictions) {
         this(type, restrictions, false);
     }
 
@@ -78,7 +78,7 @@ record CompositeRestrictionRecord<T>(
         }
 
         boolean first = true;
-        for (Restriction<T> restriction : restrictions) {
+        for (Restriction<? super T> restriction : restrictions) {
             if (first) {
                 first = false;
             } else {

--- a/api/src/main/java/jakarta/data/restrict/Restrict.java
+++ b/api/src/main/java/jakarta/data/restrict/Restrict.java
@@ -78,8 +78,10 @@ public class Restrict {
      *                                  includes a {@code null} value.
      */
     @SafeVarargs
-    public static <T> Restriction<T> all(Restriction<T>... restrictions) {
-        return new CompositeRestrictionRecord<>(CompositeRestriction.Type.ALL,
+    public static <T> Restriction<T> all(
+            Restriction<? super T>... restrictions) {
+        return new CompositeRestrictionRecord<T>(
+                CompositeRestriction.Type.ALL,
                 List.of(restrictions));
     }
 
@@ -115,8 +117,10 @@ public class Restrict {
      * @throws NullPointerException     if the supplied restrictions list
      *                                  includes a {@code null} value.
      */
-    public static <T> Restriction<T> all(List<Restriction<T>> restrictions) {
-        return new CompositeRestrictionRecord<>(CompositeRestriction.Type.ALL,
+    public static <T> Restriction<T> all(
+            List<? extends Restriction<? super T>> restrictions) {
+        return new CompositeRestrictionRecord<T>(
+                CompositeRestriction.Type.ALL,
                 List.copyOf(restrictions));
     }
 
@@ -144,8 +148,10 @@ public class Restrict {
      *                                  includes a {@code null} value.
      */
     @SafeVarargs
-    public static <T> Restriction<T> any(Restriction<T>... restrictions) {
-        return new CompositeRestrictionRecord<>(CompositeRestriction.Type.ANY,
+    public static <T> Restriction<T> any(
+            Restriction<? super T>... restrictions) {
+        return new CompositeRestrictionRecord<T>(
+                CompositeRestriction.Type.ANY,
                 List.of(restrictions));
     }
 
@@ -186,8 +192,10 @@ public class Restrict {
      * @throws NullPointerException     if the supplied restrictions array
      *                                  includes a {@code null} value.
      */
-    public static <T> Restriction<T> any(List<Restriction<T>> restrictions) {
-        return new CompositeRestrictionRecord<>(CompositeRestriction.Type.ANY,
+    public static <T> Restriction<T>any(
+            List<? extends Restriction<? super T>> restrictions) {
+        return new CompositeRestrictionRecord<T>(
+                CompositeRestriction.Type.ANY,
                 List.copyOf(restrictions));
     }
 

--- a/api/src/main/java/jakarta/data/restrict/Unmatchable.java
+++ b/api/src/main/java/jakarta/data/restrict/Unmatchable.java
@@ -38,7 +38,7 @@ class Unmatchable<T> implements CompositeRestriction<T> {
     }
 
     @Override
-    public List<Restriction<T>> restrictions() {
+    public List<Restriction<? super T>> restrictions() {
         return List.of();
     }
 

--- a/api/src/main/java/jakarta/data/restrict/Unrestricted.java
+++ b/api/src/main/java/jakarta/data/restrict/Unrestricted.java
@@ -38,7 +38,7 @@ class Unrestricted<T> implements CompositeRestriction<T> {
     }
 
     @Override
-    public List<Restriction<T>> restrictions() {
+    public List<Restriction<? super T>> restrictions() {
         return List.of();
     }
 

--- a/api/src/test/java/jakarta/data/OrderTest.java
+++ b/api/src/test/java/jakarta/data/OrderTest.java
@@ -21,6 +21,10 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import jakarta.data.mock.entity.Book;
+import jakarta.data.mock.entity._Book;
+
+import java.util.ArrayList;
 import java.util.List;
 
 class OrderTest {
@@ -42,11 +46,21 @@ class OrderTest {
     @Test
     @DisplayName("should create Order via list")
     void shouldCreateOrderFromList() {
-        var list = List.of(Sort.desc("priority"));
-        var order = Order.by(list);
 
-        SoftAssertions.assertSoftly(soft ->
-            soft.assertThat(order.sorts()).containsExactlyElementsOf(list));
+        // Do not use var. It was hiding a bug where Order.by(List<Sort<Book>>)
+        // was not being allowed.
+
+        List<Sort<Book>> list = new ArrayList<>();
+        list.add(_Book.title.asc());
+        list.add(_Book.publicationDate.desc());
+        list.add(_Book.id.asc());
+
+        Order<Book> order = Order.by(list);
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(order.sorts())
+                .containsExactlyElementsOf(list);
+        });
     }
 
     @Test

--- a/api/src/test/java/jakarta/data/restrict/CompositeRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/restrict/CompositeRestrictionRecordTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
+import java.util.ArrayList;
 import java.util.List;
 
 
@@ -56,6 +57,30 @@ class CompositeRestrictionRecordTest {
         String firstName;
         String lastName;
         String name;
+    }
+
+    @Test
+    @DisplayName("Create a composite restriction from a list of restrictions")
+    void shouldCreateCompositeRestrictionFromList() {
+
+        List<Restriction<Author>> restrictionList = new ArrayList<>();
+        restrictionList.add(_Author.age.lessThan(30));
+        restrictionList.add(_Author.titleOfFirstBook.contains("Jakarta EE"));
+
+        Restriction<Author> restriction = Restrict.all(restrictionList);
+        CompositeRestriction<Author> composite =
+                (CompositeRestriction<Author>) restriction;
+
+        SoftAssertions.assertSoftly(soft -> {
+            soft.assertThat(composite.type())
+                .isEqualTo(CompositeRestriction.Type.ALL);
+
+            soft.assertThat(composite.isNegated())
+                .isFalse();
+
+            soft.assertThat(composite.restrictions())
+                .containsExactlyElementsOf(restrictionList);
+        });
     }
 
     @Test
@@ -235,8 +260,7 @@ class CompositeRestrictionRecordTest {
         restrictionsWithNull.add(_Author.name.equalTo("Jane Doe"));
         restrictionsWithNull.add(null);
 
-        assertThatThrownBy(() -> new CompositeRestrictionRecord<>(
-                CompositeRestriction.Type.ANY, restrictionsWithNull))
+        assertThatThrownBy(() -> Restrict.any(restrictionsWithNull))
                 .isInstanceOf(NullPointerException.class);
     }
 


### PR DESCRIPTION
A common use of Restriction will be when applications present their users with customizable filtering.  For these cases, the application will need to look through all of the various filtering options that might or might not be used and build up a composite restriction based on that.  When the application doesn't know in advance which filtering will be chosen, it will help if we offer forms of the `all` and `any` methods that accept a list rather than the varags array.  This will allow applications to write code such as,

```
if (maxPrice.isPresent())
    restrictionList.add(_Product.price.lessThanEqual(maxPrice.get()));
if (minPrice.isPresent())
    restrictionList.add(_Product.price.greaterThanEqual(minPrice.get()));
if ...

found = products.search(..., Restrict.all(restrictionList), Order.by(sortList));
```
