### PR TITLE
Review comments on messages from tech writer

### DIFF
--- a/api/src/main/resources/jakarta/data/messages/DataMessages.properties
+++ b/api/src/main/resources/jakarta/data/messages/DataMessages.properties
@@ -28,10 +28,10 @@
 009.unknown.number.type=Unexpected subtype of Number: {0}
 010.unknown.total=A total count of elements is not available
 011.unknown.attr.type=The {0} instance was obtained in a way that does not \
- identify the type of the attribute. Static metamodel classes should use \
- an .of method that is defined on an Attribute subtype to supply the \
- entity class and entity attribute type.
+ identify the type of the attribute. For static metamodel classes, use an \
+ .of method that is defined on an Attribute subtype to supply the entity \
+ class and entity attribute type.
 012.unknown.decl.type=The {0} instance was obtained in a way that does not \
- identify the entity class that declares the attribute. Static metamodel \
- classes should use an .of method that is defined on an Attribute subtype \
- to supply the entity class.
+ identify the entity class that declares the attribute. For static metamodel \
+ classes, use an .of method that is defined on an Attribute subtype to supply \
+ the entity class and entity attribute type.


### PR DESCRIPTION
Adding the latest Data 1.1 API to our development stream caused our tech writers to review our messages file.  They had one comment that applied in two places, which involved using language to the user that is more direct rather than saying "should".  This PR makes the requested update.