### PR TITLE
Consistent names for GTE and LTE

### DIFF
--- a/api/src/main/java/jakarta/data/constraint/Constraint.java
+++ b/api/src/main/java/jakarta/data/constraint/Constraint.java
@@ -89,12 +89,12 @@ public interface Constraint<V> {
         return LessThan.bound(bound);
     }
 
-    static <V extends Comparable<?>> GreaterThanOrEqual<V> greaterThanOrEqual(V bound) {
-        return GreaterThanOrEqual.min(bound);
+    static <V extends Comparable<?>> GreaterThanEqual<V> greaterThanEqual(V bound) {
+        return GreaterThanEqual.min(bound);
     }
 
-    static <V extends Comparable<?>> LessThanOrEqual<V> lessThanOrEqual(V bound) {
-        return LessThanOrEqual.max(bound);
+    static <V extends Comparable<?>> LessThanEqual<V> lessThanEqual(V bound) {
+        return LessThanEqual.max(bound);
     }
 
     static <V extends Comparable<?>> Between<V> between(V lowerBound, V upperBound) {

--- a/api/src/main/java/jakarta/data/constraint/GreaterThanEqual.java
+++ b/api/src/main/java/jakarta/data/constraint/GreaterThanEqual.java
@@ -20,16 +20,16 @@ package jakarta.data.constraint;
 import jakarta.data.expression.ComparableExpression;
 import jakarta.data.spi.expression.literal.ComparableLiteral;
 
-public interface GreaterThanOrEqual<V extends Comparable<?>> extends Constraint<V> {
+public interface GreaterThanEqual<V extends Comparable<?>> extends Constraint<V> {
 
-    static <V extends Comparable<?>> GreaterThanOrEqual<V> min(
+    static <V extends Comparable<?>> GreaterThanEqual<V> min(
             V minimum) {
-        return new GreaterThanOrEqualRecord<>(ComparableLiteral.of(minimum));
+        return new GreaterThanEqualRecord<>(ComparableLiteral.of(minimum));
     }
 
-    static <V extends Comparable<?>> GreaterThanOrEqual<V> min(
+    static <V extends Comparable<?>> GreaterThanEqual<V> min(
             ComparableExpression<?, V> minimum) {
-        return new GreaterThanOrEqualRecord<>(minimum);
+        return new GreaterThanEqualRecord<>(minimum);
     }
 
     ComparableExpression<?, V> bound();

--- a/api/src/main/java/jakarta/data/constraint/GreaterThanEqualRecord.java
+++ b/api/src/main/java/jakarta/data/constraint/GreaterThanEqualRecord.java
@@ -18,19 +18,25 @@
 package jakarta.data.constraint;
 
 import jakarta.data.expression.ComparableExpression;
-import jakarta.data.spi.expression.literal.ComparableLiteral;
+import jakarta.data.messages.Messages;
 
-public interface LessThanOrEqual<V extends Comparable<?>> extends Constraint<V> {
-
-    static <V extends Comparable<?>> LessThanOrEqual<V> max(
-            V maximum) {
-        return new LessThanOrEqualRecord<>(ComparableLiteral.of(maximum));
+record GreaterThanEqualRecord<V extends Comparable<?>>(
+        ComparableExpression<?, V> bound)
+        implements GreaterThanEqual<V> {
+    public GreaterThanEqualRecord {
+        if (bound == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "minimum"));
+        }
     }
 
-    static <V extends Comparable<?>> LessThanOrEqual<V> max(
-            ComparableExpression<?, V> maximum) {
-        return new LessThanOrEqualRecord<>(maximum);
+    @Override
+    public LessThan<V> negate() {
+        return LessThan.bound(bound);
     }
 
-    ComparableExpression<?, V> bound();
+    @Override
+    public String toString() {
+        return ">= " + bound.toString();
+    }
 }

--- a/api/src/main/java/jakarta/data/constraint/GreaterThanRecord.java
+++ b/api/src/main/java/jakarta/data/constraint/GreaterThanRecord.java
@@ -31,8 +31,8 @@ record GreaterThanRecord<V extends Comparable<?>>(
     }
 
     @Override
-    public LessThanOrEqual<V> negate() {
-        return LessThanOrEqual.max(bound);
+    public LessThanEqual<V> negate() {
+        return LessThanEqual.max(bound);
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/constraint/LessThanEqual.java
+++ b/api/src/main/java/jakarta/data/constraint/LessThanEqual.java
@@ -18,25 +18,19 @@
 package jakarta.data.constraint;
 
 import jakarta.data.expression.ComparableExpression;
-import jakarta.data.messages.Messages;
+import jakarta.data.spi.expression.literal.ComparableLiteral;
 
-record GreaterThanOrEqualRecord<V extends Comparable<?>>(
-        ComparableExpression<?, V> bound)
-        implements GreaterThanOrEqual<V> {
-    public GreaterThanOrEqualRecord {
-        if (bound == null) {
-            throw new NullPointerException(
-                    Messages.get("001.arg.required", "minimum"));
-        }
+public interface LessThanEqual<V extends Comparable<?>> extends Constraint<V> {
+
+    static <V extends Comparable<?>> LessThanEqual<V> max(
+            V maximum) {
+        return new LessThanEqualRecord<>(ComparableLiteral.of(maximum));
     }
 
-    @Override
-    public LessThan<V> negate() {
-        return LessThan.bound(bound);
+    static <V extends Comparable<?>> LessThanEqual<V> max(
+            ComparableExpression<?, V> maximum) {
+        return new LessThanEqualRecord<>(maximum);
     }
 
-    @Override
-    public String toString() {
-        return ">= " + bound.toString();
-    }
+    ComparableExpression<?, V> bound();
 }

--- a/api/src/main/java/jakarta/data/constraint/LessThanEqualRecord.java
+++ b/api/src/main/java/jakarta/data/constraint/LessThanEqualRecord.java
@@ -20,10 +20,10 @@ package jakarta.data.constraint;
 import jakarta.data.expression.ComparableExpression;
 import jakarta.data.messages.Messages;
 
-record LessThanOrEqualRecord<V extends Comparable<?>>(
+record LessThanEqualRecord<V extends Comparable<?>>(
         ComparableExpression<?, V> bound)
-        implements LessThanOrEqual<V> {
-    public LessThanOrEqualRecord {
+        implements LessThanEqual<V> {
+    public LessThanEqualRecord {
         if (bound == null) {
             throw new NullPointerException(
                     Messages.get("001.arg.required", "maximum"));

--- a/api/src/main/java/jakarta/data/constraint/LessThanRecord.java
+++ b/api/src/main/java/jakarta/data/constraint/LessThanRecord.java
@@ -30,8 +30,8 @@ record LessThanRecord<V extends Comparable<?>>(ComparableExpression<?, V> bound)
     }
 
     @Override
-    public GreaterThanOrEqual<V> negate() {
-        return GreaterThanOrEqual.min(bound);
+    public GreaterThanEqual<V> negate() {
+        return GreaterThanEqual.min(bound);
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/expression/ComparableExpression.java
+++ b/api/src/main/java/jakarta/data/expression/ComparableExpression.java
@@ -19,9 +19,9 @@ package jakarta.data.expression;
 
 import jakarta.data.constraint.Between;
 import jakarta.data.constraint.GreaterThan;
-import jakarta.data.constraint.GreaterThanOrEqual;
+import jakarta.data.constraint.GreaterThanEqual;
 import jakarta.data.constraint.LessThan;
-import jakarta.data.constraint.LessThanOrEqual;
+import jakarta.data.constraint.LessThanEqual;
 import jakarta.data.constraint.NotBetween;
 import jakarta.data.metamodel.Attribute;
 import jakarta.data.restrict.BasicRestriction;
@@ -148,7 +148,7 @@ public interface ComparableExpression<T, V extends Comparable<?>>
      * @throws NullPointerException if the value is {@code null}.
      */
     default Restriction<T> greaterThanEqual(V value) {
-        return BasicRestriction.of(this, GreaterThanOrEqual.min(value));
+        return BasicRestriction.of(this, GreaterThanEqual.min(value));
     }
 
     /**
@@ -169,7 +169,7 @@ public interface ComparableExpression<T, V extends Comparable<?>>
      * @throws NullPointerException if the expression is {@code null}.
      */
     default Restriction<T> greaterThanEqual(ComparableExpression<? super T, V> expression) {
-        return BasicRestriction.of(this, GreaterThanOrEqual.min(expression));
+        return BasicRestriction.of(this, GreaterThanEqual.min(expression));
     }
 
     /**
@@ -225,7 +225,7 @@ public interface ComparableExpression<T, V extends Comparable<?>>
      * @throws NullPointerException if the value is {@code null}.
      */
     default Restriction<T> lessThanEqual(V value) {
-        return BasicRestriction.of(this, LessThanOrEqual.max(value));
+        return BasicRestriction.of(this, LessThanEqual.max(value));
     }
 
     /**
@@ -246,7 +246,7 @@ public interface ComparableExpression<T, V extends Comparable<?>>
      * @throws NullPointerException if the expression is {@code null}.
      */
     default Restriction<T> lessThanEqual(ComparableExpression<? super T, V> expression) {
-        return BasicRestriction.of(this, LessThanOrEqual.max(expression));
+        return BasicRestriction.of(this, LessThanEqual.max(expression));
     }
 
     /**

--- a/api/src/main/java/jakarta/data/restrict/Restriction.java
+++ b/api/src/main/java/jakarta/data/restrict/Restriction.java
@@ -19,7 +19,7 @@ package jakarta.data.restrict;
 
 import jakarta.data.constraint.Constraint;
 import jakarta.data.constraint.GreaterThan;
-import jakarta.data.constraint.LessThanOrEqual;
+import jakarta.data.constraint.LessThanEqual;
 import jakarta.data.constraint.Like;
 import jakarta.data.constraint.NotLike;
 import jakarta.data.metamodel.Attribute;
@@ -92,7 +92,7 @@ public interface Restriction<T> {
      *
      * <p>For example, a basic restriction that represents an
      * {@linkplain GreaterThan exclusive upper bound} on a value is negated
-     * as an {@linkplain LessThanOrEqual inclusive lower bound} on the value.
+     * as an {@linkplain LessThanEqual inclusive lower bound} on the value.
      * </p>
      *
      * <p>A basic restriction that represents {@linkplain Like matching} a

--- a/api/src/test/java/jakarta/data/expression/ExpressionTest.java
+++ b/api/src/test/java/jakarta/data/expression/ExpressionTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import jakarta.data.constraint.EqualTo;
-import jakarta.data.constraint.LessThanOrEqual;
+import jakarta.data.constraint.LessThanEqual;
 import jakarta.data.mock.entity.Book;
 import jakarta.data.mock.entity._Book;
 import jakarta.data.restrict.BasicRestriction;
@@ -137,8 +137,8 @@ class ExpressionTest {
         BasicRestriction<Book, Integer> restriction =
             (BasicRestriction<Book, Integer>) titleUpTo50Chars;
 
-        LessThanOrEqual<Integer> constraint =
-            (LessThanOrEqual<Integer>) restriction.constraint();
+        LessThanEqual<Integer> constraint =
+            (LessThanEqual<Integer>) restriction.constraint();
 
         NumericLiteral<?> literal =
             (NumericLiteral<?>) constraint.bound();

--- a/api/src/test/java/jakarta/data/expression/NumericExpressionTest.java
+++ b/api/src/test/java/jakarta/data/expression/NumericExpressionTest.java
@@ -47,8 +47,8 @@ class NumericExpressionTest {
                 (BasicRestriction<Book, Integer>)
                         averageChapterAtLeastAsLongAsNumChapters;
 
-        GreaterThanOrEqual<Integer> gteNumChapters =
-                (GreaterThanOrEqual<Integer>) restriction.constraint();
+        GreaterThanEqual<Integer> gteNumChapters =
+                (GreaterThanEqual<Integer>) restriction.constraint();
 
         NumericOperatorExpression<Book, Integer> divide =
                 (NumericOperatorExpression<Book, Integer>) restriction.expression();

--- a/api/src/test/java/jakarta/data/metamodel/ComparableAttributeTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/ComparableAttributeTest.java
@@ -20,9 +20,9 @@ package jakarta.data.metamodel;
 import jakarta.data.constraint.Between;
 import jakarta.data.constraint.Constraint;
 import jakarta.data.constraint.GreaterThan;
-import jakarta.data.constraint.GreaterThanOrEqual;
+import jakarta.data.constraint.GreaterThanEqual;
 import jakarta.data.constraint.LessThan;
-import jakarta.data.constraint.LessThanOrEqual;
+import jakarta.data.constraint.LessThanEqual;
 import jakarta.data.restrict.BasicRestriction;
 
 import org.assertj.core.api.SoftAssertions;
@@ -64,8 +64,8 @@ class ComparableAttributeTest {
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
             soft.assertThat(restriction.expression()).isEqualTo(testAttribute);
-            soft.assertThat(restriction.constraint()).isInstanceOf(GreaterThanOrEqual.class);
-            soft.assertThat(restriction.constraint()).isEqualTo(Constraint.greaterThanOrEqual(10));
+            soft.assertThat(restriction.constraint()).isInstanceOf(GreaterThanEqual.class);
+            soft.assertThat(restriction.constraint()).isEqualTo(Constraint.greaterThanEqual(10));
         });
     }
 
@@ -84,7 +84,7 @@ class ComparableAttributeTest {
     }
 
     @Test
-    void shouldCreateLessThanOrEqualRestriction() {
+    void shouldCreateLessThanEqualRestriction() {
         @SuppressWarnings("unchecked")
         BasicRestriction<Person, Integer> restriction =
                 (BasicRestriction<Person, Integer>) testAttribute.lessThanEqual(10);
@@ -92,8 +92,8 @@ class ComparableAttributeTest {
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
             soft.assertThat(restriction.expression()).isEqualTo(testAttribute);
-            soft.assertThat(restriction.constraint()).isInstanceOf(LessThanOrEqual.class);
-            soft.assertThat(restriction.constraint()).isEqualTo(Constraint.lessThanOrEqual(10));
+            soft.assertThat(restriction.constraint()).isInstanceOf(LessThanEqual.class);
+            soft.assertThat(restriction.constraint()).isEqualTo(Constraint.lessThanEqual(10));
         });
     }
 

--- a/api/src/test/java/jakarta/data/metamodel/ComparableExpressionTest.java
+++ b/api/src/test/java/jakarta/data/metamodel/ComparableExpressionTest.java
@@ -19,9 +19,9 @@ package jakarta.data.metamodel;
 
 import jakarta.data.constraint.Between;
 import jakarta.data.constraint.GreaterThan;
-import jakarta.data.constraint.GreaterThanOrEqual;
+import jakarta.data.constraint.GreaterThanEqual;
 import jakarta.data.constraint.LessThan;
-import jakarta.data.constraint.LessThanOrEqual;
+import jakarta.data.constraint.LessThanEqual;
 import jakarta.data.constraint.NotBetween;
 import jakarta.data.expression.ComparableExpression;
 import jakarta.data.restrict.BasicRestriction;
@@ -72,7 +72,7 @@ class ComparableExpressionTest {
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
-            soft.assertThat(((BasicRestriction<?, ?>) restriction).constraint()).isEqualTo(GreaterThanOrEqual.min(65));
+            soft.assertThat(((BasicRestriction<?, ?>) restriction).constraint()).isEqualTo(GreaterThanEqual.min(65));
         });
     }
 
@@ -111,7 +111,7 @@ class ComparableExpressionTest {
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
             soft.assertThat(((BasicRestriction<?, ?>) restriction).constraint())
-                    .isEqualTo(LessThanOrEqual.max(60));
+                    .isEqualTo(LessThanEqual.max(60));
         });
     }
 
@@ -160,7 +160,7 @@ class ComparableExpressionTest {
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
             soft.assertThat(((BasicRestriction<?, ?>) restriction).constraint())
-                    .isEqualTo(GreaterThanOrEqual.min(_Person.age));
+                    .isEqualTo(GreaterThanEqual.min(_Person.age));
         });
     }
 
@@ -184,7 +184,7 @@ class ComparableExpressionTest {
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction).isInstanceOf(BasicRestriction.class);
             soft.assertThat(((BasicRestriction<?, ?>) restriction).constraint())
-                    .isEqualTo(LessThanOrEqual.max(_Person.age));
+                    .isEqualTo(LessThanEqual.max(_Person.age));
         });
     }
 

--- a/api/src/test/java/jakarta/data/restrict/BasicRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/restrict/BasicRestrictionRecordTest.java
@@ -20,10 +20,10 @@ package jakarta.data.restrict;
 import jakarta.data.constraint.Between;
 import jakarta.data.constraint.EqualTo;
 import jakarta.data.constraint.GreaterThan;
-import jakarta.data.constraint.GreaterThanOrEqual;
+import jakarta.data.constraint.GreaterThanEqual;
 import jakarta.data.constraint.In;
 import jakarta.data.constraint.LessThan;
-import jakarta.data.constraint.LessThanOrEqual;
+import jakarta.data.constraint.LessThanEqual;
 import jakarta.data.constraint.Like;
 import jakarta.data.constraint.NotBetween;
 import jakarta.data.constraint.NotEqualTo;
@@ -73,15 +73,15 @@ class BasicRestrictionRecordTest {
     }
 
     @Test
-    @DisplayName("should negate LessThanOrEqual into GreaterThan")
+    @DisplayName("should negate LessThanEqual into GreaterThan")
     void shouldNegateLTERestriction() {
         var lessThanEqual = (BasicRestriction<Book, Integer>) _Book.numChapters.lessThanEqual(10);
         var negated = (BasicRestriction<Book, Integer>) lessThanEqual.negate();
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(lessThanEqual.expression()).isEqualTo(_Book.numChapters);
-            soft.assertThat(lessThanEqual.constraint()).isEqualTo(LessThanOrEqual.max(10));
-            soft.assertThat(lessThanEqual.constraint()).isInstanceOf(LessThanOrEqual.class);
+            soft.assertThat(lessThanEqual.constraint()).isEqualTo(LessThanEqual.max(10));
+            soft.assertThat(lessThanEqual.constraint()).isInstanceOf(LessThanEqual.class);
 
             soft.assertThat(negated.expression()).isEqualTo(_Book.numChapters);
             soft.assertThat(negated.constraint()).isEqualTo(GreaterThan.bound(10));
@@ -150,14 +150,14 @@ class BasicRestrictionRecordTest {
     }
 
     @Test
-    @DisplayName("should create GreaterThanOrEqual restriction correctly")
-    void shouldCreateGreaterThanOrEqualRestriction() {
+    @DisplayName("should create GreaterThanEqual restriction correctly")
+    void shouldCreateGreaterThanEqualRestriction() {
         var restriction = (BasicRestriction<Book, Integer>) _Book.numPages.greaterThanEqual(200);
 
         SoftAssertions.assertSoftly(soft -> {
             soft.assertThat(restriction.expression()).isEqualTo(_Book.numPages);
-            soft.assertThat(restriction.constraint()).isEqualTo(GreaterThanOrEqual.min(200));
-            soft.assertThat(restriction.constraint()).isInstanceOf(GreaterThanOrEqual.class);
+            soft.assertThat(restriction.constraint()).isEqualTo(GreaterThanEqual.min(200));
+            soft.assertThat(restriction.constraint()).isInstanceOf(GreaterThanEqual.class);
         });
     }
 


### PR DESCRIPTION
In some places (Restrictions, Expressions, Query by Method Name), we use names `GreaterThanEqual`, `LessThanEqual`, `greaterThanEqual(value)`, `lessThanEqual(value)`.
In Constraints, we have a slightly different form: `GreaterThanOrEqual` and `LessThanOrEqual`.
This PR makes all of the names consistent.