### PR TITLE
Clarify where patterns have no escape character

### DIFF
--- a/api/src/main/java/jakarta/data/constraint/Constraint.java
+++ b/api/src/main/java/jakarta/data/constraint/Constraint.java
@@ -195,8 +195,8 @@ public interface Constraint<V> {
 
     /**
      * <p>Requires that the constraint target match the given {@code pattern},
-     * in which {@code _} and {@code %} represent wildcards, and no escape
-     * character is included.</p>
+     * in which {@code _} and {@code %} represent wildcards. The supplied
+     * pattern has no escape character.</p>
      *
      * @param pattern a pattern in which {@code _} matches a single character
      *                and {@code %} matches 0 or more characters.
@@ -210,8 +210,8 @@ public interface Constraint<V> {
 
     /**
      * <p>Requires that the constraint target match the given {@code pattern},
-     * in which the given characters represent wildcards, and no escape
-     * character is included.</p>
+     * in which the given characters represent wildcards. The supplied
+     * pattern has no escape character.</p>
      *
      * @param pattern        a pattern that can include the given wildcard
      *                       characters.
@@ -244,8 +244,8 @@ public interface Constraint<V> {
 
     /**
      * <p>Requires that the constraint target does not match the given
-     * {@code pattern}, in which {@code _} and {@code %} represent wildcards,
-     * and no escape character is included.</p>
+     * {@code pattern}, in which {@code _} and {@code %} represent wildcards.
+     * The supplied pattern has no escape character.</p>
      *
      * @param pattern a pattern in which {@code _} matches a single character
      *                and {@code %} matches 0 or more characters.
@@ -259,8 +259,8 @@ public interface Constraint<V> {
 
     /**
      * <p>Requires that the constraint target does not match the given
-     * {@code pattern}, in which the given characters represent wildcards,
-     * and no escape character is included.</p>
+     * {@code pattern}, in which the given characters represent wildcards.
+     * The supplied pattern has no escape character.</p>
      *
      * @param pattern        a pattern that can include the given wildcard
      *                       characters.

--- a/api/src/main/java/jakarta/data/constraint/Like.java
+++ b/api/src/main/java/jakarta/data/constraint/Like.java
@@ -87,8 +87,8 @@ public interface Like extends Constraint<String> {
 
     /**
      * <p>Requires that the constraint target match the given {@code pattern},
-     * in which {@code _} and {@code %} represent wildcards, and no escape
-     * character is included.</p>
+     * in which {@code _} and {@code %} represent wildcards. The supplied
+     * pattern has no escape character.</p>
      *
      * <p>For example, the following requires that the first 3 positions of a
      * VIN number are {@code JHM}, positions 4 through 6 are any character,
@@ -110,8 +110,8 @@ public interface Like extends Constraint<String> {
 
     /**
      * <p>Requires that the constraint target match the given {@code pattern},
-     * in which the given characters represent wildcards, and no escape
-     * character is included.</p>
+     * in which the given characters represent wildcards. The supplied
+     * pattern has no escape character.</p>
      *
      * <p>For example, the following requires that the first 3 positions of a
      * VIN number are {@code JHM}, positions 4 through 6 are any character,

--- a/api/src/main/java/jakarta/data/constraint/NotLike.java
+++ b/api/src/main/java/jakarta/data/constraint/NotLike.java
@@ -83,8 +83,8 @@ public interface NotLike extends Constraint<String> {
 
     /**
      * <p>Requires that the constraint target not match the given
-     * {@code pattern}, in which {@code _} and {@code %} represent wildcards,
-     * and no escape character is included.</p>
+     * {@code pattern}, in which {@code _} and {@code %} represent wildcards.
+     * The supplied pattern has no escape character.</p>
      *
      * <p>For example, the following requires that the VIN number not have
      * {@code JHM} as its first 3 character positions and {@code E} in
@@ -105,8 +105,8 @@ public interface NotLike extends Constraint<String> {
 
     /**
      * <p>Requires that the constraint target not match the given
-     * {@code pattern}, in which the given characters represent wildcards,
-     * and no escape character is included.</p>
+     * {@code pattern}, in which the given characters represent wildcards.
+     * The supplied pattern has no escape character.</p>
      *
      * <p>For example, the following requires that the VIN number not have
      * {@code JHM} as its first 3 character positions and {@code F} in


### PR DESCRIPTION
Address review comment that was _originally posted by @gavinking in https://github.com/jakartaee/data/pull/1211#discussion_r2349969217_

> "no escape character is included" is very ambiguous to me. Does it mean:
> 
> - there is no escape character at all, or
> - there is no escape character explicitly specified, so the escape character defaults to `\`?

