### PR TITLE
feat: add missing NoSQL annotation for capital field in Country class

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/Country.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/Country.java
@@ -27,6 +27,7 @@ public class Country {
 
     @jakarta.persistence.Column(nullable = false)
     @jakarta.persistence.Embedded
+    @jakarta.nosql.Column
     private City capital;
 
     @jakarta.nosql.Id


### PR DESCRIPTION
This pull request introduces a minor update to the `Country` class in the TCK data framework. The main change is the addition of a NoSQL-specific annotation to the `capital` field, likely to improve compatibility with NoSQL data stores.

* Added the `@jakarta.nosql.Column` annotation to the `capital` field in the `Country` class to support NoSQL data mapping.