### PR TITLE
fix: javadoc failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,4 +64,4 @@ jobs:
           cache: maven
       - name: Generate Javadoc
         # FIXME '-P release' is necessary to handle the un-supported javadoc tag @apiNote
-        run: mvn -P release javadoc:javadoc --file pom.xml
+        run: mvn -P release javadoc:aggregate-jar --file pom.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ permissions:
   contents: read
 
 jobs:
+  # Catch compilation and packaging errors
   build:
 
     strategy:
@@ -36,6 +37,7 @@ jobs:
     - name: Build project
       run: mvn -B package --file pom.xml
   
+  # Catch dependency issues in the tck-dist starters
   analyze:
     runs-on: ubuntu-latest
     steps:
@@ -48,3 +50,17 @@ jobs:
           cache: maven
       - name: Analyze starters
         run: mvn dependency:analyze --file tck-dist/src/main/pom.xml
+  
+  # Catch javadoc errors
+  javadoc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Set up JDK 21
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
+        with:
+          java-version: 21
+          distribution: 'temurin'
+          cache: maven
+      - name: Generate Javadoc
+        run: mvn javadoc:javadoc --file pom.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,4 +63,5 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Generate Javadoc
-        run: mvn javadoc:javadoc --file pom.xml
+        # FIXME '-P release' is necessary to handle the un-supported javadoc tag @apiNote
+        run: mvn -P release javadoc:javadoc --file pom.xml

--- a/api/src/main/java/jakarta/data/repository/Select.java
+++ b/api/src/main/java/jakarta/data/repository/Select.java
@@ -71,7 +71,7 @@ public @interface Select {
      * <p>The {@code Select} annotation can be used with repository methods
      * that return a single entity attribute or multiple entity attributes.</p>
      *
-     * <h2>Method that returns Single Entity Attributes</h2>
+     * <h4>Method that returns Single Entity Attributes</h4>
      *
      * <p>Place the {@code Select} annotation on a repository find method and
      * assign the annotation value to be the name of a single entity attribute.
@@ -91,13 +91,13 @@ public @interface Select {
      * }
      * </pre>
      *
-     * <h2>Method that returns Java Records</h2>
+     * <h4>Method that returns Java Records</h4>
      *
      * <p>A repository method can return a projection by having the result type
      * be a Java record. The {@code Select} annotation can be used in the
      * following ways to accommodate this.</p>
      *
-     * <h3>Annotating a Repository Method</h3>
+     * <h5>Annotating a Repository Method</h5>
      *
      * <p>Place one or more {@code Select} annotations on a repository find
      * method and assign the annotation values to be the names of entity
@@ -123,7 +123,7 @@ public @interface Select {
      * }
      * </pre>
      *
-     * <h3>Annotating a Record Component</h3>
+     * <h5>Annotating a Record Component</h5>
      *
      * <p>Place the {@code Select} annotation on each record component of the
      * Java record that is used as the result type of the repository method.

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -402,7 +402,6 @@ import java.util.Set;
  *     Stream&lt;Product&gt; pricedUnder(LessThan&lt;Float&gt; price);
  *     </pre>
  * </li>
- * </li>
  * <li>The parameter is a {@link Restriction} and its type parameter is the
  *     entity class. For example,
  *     <pre>

--- a/pom.xml
+++ b/pom.xml
@@ -334,7 +334,7 @@
                             <execution>
                                 <id>attach-javadocs</id>
                                 <goals>
-                                    <goal>jar</goal>
+                                    <goal>aggregate-jar</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -322,13 +322,13 @@
                              to add support for this tag in all Jakarta APIs 
                         -->
                         <configuration>
-                        	<tags>
-                        		<tag>
-                        			<name>apiNote</name>
-                        			<placement>a</placement>
-                        			<head>API Note:</head>
-                        		</tag>
-                        	</tags>
+                            <tags>
+                                <tag>
+                                    <name>apiNote</name>
+                                    <placement>a</placement>
+                                    <head>API Note:</head>
+                                </tag>
+                            </tags>
                         </configuration>
                         <executions>
                             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -314,6 +314,22 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.11.3</version>
+                        <!-- TODO javadoc tag @apiNote is not offically supported outside
+                             JDK classes, when we switch over to using the parent profile
+                             oss-release we will either need to remove these tags from 
+                             our API javadoc, or make a pull request to the parent project
+                             to add support for this tag in all Jakarta APIs 
+                        -->
+                        <configuration>
+                        	<tags>
+                        		<tag>
+                        			<name>apiNote</name>
+                        			<placement>a</placement>
+                        			<head>API Note:</head>
+                        		</tag>
+                        	</tags>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>

--- a/stateful/src/main/java/jakarta/data/repository/stateful/Merge.java
+++ b/stateful/src/main/java/jakarta/data/repository/stateful/Merge.java
@@ -68,6 +68,7 @@ import java.lang.annotation.Target;
  *     <li>Otherwise, if no such record exists, the merge operation schedules
  *     the insertion of a new record with the state held by the merged entity.
  * </ul>
+ * <p>
  * In either case, the method annotated {@code @Merge} returns a managed entity
  * representing the inserted or updated record and reflecting the merged changes,
  * even if the scheduled insertion or update has not yet occurred.

--- a/tck-dist/pom.xml
+++ b/tck-dist/pom.xml
@@ -215,4 +215,24 @@
    </plugin>
   </plugins>
  </build>
+ 
+ <profiles>
+    <!-- TODO switch to oss-release once parent pom is updated -->
+    <!-- Skip javadoc for TCK-DIST -->
+    <profile>
+      <id>release</id>
+      <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.11.3</version>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
+        </plugin>
+      </plugins>
+      </build>
+    </profile>
+ </profiles>
 </project>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -351,5 +351,24 @@
         </plugins>
       </build>
     </profile>
+    
+    <!-- TODO switch to oss-release once parent pom is updated -->
+    <!-- Skip javadoc for TCK -->
+    <profile>
+      <id>release</id>
+      <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.11.3</version>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
+        </plugin>
+      </plugins>
+      </build>
+    </profile>
+
   </profiles>
 </project>


### PR DESCRIPTION
Related #1168 

Jenkins release build is catching javadoc errors when attempting to deploy that our current github actions build does not.
- add build step to github actions to catch errors put into javadoc during development
- fix errors that made it in while jenkins builds were broken. 
- skip javadoc for tck submodules (performance improvement and error prone)