### PR TITLE
correct a copy paste error in WHERE clause requirement

### DIFF
--- a/spec/src/main/asciidoc/query-language.asciidoc
+++ b/spec/src/main/asciidoc/query-language.asciidoc
@@ -102,7 +102,7 @@ When working with NoSQL databases, the `WHERE` clause behavior may vary dependin
 
 Key-Value Databases:: Support for a `WHERE` clause with an equality restriction on the unique identifier attribute is required. A key-value database might not be capable of processing a query without a `WHERE` clause or with a `WHERE` clause that does not include an equality restriction on the unique identifier attribute.
 
-Wide-Column Databases:: Support for a `WHERE` clause with an equality restriction on the unique identifier attribute is required. A wide-column database might not be capable of processing a query without a `WHERE` clause or with a `WHERE` clause that does not include an equality restriction on the unique identifier attribute.
+Wide-Column Databases:: Support for a `WHERE` clause with an equality restriction on the unique identifier attribute is required. A wide-column database might not be capable of processing a query without a `WHERE` clause or with a `WHERE` clause that restricts an attribute other than the unique identifier.
 
 ==== Update statements
 


### PR DESCRIPTION
When I recently added the `WHERE` clause exemption section for NoSQL databases, I copy/pasted the Wide-Column text from the Key-Value text and missed updating the end of it, which still has information that matches Key-Value rather than Wide-Column, making it contradictory to other text in the specification.  This PR corrects it.