### PR TITLE
fix: distributionManagement override

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,7 +278,14 @@
             <id>release</id>
             <distributionManagement>
                 <!-- Overwrite distribution management from parent pom -->
-                <!-- Keep blank, the central-publishing-maven-plugin knows where to publish snapshots and releases -->
+                <repository>
+                    <id>central</id>
+                    <url>https://central.sonatype.com</url>
+                </repository>
+                <snapshotRepository>
+                    <id>central-snapshot</id>
+                    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+                </snapshotRepository>
             </distributionManagement>
             <build>
                 <plugins>


### PR DESCRIPTION
Follow up to #1206
Related to #1168

I thought I could overwrite the `<distributionManagement>` config by blanking it out.
However, that behavior was not well documented, and to override nested elements we need to actually define `<repository>` and `<snapshotRepository>` elements. 

This is a work around until a snapshot of the new parent pom is released.  Tracked with issue: https://github.com/eclipse-ee4j/ee4j/issues/101