### PR TITLE
Since 1.1 missing from various places in metamodel package

### DIFF
--- a/api/src/main/java/jakarta/data/messages/Messages.java
+++ b/api/src/main/java/jakarta/data/messages/Messages.java
@@ -41,4 +41,18 @@ public class Messages {
         return MessageFormat.format(MESSAGES.getString(key),
                                     args);
     }
+
+    /**
+     * Raises NullPointerException if the value is null.
+     *
+     * @param value   value of a method argument.
+     * @param argName name of the argument.
+     * @throws NullPointerException if the value is null.
+     */
+    public static void requireNonNull(Object value, String argName) {
+        if (value == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", argName));
+        }
+    }
 }

--- a/api/src/main/java/jakarta/data/metamodel/BasicAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/BasicAttribute.java
@@ -17,9 +17,8 @@
  */
 package jakarta.data.metamodel;
 
-import java.util.Objects;
-
 import jakarta.data.expression.Expression;
+import jakarta.data.messages.Messages;
 
 /**
  * <p>Represents an entity attribute in the {@link StaticMetamodel}
@@ -46,9 +45,9 @@ public interface BasicAttribute<T, V> extends Attribute<T>, Expression<T, V> {
     static <T, V> BasicAttribute<T, V> of(Class<T> entityClass,
                                           String name,
                                           Class<V> attributeType) {
-        Objects.requireNonNull(entityClass, "The entityClass is required");
-        Objects.requireNonNull(name, "The name is required");
-        Objects.requireNonNull(attributeType, "The attributeType is required");
+        Messages.requireNonNull(entityClass, "entityClass");
+        Messages.requireNonNull(name, "name");
+        Messages.requireNonNull(attributeType, "attributeType");
 
         return new BasicAttributeRecord<>(entityClass, name, attributeType);
     }

--- a/api/src/main/java/jakarta/data/metamodel/ComparableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/ComparableAttribute.java
@@ -17,9 +17,8 @@
  */
 package jakarta.data.metamodel;
 
-import java.util.Objects;
-
 import jakarta.data.expression.ComparableExpression;
+import jakarta.data.messages.Messages;
 
 /**
  * <p>Represents a comparable entity attribute in the {@link StaticMetamodel}.
@@ -79,9 +78,9 @@ public interface ComparableAttribute<T, V extends Comparable<?>>
             Class<T> entityClass,
             String name,
             Class<V> attributeType) {
-        Objects.requireNonNull(entityClass, "The entityClass is required");
-        Objects.requireNonNull(name, "The name is required");
-        Objects.requireNonNull(attributeType, "The attributeType is required");
+        Messages.requireNonNull(entityClass, "entityClass");
+        Messages.requireNonNull(name, "name");
+        Messages.requireNonNull(attributeType, "attributeType");
 
         return new ComparableAttributeRecord<>(entityClass, name, attributeType);
     }

--- a/api/src/main/java/jakarta/data/metamodel/NavigableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/NavigableAttribute.java
@@ -17,9 +17,8 @@
  */
 package jakarta.data.metamodel;
 
-import java.util.Objects;
-
 import jakarta.data.expression.NavigableExpression;
+import jakarta.data.messages.Messages;
 
 /**
  * <p>Represents an entity attribute that is an embeddable or association to
@@ -39,8 +38,7 @@ public interface NavigableAttribute<T, U>
 
     /**
      * <p>Creates a static metamodel {@code NavigableAttribute} representing
-     * the
-     * entity attribute with the specified name.</p>
+     * the entity attribute with the specified name.</p>
      *
      * @param <T>           entity class of the static metamodel.
      * @param <U>           type of entity attribute.
@@ -52,9 +50,9 @@ public interface NavigableAttribute<T, U>
     static <T, U> NavigableAttribute<T, U> of(Class<T> entityClass,
                                               String name,
                                               Class<U> attributeType) {
-        Objects.requireNonNull(entityClass, "The entityClass is required");
-        Objects.requireNonNull(name, "The name is required");
-        Objects.requireNonNull(attributeType, "The attributeType is required");
+        Messages.requireNonNull(entityClass, "entityClass");
+        Messages.requireNonNull(name, "name");
+        Messages.requireNonNull(attributeType, "attributeType");
 
         return new NavigableAttributeRecord<>(entityClass, name, attributeType);
     }

--- a/api/src/main/java/jakarta/data/metamodel/NumericAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/NumericAttribute.java
@@ -17,9 +17,8 @@
  */
 package jakarta.data.metamodel;
 
-import java.util.Objects;
-
 import jakarta.data.expression.NumericExpression;
+import jakarta.data.messages.Messages;
 
 /**
  * <p>Represents a {@linkplain Number numeric} entity attribute in the
@@ -64,9 +63,9 @@ public interface NumericAttribute<T, N extends Number & Comparable<N>>
      */
     static <T, N extends Number & Comparable<N>> NumericAttribute<T, N> of(
             Class<T> entityClass, String name, Class<N> attributeType) {
-        Objects.requireNonNull(entityClass, "The entityClass is required");
-        Objects.requireNonNull(name, "The name is required");
-        Objects.requireNonNull(attributeType, "The attributeType is required");
+        Messages.requireNonNull(entityClass, "entityClass");
+        Messages.requireNonNull(name, "name");
+        Messages.requireNonNull(attributeType, "attributeType");
 
         return new NumericAttributeRecord<>(entityClass, name, attributeType);
     }

--- a/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java
@@ -17,9 +17,8 @@
  */
 package jakarta.data.metamodel;
 
-import java.util.Objects;
-
 import jakarta.data.Sort;
+import jakarta.data.messages.Messages;
 
 /**
  * <p>Represents a entity attribute in the {@link StaticMetamodel}
@@ -74,9 +73,9 @@ public interface SortableAttribute<T> extends Attribute<T> {
     static <T, V> SortableAttribute<T> of(Class<T> entityClass,
                                           String name,
                                           Class<V> attributeType) {
-        Objects.requireNonNull(entityClass, "The entityClass is required");
-        Objects.requireNonNull(name, "The name is required");
-        Objects.requireNonNull(attributeType, "The attributeType is required");
+        Messages.requireNonNull(entityClass, "entityClass");
+        Messages.requireNonNull(name, "name");
+        Messages.requireNonNull(attributeType, "attributeType");
 
         return new SortableAttributeRecord<>(entityClass, name, attributeType);
     }

--- a/api/src/main/java/jakarta/data/metamodel/TemporalAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/TemporalAttribute.java
@@ -18,9 +18,9 @@
 package jakarta.data.metamodel;
 
 import java.time.temporal.Temporal;
-import java.util.Objects;
 
 import jakarta.data.expression.TemporalExpression;
+import jakarta.data.messages.Messages;
 
 /**
  * <p>Represents a {@linkplain Temporal temporal} entity attribute in the
@@ -62,9 +62,9 @@ public interface TemporalAttribute<T, V extends Temporal & Comparable<? extends 
      */
     static <T, V extends Temporal & Comparable<? extends Temporal>> TemporalAttribute<T, V> of(
             Class<T> entityClass, String name, Class<V> attributeType) {
-        Objects.requireNonNull(entityClass, "The entityClass is required");
-        Objects.requireNonNull(name, "The name is required");
-        Objects.requireNonNull(attributeType, "The attributeType is required");
+        Messages.requireNonNull(entityClass, "entityClass");
+        Messages.requireNonNull(name, "name");
+        Messages.requireNonNull(attributeType, "attributeType");
 
         return new TemporalAttributeRecord<>(entityClass, name, attributeType);
     }

--- a/api/src/main/java/jakarta/data/metamodel/TextAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/TextAttribute.java
@@ -19,8 +19,7 @@ package jakarta.data.metamodel;
 
 import jakarta.data.Sort;
 import jakarta.data.expression.TextExpression;
-
-import java.util.Objects;
+import jakarta.data.messages.Messages;
 
 /**
  * Represents an textual entity attribute in the {@link StaticMetamodel}.
@@ -74,8 +73,8 @@ public interface TextAttribute<T> extends ComparableAttribute<T, String>, TextEx
      * @since 1.1
      */
     static <T> TextAttribute<T> of(Class<T> entityClass, String name) {
-        Objects.requireNonNull(entityClass, "The entityClass is required");
-        Objects.requireNonNull(name, "The name is required");
+        Messages.requireNonNull(entityClass, "entityClass");
+        Messages.requireNonNull(name, "name");
 
         return new TextAttributeRecord<>(entityClass, name);
     }

--- a/api/src/main/java/jakarta/data/spi/expression/path/ComparablePathRecord.java
+++ b/api/src/main/java/jakarta/data/spi/expression/path/ComparablePathRecord.java
@@ -17,9 +17,8 @@
  */
 package jakarta.data.spi.expression.path;
 
-import java.util.Objects;
-
 import jakarta.data.expression.NavigableExpression;
+import jakarta.data.messages.Messages;
 import jakarta.data.metamodel.ComparableAttribute;
 
 record ComparablePathRecord<T, U, C extends Comparable<?>>
@@ -28,8 +27,8 @@ record ComparablePathRecord<T, U, C extends Comparable<?>>
         implements ComparablePath<T, U, C> {
 
     ComparablePathRecord {
-        Objects.requireNonNull(expression, "The expression is required");
-        Objects.requireNonNull(attribute, "The attribute is required");
+        Messages.requireNonNull(expression, "expression");
+        Messages.requireNonNull(attribute, "attribute");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/spi/expression/path/NavigablePathRecord.java
+++ b/api/src/main/java/jakarta/data/spi/expression/path/NavigablePathRecord.java
@@ -17,9 +17,8 @@
  */
 package jakarta.data.spi.expression.path;
 
-import java.util.Objects;
-
 import jakarta.data.expression.NavigableExpression;
+import jakarta.data.messages.Messages;
 import jakarta.data.metamodel.NavigableAttribute;
 
 record NavigablePathRecord<T, U, V>
@@ -28,8 +27,8 @@ record NavigablePathRecord<T, U, V>
         implements NavigablePath<T, U, V> {
 
     NavigablePathRecord {
-        Objects.requireNonNull(expression, "The expression is required");
-        Objects.requireNonNull(attribute, "The attribute is required");
+        Messages.requireNonNull(expression, "expression");
+        Messages.requireNonNull(attribute, "attribute");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/spi/expression/path/NumericPathRecord.java
+++ b/api/src/main/java/jakarta/data/spi/expression/path/NumericPathRecord.java
@@ -17,9 +17,8 @@
  */
 package jakarta.data.spi.expression.path;
 
-import java.util.Objects;
-
 import jakarta.data.expression.NavigableExpression;
+import jakarta.data.messages.Messages;
 import jakarta.data.metamodel.NumericAttribute;
 
 record NumericPathRecord<T, U, N extends Number & Comparable<N>>
@@ -27,8 +26,8 @@ record NumericPathRecord<T, U, N extends Number & Comparable<N>>
         implements NumericPath<T, U, N> {
 
     NumericPathRecord {
-        Objects.requireNonNull(expression, "The expression is required");
-        Objects.requireNonNull(attribute, "The attribute is required");
+        Messages.requireNonNull(expression, "expression");
+        Messages.requireNonNull(attribute, "attribute");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/spi/expression/path/TemporalPathRecord.java
+++ b/api/src/main/java/jakarta/data/spi/expression/path/TemporalPathRecord.java
@@ -18,9 +18,9 @@
 package jakarta.data.spi.expression.path;
 
 import java.time.temporal.Temporal;
-import java.util.Objects;
 
 import jakarta.data.expression.NavigableExpression;
+import jakarta.data.messages.Messages;
 import jakarta.data.metamodel.TemporalAttribute;
 
 record TemporalPathRecord<T, U, V extends Temporal & Comparable<? extends Temporal>>(
@@ -28,8 +28,8 @@ record TemporalPathRecord<T, U, V extends Temporal & Comparable<? extends Tempor
         TemporalAttribute<U, V> attribute) implements TemporalPath<T, U, V> {
 
     TemporalPathRecord {
-        Objects.requireNonNull(expression, "The expression is required");
-        Objects.requireNonNull(attribute, "The attribute is required");
+        Messages.requireNonNull(expression, "expression");
+        Messages.requireNonNull(attribute, "attribute");
     }
 
     @Override

--- a/api/src/main/java/jakarta/data/spi/expression/path/TextPathRecord.java
+++ b/api/src/main/java/jakarta/data/spi/expression/path/TextPathRecord.java
@@ -17,9 +17,8 @@
  */
 package jakarta.data.spi.expression.path;
 
-import java.util.Objects;
-
 import jakarta.data.expression.NavigableExpression;
+import jakarta.data.messages.Messages;
 import jakarta.data.metamodel.TextAttribute;
 
 record TextPathRecord<T, U>
@@ -27,8 +26,8 @@ record TextPathRecord<T, U>
         implements TextPath<T, U> {
 
     TextPathRecord {
-        Objects.requireNonNull(expression, "The expression is required");
-        Objects.requireNonNull(attribute, "The attribute is required");
+        Messages.requireNonNull(expression, "expression");
+        Messages.requireNonNull(attribute, "attribute");
     }
 
     @Override

--- a/api/src/test/java/jakarta/data/restrict/BasicRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/restrict/BasicRestrictionRecordTest.java
@@ -138,7 +138,7 @@ class BasicRestrictionRecordTest {
     void shouldThrowExceptionWhenAttributeIsNull() {
         assertThatThrownBy(() -> BasicAttribute.of(Book.class, null, Object.class).equalTo("testValue"))
                 .isInstanceOf(NullPointerException.class)
-                .hasMessage("The name is required");
+                .hasMessage("The name argument is required");
     }
 
     @Test

--- a/api/src/test/java/jakarta/data/restrict/TextRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/restrict/TextRestrictionRecordTest.java
@@ -230,6 +230,6 @@ class TextRestrictionRecordTest {
     void shouldThrowExceptionWhenAttributeIsNullInTextRestriction() {
         assertThatThrownBy(() -> TextAttribute.of(_Book.class, null).equalTo("testValue"))
                 .isInstanceOf(NullPointerException.class)
-                .hasMessage("The name is required");
+                .hasMessage("The name argument is required");
     }
 }


### PR DESCRIPTION
Adds `@since 1.1` to various places where it was missing in the metamodel package.

Also, many classes in this package were hard coding the same message instead of using the one from the messages file, so I updated those as well.