### PR TITLE
fix: avoid using distribution management from parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,10 @@
         <!-- TODO remove once parent is updated https://github.com/eclipse-ee4j/ee4j/issues/98 -->
         <profile>
             <id>release</id>
+            <distributionManagement>
+                <!-- Overwrite distribution management from parent pom -->
+                <!-- Keep blank, the central-publishing-maven-plugin knows where to publish snapshots and releases -->
+            </distributionManagement>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
related #1168

Most recent jenkins snapshot build was still failing to publish because it was picking up the snapshot repository from parent pom: https://github.com/eclipse-ee4j/ee4j/blob/main/parent/pom.xml#L115-L119

Resulting in error: 
[ERROR] Failed to execute goal org.sonatype.central:central-publishing-maven-plugin:0.8.0:publish (injected-central-publishing) on project jakarta.data-tck-dist: Failed to deploy artifacts: Could not transfer artifact jakarta.data:jakarta.data-api:json.asc:cyclonedx:1.1.0-20250909.070649-8 from/to ossrh (https://jakarta.oss.sonatype.org/content/repositories/snapshots/): status code: 403, reason phrase: Forbidden (403)