### PR TITLE
Pattern translation is broken when already-escaped pattern is supplied

### DIFF
--- a/api/src/main/java/jakarta/data/constraint/Constraint.java
+++ b/api/src/main/java/jakarta/data/constraint/Constraint.java
@@ -195,7 +195,8 @@ public interface Constraint<V> {
 
     /**
      * <p>Requires that the constraint target match the given {@code pattern},
-     * in which {@code _} and {@code %} represent wildcards.</p>
+     * in which {@code _} and {@code %} represent wildcards, and no escape
+     * character is included.</p>
      *
      * @param pattern a pattern in which {@code _} matches a single character
      *                and {@code %} matches 0 or more characters.
@@ -209,7 +210,8 @@ public interface Constraint<V> {
 
     /**
      * <p>Requires that the constraint target match the given {@code pattern},
-     * in which the given characters represent wildcards.</p>
+     * in which the given characters represent wildcards, and no escape
+     * character is included.</p>
      *
      * @param pattern        a pattern that can include the given wildcard
      *                       characters.
@@ -242,8 +244,8 @@ public interface Constraint<V> {
 
     /**
      * <p>Requires that the constraint target does not match the given
-     * {@code pattern}, in which {@code _} and {@code %} represent wildcards.
-     * </p>
+     * {@code pattern}, in which {@code _} and {@code %} represent wildcards,
+     * and no escape character is included.</p>
      *
      * @param pattern a pattern in which {@code _} matches a single character
      *                and {@code %} matches 0 or more characters.
@@ -257,7 +259,8 @@ public interface Constraint<V> {
 
     /**
      * <p>Requires that the constraint target does not match the given
-     * {@code pattern}, in which the given characters represent wildcards.</p>
+     * {@code pattern}, in which the given characters represent wildcards,
+     * and no escape character is included.</p>
      *
      * @param pattern        a pattern that can include the given wildcard
      *                       characters.

--- a/api/src/main/java/jakarta/data/constraint/Like.java
+++ b/api/src/main/java/jakarta/data/constraint/Like.java
@@ -17,6 +17,7 @@
  */
 package jakarta.data.constraint;
 
+import static jakarta.data.constraint.LikeRecord.CHAR_WILDCARD;
 import static jakarta.data.constraint.LikeRecord.ESCAPE;
 import static jakarta.data.constraint.LikeRecord.STRING_WILDCARD;
 import static jakarta.data.constraint.LikeRecord.translate;
@@ -86,7 +87,8 @@ public interface Like extends Constraint<String> {
 
     /**
      * <p>Requires that the constraint target match the given {@code pattern},
-     * in which {@code _} and {@code %} represent wildcards.</p>
+     * in which {@code _} and {@code %} represent wildcards, and no escape
+     * character is included.</p>
      *
      * <p>For example, the following requires that the first 3 positions of a
      * VIN number are {@code JHM}, positions 4 through 6 are any character,
@@ -103,18 +105,13 @@ public interface Like extends Constraint<String> {
      * @throws NullPointerException if the pattern is {@code null}.
      */
     static Like pattern(String pattern) {
-        if (pattern == null) {
-            throw new NullPointerException(
-                    Messages.get("001.arg.required", "pattern"));
-        }
-
-        StringLiteral expression = StringLiteral.of(pattern);
-        return new LikeRecord(expression, null);
+        return pattern(pattern, CHAR_WILDCARD, STRING_WILDCARD);
     }
 
     /**
      * <p>Requires that the constraint target match the given {@code pattern},
-     * in which the given characters represent wildcards.</p>
+     * in which the given characters represent wildcards, and no escape
+     * character is included.</p>
      *
      * <p>For example, the following requires that the first 3 positions of a
      * VIN number are {@code JHM}, positions 4 through 6 are any character,
@@ -304,11 +301,13 @@ public interface Like extends Constraint<String> {
     }
 
     /**
-     * The escape character if one is defined for the pattern.
+     * <p>The escape character to use for the {@link #pattern()}. The pattern
+     * is assigned an escape character even if the application did not supply
+     * one when requesting the {@code Like} constraint.</p>
      *
      * @return the escape character if defined, otherwise {@code null}.
      */
-    Character escape();
+    char escape();
 
     /**
      * <p>An expression that evaluates to a pattern against which the

--- a/api/src/main/java/jakarta/data/constraint/Like.java
+++ b/api/src/main/java/jakarta/data/constraint/Like.java
@@ -122,7 +122,7 @@ public interface Like extends Constraint<String> {
      * </p>
      *
      * <pre>
-     * found = cars.matchVIN(Like.pattern("JHM???F*"), '?', '*');
+     * found = cars.matchVIN(Like.pattern("JHM???F*", '?', '*'));
      * </pre>
      *
      * @param pattern        a pattern that can include the given wildcard
@@ -133,7 +133,12 @@ public interface Like extends Constraint<String> {
      * @throws NullPointerException if the pattern is {@code null}.
      */
     static Like pattern(String pattern, char charWildcard, char stringWildcard) {
-        return Like.pattern(pattern, charWildcard, stringWildcard, ESCAPE);
+        Messages.requireNonNull(pattern, "pattern");
+
+        StringLiteral expression = StringLiteral.of(
+                translate(pattern, charWildcard, stringWildcard, ESCAPE, false));
+
+        return new LikeRecord(expression, ESCAPE);
     }
 
     /**
@@ -146,7 +151,7 @@ public interface Like extends Constraint<String> {
      * </p>
      *
      * <pre>
-     * found = cars.matchVIN(Like.pattern("JHM---^CC"), '-', 'C', '^');
+     * found = cars.matchVIN(Like.pattern("JHM---^CC", '-', 'C', '^'));
      * </pre>
      *
      * @param pattern        a pattern that can include the given wildcard
@@ -164,7 +169,7 @@ public interface Like extends Constraint<String> {
         }
 
         StringLiteral expression = StringLiteral.of(
-                translate(pattern, charWildcard, stringWildcard, escape));
+                translate(pattern, charWildcard, stringWildcard, escape, true));
         return new LikeRecord(expression, escape);
     }
 
@@ -315,7 +320,7 @@ public interface Like extends Constraint<String> {
      * characters are interpreted literally rather than as wildcards or
      * escape.</p>
      *
-     * <p>For example, {@code Like.pattern("is --.-*% of", '-', '*', '^')"}
+     * <p>For example, {@code Like.pattern("is --.-*% of", '-', '*', '^')}
      * is represented as {@code is __._%^% of} where {@code ^} is the escape
      * character.</p>
      *

--- a/api/src/main/java/jakarta/data/constraint/LikeRecord.java
+++ b/api/src/main/java/jakarta/data/constraint/LikeRecord.java
@@ -20,7 +20,7 @@ package jakarta.data.constraint;
 import jakarta.data.expression.TextExpression;
 import jakarta.data.messages.Messages;
 
-record LikeRecord(TextExpression<?> pattern, Character escape)
+record LikeRecord(TextExpression<?> pattern, char escape)
         implements Like {
 
     static final char CHAR_WILDCARD = '_';
@@ -34,8 +34,7 @@ record LikeRecord(TextExpression<?> pattern, Character escape)
 
     @Override
     public String toString() {
-        return "LIKE " + pattern +
-                (escape == null ? "" : " ESCAPE '" + escape + "'");
+        return "LIKE " + pattern + " ESCAPE '" + escape + "'";
     }
 
     static String escape(String literal) {

--- a/api/src/main/java/jakarta/data/constraint/NotLike.java
+++ b/api/src/main/java/jakarta/data/constraint/NotLike.java
@@ -117,7 +117,7 @@ public interface NotLike extends Constraint<String> {
      * character position 7.</p>
      *
      * <pre>
-     * found = cars.matchVIN(NotLike.pattern("JHM???F*"), '?', '*');
+     * found = cars.matchVIN(NotLike.pattern("JHM???F*", '?', '*'));
      * </pre>
      *
      * @param pattern        a pattern that can include the given wildcard
@@ -128,7 +128,15 @@ public interface NotLike extends Constraint<String> {
      * @throws NullPointerException if the pattern is {@code null}.
      */
     static NotLike pattern(String pattern, char charWildcard, char stringWildcard) {
-        return NotLike.pattern(pattern, charWildcard, stringWildcard, ESCAPE);
+        if (pattern == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "pattern"));
+        }
+
+        StringLiteral expression = StringLiteral.of(
+                translate(pattern, charWildcard, stringWildcard, ESCAPE, false));
+
+        return new NotLikeRecord(expression, ESCAPE);
     }
 
     /**
@@ -141,7 +149,7 @@ public interface NotLike extends Constraint<String> {
      * character position 7.</p>
      *
      * <pre>
-     * found = cars.matchVIN(Like.pattern("JHM---^CC"), '-', 'C', '^');
+     * found = cars.matchVIN(Like.pattern("JHM---^CC", '-', 'C', '^'));
      * </pre>
      *
      * @param pattern        a pattern that can include the given wildcard
@@ -159,7 +167,7 @@ public interface NotLike extends Constraint<String> {
         }
 
         StringLiteral expression = StringLiteral.of(
-                translate(pattern, charWildcard, stringWildcard, escape));
+                translate(pattern, charWildcard, stringWildcard, escape, true));
         return new NotLikeRecord(expression, escape);
     }
 

--- a/api/src/main/java/jakarta/data/constraint/NotLike.java
+++ b/api/src/main/java/jakarta/data/constraint/NotLike.java
@@ -17,6 +17,7 @@
  */
 package jakarta.data.constraint;
 
+import static jakarta.data.constraint.LikeRecord.CHAR_WILDCARD;
 import static jakarta.data.constraint.LikeRecord.ESCAPE;
 import static jakarta.data.constraint.LikeRecord.STRING_WILDCARD;
 import static jakarta.data.constraint.LikeRecord.translate;
@@ -82,8 +83,8 @@ public interface NotLike extends Constraint<String> {
 
     /**
      * <p>Requires that the constraint target not match the given
-     * {@code pattern}, in which {@code _} and {@code %} represent wildcards.
-     * </p>
+     * {@code pattern}, in which {@code _} and {@code %} represent wildcards,
+     * and no escape character is included.</p>
      *
      * <p>For example, the following requires that the VIN number not have
      * {@code JHM} as its first 3 character positions and {@code E} in
@@ -99,18 +100,13 @@ public interface NotLike extends Constraint<String> {
      * @throws NullPointerException if the pattern is {@code null}.
      */
     static NotLike pattern(String pattern) {
-        if (pattern == null) {
-            throw new NullPointerException(
-                    Messages.get("001.arg.required", "pattern"));
-        }
-
-        StringLiteral expression = StringLiteral.of(pattern);
-        return new NotLikeRecord(expression, null);
+        return pattern(pattern, CHAR_WILDCARD, STRING_WILDCARD);
     }
 
     /**
      * <p>Requires that the constraint target not match the given
-     * {@code pattern}, in which the given characters represent wildcards.</p>
+     * {@code pattern}, in which the given characters represent wildcards,
+     * and no escape character is included.</p>
      *
      * <p>For example, the following requires that the VIN number not have
      * {@code JHM} as its first 3 character positions and {@code F} in
@@ -301,11 +297,13 @@ public interface NotLike extends Constraint<String> {
     }
 
     /**
-     * The escape character if one is defined for the pattern.
+     * <p>The escape character to use for the {@link #pattern()}. The pattern
+     * is assigned an escape character even if the application did not supply
+     * one when requesting the {@code NotLike} constraint.</p>
      *
      * @return the escape character if defined, otherwise {@code null}.
      */
-    Character escape();
+    char escape();
 
     /**
      * <p>An expression that evaluates to a pattern against which the

--- a/api/src/main/java/jakarta/data/constraint/NotLikeRecord.java
+++ b/api/src/main/java/jakarta/data/constraint/NotLikeRecord.java
@@ -19,7 +19,7 @@ package jakarta.data.constraint;
 
 import jakarta.data.expression.TextExpression;
 
-record NotLikeRecord(TextExpression<?> pattern, Character escape)
+record NotLikeRecord(TextExpression<?> pattern, char escape)
         implements NotLike {
 
     @Override
@@ -29,7 +29,6 @@ record NotLikeRecord(TextExpression<?> pattern, Character escape)
 
     @Override
     public String toString() {
-        return "NOT LIKE " + pattern +
-                (escape == null ? "" : " ESCAPE '" + escape + "'");
+        return "NOT LIKE " + pattern + " ESCAPE '" + escape + "'";
     }
 }

--- a/api/src/test/java/jakarta/data/constraint/LikeTest.java
+++ b/api/src/test/java/jakarta/data/constraint/LikeTest.java
@@ -49,7 +49,7 @@ class LikeTest {
         Like like = Like.pattern("JHM___E%");
 
         SoftAssertions.assertSoftly(soft -> soft.assertThat(like.escape())
-                .isNull());
+                .isEqualTo('\\'));
 
         SoftAssertions.assertSoftly(soft -> soft.assertThat(like.pattern())
                 .isInstanceOf(StringLiteral.class));

--- a/api/src/test/java/jakarta/data/constraint/LikeTest.java
+++ b/api/src/test/java/jakarta/data/constraint/LikeTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data.constraint;
+
+import jakarta.data.spi.expression.literal.StringLiteral;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the Like constraint, including patterns, wildcards, and
+ * escape characters.
+ */
+class LikeTest {
+
+    @Test
+    void likeLiteral() {
+        Like like = Like.literal("100% first_item\\second_item\\third_item");
+
+        SoftAssertions.assertSoftly(soft -> soft.assertThat(like.escape())
+                .isEqualTo('\\'));
+
+        SoftAssertions.assertSoftly(soft -> soft.assertThat(like.pattern())
+                .isInstanceOf(StringLiteral.class));
+
+        SoftAssertions.assertSoftly(soft -> soft.assertThat(
+                ((StringLiteral) like.pattern()).value())
+                .isEqualTo("100\\% first\\_item\\\\second\\_item\\\\third\\_item"));
+    }
+
+    @Test
+    void likePattern() {
+        // Usage is from Javadoc example
+        Like like = Like.pattern("JHM___E%");
+
+        SoftAssertions.assertSoftly(soft -> soft.assertThat(like.escape())
+                .isNull());
+
+        SoftAssertions.assertSoftly(soft -> soft.assertThat(like.pattern())
+                .isInstanceOf(StringLiteral.class));
+
+        SoftAssertions.assertSoftly(soft -> soft.assertThat(
+                ((StringLiteral) like.pattern()).value())
+                .isEqualTo("JHM___E%"));
+    }
+
+    @Test
+    void likePatternWithCustomWildcards() {
+        // Usage is from Javadoc example
+        Like like = Like.pattern("JHM???F*", '?', '*');
+
+        SoftAssertions.assertSoftly(soft -> soft.assertThat(like.escape())
+                .isEqualTo('\\'));
+
+        SoftAssertions.assertSoftly(soft -> soft.assertThat(like.pattern())
+                .isInstanceOf(StringLiteral.class));
+
+        SoftAssertions.assertSoftly(soft -> soft.assertThat(
+                ((StringLiteral) like.pattern()).value())
+                .isEqualTo("JHM___F%"));
+    }
+
+    @Test
+    void likePatternWithCustomWildcardsAndCustomEscape() {
+        // Usage is from Javadoc example
+        Like like1 = Like.pattern("JHM---^CC", '-', 'C', '^');
+
+        SoftAssertions.assertSoftly(soft -> soft.assertThat(like1.escape())
+                .isEqualTo('^'));
+
+        SoftAssertions.assertSoftly(soft -> soft.assertThat(like1.pattern())
+                .isInstanceOf(StringLiteral.class));
+
+        SoftAssertions.assertSoftly(soft -> soft.assertThat(
+                ((StringLiteral) like1.pattern()).value())
+                .isEqualTo("JHM___C%"));
+
+        // Usage is from Javadoc example
+        Like like2 = Like.pattern("is --.-*% of", '-', '*', '^');
+
+        SoftAssertions.assertSoftly(soft -> soft.assertThat(like2.escape())
+                .isEqualTo('^'));
+
+        SoftAssertions.assertSoftly(soft -> soft.assertThat(like2.pattern())
+                .isInstanceOf(StringLiteral.class));
+
+        SoftAssertions.assertSoftly(soft -> soft.assertThat(
+                ((StringLiteral) like2.pattern()).value())
+                .isEqualTo("is __._%^% of"));
+    }
+
+    @Test
+    void likePatternWithCustomWildcardsAndNormalEscape() {
+        Like like = Like.pattern("11% of \\#1# \\\\ \\1", '1', '#', '\\');
+
+        SoftAssertions.assertSoftly(soft -> soft.assertThat(like.escape())
+                .isEqualTo('\\'));
+
+        SoftAssertions.assertSoftly(soft -> soft.assertThat(like.pattern())
+                .isInstanceOf(StringLiteral.class));
+
+        SoftAssertions.assertSoftly(soft -> soft.assertThat(
+                ((StringLiteral) like.pattern()).value())
+                .isEqualTo("__\\% of #_% \\\\ 1"));
+    }
+
+    @Test
+    void likePatternWithNormalWildcardsAndNormalEscape() {
+        Like like = Like.pattern("__\\% of _._% \\\\\\\\ ", '_', '%', '\\');
+
+        SoftAssertions.assertSoftly(soft -> soft.assertThat(like.escape())
+                .isEqualTo('\\'));
+
+        SoftAssertions.assertSoftly(soft -> soft.assertThat(like.pattern())
+                .isInstanceOf(StringLiteral.class));
+
+        SoftAssertions.assertSoftly(soft -> soft.assertThat(
+                ((StringLiteral) like.pattern()).value())
+                .isEqualTo("__\\% of _._% \\\\\\\\ "));
+    }
+}

--- a/api/src/test/java/jakarta/data/restrict/TextRestrictionRecordTest.java
+++ b/api/src/test/java/jakarta/data/restrict/TextRestrictionRecordTest.java
@@ -47,7 +47,7 @@ class TextRestrictionRecordTest {
             // TODO TextRestriction.ignoreCase vs TextAttribute.upper/lowercased
             //soft.assertThat(restriction.isCaseSensitive()).isTrue();
             soft.assertThat(literal.value()).isEqualTo("%Java%");
-            soft.assertThat(constraint.escape()).isNull();
+            soft.assertThat(constraint.escape()).isEqualTo('\\');
         });
     }
 
@@ -65,7 +65,7 @@ class TextRestrictionRecordTest {
             // TODO TextRestriction.ignoreCase vs TextAttribute.upper/lowercased
             //soft.assertThat(restriction.isCaseSensitive()).isTrue();
             soft.assertThat(literal.value()).isEqualTo("%Java%");
-            soft.assertThat(constraint.escape()).isNull();
+            soft.assertThat(constraint.escape()).isEqualTo('\\');
         });
     }
 
@@ -84,7 +84,7 @@ class TextRestrictionRecordTest {
         //    soft.assertThat(caseInsensitiveRestriction.expression()).isEqualTo(_Book.title);
         //    soft.assertThat(caseInsensitiveRestriction.isCaseSensitive()).isFalse();
             soft.assertThat(literal.value()).isEqualTo("%Java%");
-            soft.assertThat(constraint.escape()).isNull();
+            soft.assertThat(constraint.escape()).isEqualTo('\\');
         });
     }
 
@@ -102,7 +102,7 @@ class TextRestrictionRecordTest {
             // TODO TextRestriction.ignoreCase vs TextAttribute.upper/lowercased
             //soft.assertThat(restriction.isCaseSensitive()).isTrue();
             soft.assertThat(literal.value()).isEqualTo("%Java%");
-            soft.assertThat(constraint.escape()).isNull();
+            soft.assertThat(constraint.escape()).isEqualTo('\\');
         });
     }
 


### PR DESCRIPTION
While trying out `Like` constraints, I noticed that the API method for supplying an already escaped pattern is buggy in how it translates the pattern because the implementation has no awareness of whether or not the pattern is already escaped.  This PR adds that awareness and corrects the implementation. It could have been alternatively corrected in a less verbose form, but this seemed clearer.  Let me know if anyone prefers the other form and I can switch it.

This also adds test cases, including trying out the example usage of the API that we had stated in Javadoc, which in some cases was also broken by the same issue.

This also adds some clarity to the Javadoc when the pattern supplied to an API method does not include escape characters. Previously this was unstated, risking that a user might make wrong assumptions.

Also, I noticed some inconsistency between Like.pattern(pattern) and Like.pattern(pattern, charwildcard, stringwildcard) methods, where one of them ends up with NULL `escape()` and the other with `\`.  These really ought to be the same code path, except for the use of default vs custom wildcards.  This appears to be the only place where `LikeRecord` uses a NULL value, also requiring it specify `Character` type rather than `char`.  A commit added to this PR gets rid of the possibility of NULL here and makes both consistent, with Javadoc added to explain that the escape character returned by the `escape()` SPI method corresponds to the `pattern()` SPI method.