### PR TITLE
Attribute has wrong javadoc and should use message file for error

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/Attribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/Attribute.java
@@ -17,6 +17,8 @@
  */
 package jakarta.data.metamodel;
 
+import jakarta.data.messages.Messages;
+
 /**
  * <p>Supertype for {@link StaticMetamodel} fields representing entity
  * attributes.</p>
@@ -125,36 +127,28 @@ public interface Attribute<T> {
      * @throws UnsupportedOperationException if the declaring type is not
      *                                       known.
      * @apiNote This is only guaranteed to be known if a static <code>of</code>
-     * method, such as {@link BasicAttribute#of(Class, String, Class)}, was used
-     * to obtain the instance.
+     *          method, such as {@link BasicAttribute#of(Class, String, Class)},
+     *          was used to obtain the instance.
      * @since 1.1
      */
     default Class<T> declaringType() {
-        throw new UnsupportedOperationException(getClass().getName() + """
-                 was obtained in a way that does not identify the entity class\
-                 that declares the attribute. Static metamodel classes should\
-                 use the .of method that is defined on the Attribute subtype\
-                 to provide the entity class.\
-                """);
+        throw new UnsupportedOperationException(
+                Messages.get("012.unknown.decl.type", getClass().getName()));
     }
 
     /**
-     * Obtain the Java class which declares this entity attribute.
+     * Obtain the Java class of the entity attribute.
      *
-     * @return the declaring class
-     * @throws UnsupportedOperationException if the declaring type is not
-     *                                       known.
+     * @return the type of the entity attribute.
+     * @throws UnsupportedOperationException if the entity attribute type is
+     *                                       not known.
      * @apiNote This is only guaranteed to be known if a static <code>of</code>
-     * method, such as {@link BasicAttribute#of(Class, String, Class)}, was used
-     * to obtain the instance.
+     *          method, such as {@link BasicAttribute#of(Class, String, Class)},
+     *          was used to obtain the instance.
      * @since 1.1
      */
     default Class<?> attributeType() {
-        throw new UnsupportedOperationException(getClass().getName() + """
-                 was obtained in a way that does not identify the type\
-                 of the attribute. Static metamodel classes should\
-                 use the .of method that is defined on the Attribute subtype\
-                 to provide the entity class.\
-                """);
+        throw new UnsupportedOperationException(
+                Messages.get("011.unknown.attr.type", getClass().getName()));
     }
 }

--- a/api/src/main/java/jakarta/data/metamodel/BasicAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/BasicAttribute.java
@@ -30,16 +30,6 @@ import jakarta.data.expression.Expression;
  */
 public interface BasicAttribute<T, V> extends Attribute<T>, Expression<T, V> {
 
-    @Override
-    default Class<V> attributeType() {
-        throw new UnsupportedOperationException(getClass().getName() + """
-                 was obtained in a way that does not identify the type\
-                 of the attribute. Static metamodel classes should\
-                 use the .of method that is defined on the Attribute subtype\
-                 to provide the entity class.\
-                """);
-    }
-
     /**
      * <p>Creates a static metamodel {@code BasicAttribute} representing the
      * entity attribute with the specified name.</p>

--- a/api/src/main/java/jakarta/data/metamodel/TextAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/TextAttribute.java
@@ -41,6 +41,18 @@ public interface TextAttribute<T> extends ComparableAttribute<T, String>, TextEx
     }
 
     /**
+     * Returns {@code String.class} as the entity attribute type for text
+     * attributes.
+     *
+     * @return {@code String.class}.
+     * @since 1.1
+     */
+    @Override
+    default Class<String> attributeType() {
+        return String.class;
+    }
+
+    /**
      * Obtain a request for a descending, case insensitive {@link Sort} based on
      * the entity attribute.
      *

--- a/api/src/main/java/jakarta/data/metamodel/TextAttributeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/TextAttributeRecord.java
@@ -19,10 +19,6 @@ package jakarta.data.metamodel;
 
 record TextAttributeRecord<T>(Class<T> declaringType, String name)
         implements TextAttribute<T> {
-    @Override
-    public Class<String> attributeType() {
-        return String.class;
-    }
 
     @Override
     public String toString() {

--- a/api/src/main/resources/jakarta/data/messages/Messages.properties
+++ b/api/src/main/resources/jakarta/data/messages/Messages.properties
@@ -27,3 +27,11 @@
  and escape character
 009.unknown.number.type=Unexpected subtype of Number: {0}
 010.unknown.total=A total count of elements is not available
+011.unknown.attr.type=The {0} instance was obtained in a way that does not \
+ identify the type of the attribute. Static metamodel classes should use \
+ an .of method that is defined on an Attribute subtype to supply the \
+ entity class and entity attribute type.
+012.unknown.decl.type=The {0} instance was obtained in a way that does not \
+ identify the entity class that declares the attribute. Static metamodel \
+ classes should use an .of method that is defined on an Attribute subtype \
+ to supply the entity class.


### PR DESCRIPTION
This PR started out as updating the default implementations of `attributeType()` and `declaringType()` to obtain the error message from the messages file.  But then I noticed that `Attribute.attributeType()` had a copy/paste error where it had a copy of the Javadoc from `declaringType()`.  Also `BasicAttribute.attributeType()` was overriding `Attribute.attributeType()` for no apparent reason and losing the Javadoc.  I removed the former to have it inherit the latter.  `TextAttribute` did not override `attributeType()`, but here it makes sense to because we can hard code a return value of `String.class` for text attribute and then not need to raise the UnsupportedOperationException for that method.  This last item is done as a separate commit in case anyone objects to just that part.