### PR TITLE
update: parent project to M1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
     - name: Build project
       run: |
         mvn -B \
-        -P oss-release \
         --file pom.xml \
         clean package
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0-M1</version>
     </parent>
 
     <groupId>jakarta.data</groupId>
@@ -66,20 +66,6 @@
             <organizationUrl>https://accounts.eclipse.org/mailing-list/data-dev</organizationUrl>
         </developer>
     </developers>
-    
-    <repositories>
-        <repository>
-            <name>Central Portal Snapshots</name>
-            <id>central-portal-snapshots</id>
-            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 
     <properties>
         <maven.compiler.release>21</maven.compiler.release>


### PR DESCRIPTION
Release notes: https://github.com/eclipse-ee4j/ee4j/releases/tag/2.0.0-M1
I'll wait to do the M1 release of Data until this is merged to save us the headache of having to update the SNAPSHOT version of the parent later in the service branch. 