### PR TITLE
TCK assertion is missing a character

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -2642,7 +2642,7 @@ public class EntityTests {
 
         Stream<CardinalNumber> stream = characters.cardinalNumberStream(3L);
 
-        assertEquals(List.of("10 COMPOSITE (4 bits",
+        assertEquals(List.of("10 COMPOSITE (4 bits)",
                         "11 PRIME (4 bits)",
                         "12 COMPOSITE (4 bits)",
                         "13 PRIME (4 bits)",


### PR DESCRIPTION
I noticed this TCK test is missing a character in the assertion after it failed when I tried to run the TCK.  This PR corrects it.  It is one of the new tests for Data 1.1 which is under development.