### PR TITLE
Suppress PMD complaints about non-FunctionalInterfaces

### DIFF
--- a/api/src/main/resources/rules.xml
+++ b/api/src/main/resources/rules.xml
@@ -25,6 +25,13 @@
 
     <rule ref="category/java/bestpractices.xml">
         <exclude name="AbstractClassWithoutAbstractMethod"/>
+        <!-- The PMD checker doesn't believe we omitted @FunctionalInterface
+             from interfaces on purpose unless we explicitly tell it so with
+             @SuppressWarnings("PMD.ImplicitFunctionalInterface"), which gives
+             the impression the interface is implicitly a FunctionalInterface.
+             It is not, so I'm excluding the checking.
+         -->
+        <exclude name="ImplicitFunctionalInterface"/>
     </rule>
     <rule ref="category/java/security.xml"/>
     <rule ref="category/java/performance.xml">


### PR DESCRIPTION
When I tried to build the project locally, it failed with,

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-pmd-plugin:3.27.0:check (default) on project jakarta.data-api: PMD 7.14.0 has found 16 violations. For more details see: /Users/njr/lgit/data/api/target/pmd.xml -> [Help 1]
```

Here are the violations:
```
<file name="/Users/njr/lgit/data/api/src/main/java/jakarta/data/constraint/Constraint.java">
<violation beginline="22" endline="22" begincolumn="8" endcolumn="17" rule="ImplicitFunctionalInterface" ruleset="Best Practices" package="jakarta.data.constraint" class="Constraint" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.14.0/pmd_rules_java_bestpractices.html#implicitfunctionalinterface" priority="2">
Annotate this interface with @FunctionalInterface or with @SuppressWarnings("PMD.ImplicitFunctionalInterface") to clarify your intent.
</violation>
</file>
<file name="/Users/njr/lgit/data/api/src/main/java/jakarta/data/constraint/NotNull.java">
<violation beginline="20" endline="20" begincolumn="8" endcolumn="17" rule="ImplicitFunctionalInterface" ruleset="Best Practices" package="jakarta.data.constraint" class="NotNull" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.14.0/pmd_rules_java_bestpractices.html#implicitfunctionalinterface" priority="2">
</violation>
</file>
<file name="/Users/njr/lgit/data/api/src/main/java/jakarta/data/constraint/Null.java">
<violation beginline="20" endline="20" begincolumn="8" endcolumn="17" rule="ImplicitFunctionalInterface" ruleset="Best Practices" package="jakarta.data.constraint" class="Null" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.14.0/pmd_rules_java_bestpractices.html#implicitfunctionalinterface" priority="2">
Annotate this interface with @FunctionalInterface or with @SuppressWarnings("PMD.ImplicitFunctionalInterface") to clarify your intent.
</violation>
</file>
<file name="/Users/njr/lgit/data/api/src/main/java/jakarta/data/metamodel/Attribute.java">
<violation beginline="110" endline="110" begincolumn="8" endcolumn="17" rule="ImplicitFunctionalInterface" ruleset="Best Practices" package="jakarta.data.metamodel" class="Attribute" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.14.0/pmd_rules_java_bestpractices.html#implicitfunctionalinterface" priority="2">
Annotate this interface with @FunctionalInterface or with @SuppressWarnings("PMD.ImplicitFunctionalInterface") to clarify your intent.
</violation>
</file>
<file name="/Users/njr/lgit/data/api/src/main/java/jakarta/data/metamodel/BasicAttribute.java">
<violation beginline="31" endline="31" begincolumn="8" endcolumn="17" rule="ImplicitFunctionalInterface" ruleset="Best Practices" package="jakarta.data.metamodel" class="BasicAttribute" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.14.0/pmd_rules_java_bestpractices.html#implicitfunctionalinterface" priority="2">
Annotate this interface with @FunctionalInterface or with @SuppressWarnings("PMD.ImplicitFunctionalInterface") to clarify your intent.
</violation>
</file>
<file name="/Users/njr/lgit/data/api/src/main/java/jakarta/data/metamodel/ComparableAttribute.java">
<violation beginline="62" endline="62" begincolumn="8" endcolumn="17" rule="ImplicitFunctionalInterface" ruleset="Best Practices" package="jakarta.data.metamodel" class="ComparableAttribute" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.14.0/pmd_rules_java_bestpractices.html#implicitfunctionalinterface" priority="2">
Annotate this interface with @FunctionalInterface or with @SuppressWarnings("PMD.ImplicitFunctionalInterface") to clarify your intent.
</violation>
</file>
<file name="/Users/njr/lgit/data/api/src/main/java/jakarta/data/metamodel/NumericAttribute.java">
<violation beginline="50" endline="50" begincolumn="8" endcolumn="17" rule="ImplicitFunctionalInterface" ruleset="Best Practices" package="jakarta.data.metamodel" class="NumericAttribute" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.14.0/pmd_rules_java_bestpractices.html#implicitfunctionalinterface" priority="2">
Annotate this interface with @FunctionalInterface or with @SuppressWarnings("PMD.ImplicitFunctionalInterface") to clarify your intent.
</violation>
</file>
<file name="/Users/njr/lgit/data/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java">
<violation beginline="39" endline="39" begincolumn="8" endcolumn="17" rule="ImplicitFunctionalInterface" ruleset="Best Practices" package="jakarta.data.metamodel" class="SortableAttribute" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.14.0/pmd_rules_java_bestpractices.html#implicitfunctionalinterface" priority="2">
Annotate this interface with @FunctionalInterface or with @SuppressWarnings("PMD.ImplicitFunctionalInterface") to clarify your intent.
</violation>
</file>
<file name="/Users/njr/lgit/data/api/src/main/java/jakarta/data/metamodel/TemporalAttribute.java">
<violation beginline="49" endline="49" begincolumn="8" endcolumn="17" rule="ImplicitFunctionalInterface" ruleset="Best Practices" package="jakarta.data.metamodel" class="TemporalAttribute" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.14.0/pmd_rules_java_bestpractices.html#implicitfunctionalinterface" priority="2">
Annotate this interface with @FunctionalInterface or with @SuppressWarnings("PMD.ImplicitFunctionalInterface") to clarify your intent.
</violation>
</file>
<file name="/Users/njr/lgit/data/api/src/main/java/jakarta/data/metamodel/TextAttribute.java">
<violation beginline="30" endline="30" begincolumn="8" endcolumn="17" rule="ImplicitFunctionalInterface" ruleset="Best Practices" package="jakarta.data.metamodel" class="TextAttribute" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.14.0/pmd_rules_java_bestpractices.html#implicitfunctionalinterface" priority="2">
Annotate this interface with @FunctionalInterface or with @SuppressWarnings("PMD.ImplicitFunctionalInterface") to clarify your intent.
</violation>
</file>
<file name="/Users/njr/lgit/data/api/src/main/java/jakarta/data/restrict/Restriction.java">
<violation beginline="88" endline="88" begincolumn="8" endcolumn="17" rule="ImplicitFunctionalInterface" ruleset="Best Practices" package="jakarta.data.restrict" class="Restriction" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.14.0/pmd_rules_java_bestpractices.html#implicitfunctionalinterface" priority="2">
Annotate this interface with @FunctionalInterface or with @SuppressWarnings("PMD.ImplicitFunctionalInterface") to clarify your intent.
</violation>
</file>
<file name="/Users/njr/lgit/data/api/src/main/java/jakarta/data/spi/expression/literal/ComparableLiteral.java">
<violation beginline="39" endline="39" begincolumn="8" endcolumn="17" rule="ImplicitFunctionalInterface" ruleset="Best Practices" package="jakarta.data.spi.expression.literal" class="ComparableLiteral" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.14.0/pmd_rules_java_bestpractices.html#implicitfunctionalinterface" priority="2">
Annotate this interface with @FunctionalInterface or with @SuppressWarnings("PMD.ImplicitFunctionalInterface") to clarify your intent.
</violation>
</file>
<file name="/Users/njr/lgit/data/api/src/main/java/jakarta/data/spi/expression/literal/Literal.java">
<violation beginline="35" endline="35" begincolumn="8" endcolumn="17" rule="ImplicitFunctionalInterface" ruleset="Best Practices" package="jakarta.data.spi.expression.literal" class="Literal" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.14.0/pmd_rules_java_bestpractices.html#implicitfunctionalinterface" priority="2">
Annotate this interface with @FunctionalInterface or with @SuppressWarnings("PMD.ImplicitFunctionalInterface") to clarify your intent.
</violation>
</file>
<file name="/Users/njr/lgit/data/api/src/main/java/jakarta/data/spi/expression/literal/NumericLiteral.java">
<violation beginline="33" endline="33" begincolumn="8" endcolumn="17" rule="ImplicitFunctionalInterface" ruleset="Best Practices" package="jakarta.data.spi.expression.literal" class="NumericLiteral" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.14.0/pmd_rules_java_bestpractices.html#implicitfunctionalinterface" priority="2">
Annotate this interface with @FunctionalInterface or with @SuppressWarnings("PMD.ImplicitFunctionalInterface") to clarify your intent.
</violation>
</file>
<file name="/Users/njr/lgit/data/api/src/main/java/jakarta/data/spi/expression/literal/StringLiteral.java">
<violation beginline="27" endline="27" begincolumn="8" endcolumn="17" rule="ImplicitFunctionalInterface" ruleset="Best Practices" package="jakarta.data.spi.expression.literal" class="StringLiteral" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.14.0/pmd_rules_java_bestpractices.html#implicitfunctionalinterface" priority="2">
Annotate this interface with @FunctionalInterface or with @SuppressWarnings("PMD.ImplicitFunctionalInterface") to clarify your intent.
</violation>
</file>
<file name="/Users/njr/lgit/data/api/src/main/java/jakarta/data/spi/expression/literal/TemporalLiteral.java">
<violation beginline="38" endline="38" begincolumn="8" endcolumn="17" rule="ImplicitFunctionalInterface" ruleset="Best Practices" package="jakarta.data.spi.expression.literal" class="TemporalLiteral" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.14.0/pmd_rules_java_bestpractices.html#implicitfunctionalinterface" priority="2">
Annotate this interface with @FunctionalInterface or with @SuppressWarnings("PMD.ImplicitFunctionalInterface") to clarify your intent.
</violation>
</file>
```

PMD is complaining that we might have forgotten to put `@FunctionalInterface` onto many of our interface classes. It is complaining because it didn't use a special `@SuppressWarnings("PMD.ImplicitFunctionalInterface")` everywhere to tell it otherwise. I don't want to put that everywhere because it seems confusing, so I'm proposing that we suppress the checking for this violation.
