### PR TITLE
Avoid confusion over the term comparable

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/Attribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/Attribute.java
@@ -35,9 +35,10 @@ import jakarta.data.messages.Messages;
  *     {@link java.time.Instant}.</li>
  * <li>{@link ComparableAttribute} for entity attributes that represent other
  *     sortable and comparable values, such as {@code boolean} and enumerations.</li>
- * <li>{@link SortableAttribute} for entity types that are sortable, but not
- *     comparable. Generally this subtype is unused but is applicable for
- *     databases that allow sorting on attributes of type {@code byte[]}.</li>
+ * <li>{@link SortableAttribute} for entity types that are sortable, but
+ *     incapable of order-based comparison. Generally this subtype is unused
+ *     but is applicable for databases that allow sorting on attributes of type
+ *     {@code byte[]}.</li>
  * <li>{@link NavigableAttribute} for entity attributes that have attributes
  *     of their own. This is used for embeddables and associations to other
  *     entities.</li>

--- a/api/src/main/java/jakarta/data/metamodel/BasicAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/BasicAttribute.java
@@ -21,8 +21,9 @@ import jakarta.data.expression.Expression;
 import jakarta.data.messages.Messages;
 
 /**
- * <p>Represents an entity attribute in the {@link StaticMetamodel}
- * that is neither sortable nor comparable.</p>
+ * <p>Represents an entity attribute in the {@link StaticMetamodel} that is
+ * neither sortable nor capable of order-based comparison. Subclasses of
+ * {@code BasicAttribute} allow for entity attributes with those abilities.</p>
  *
  * @param <T> entity class of the static metamodel.
  * @param <V> type of entity attribute (or wrapper type if primitive).

--- a/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java
+++ b/api/src/main/java/jakarta/data/metamodel/SortableAttribute.java
@@ -22,7 +22,7 @@ import jakarta.data.messages.Messages;
 
 /**
  * <p>Represents a entity attribute in the {@link StaticMetamodel}
- * that is sortable, but not comparable.</p>
+ * that is sortable, but incapable of order-based comparison.</p>
  *
  * <p>A {@code SortableAttribute} may be used to sort query results.
  * When an attribute type is a numeric type, {@link NumericAttribute} is


### PR DESCRIPTION
It's confusing to say `BasicAttribute` is for entity attributes that are not comparable, because these attributes can be compared in some ways (equalTo, notEqualTo, isNull, isNotNull, in, notIn) which are allowed by Expression from which BasicAttribute inherits.
What we really meant here is to say they are not `java.lang.Comparable` in that they are not capable of order-based comparisons.  This PR clarifies.