### PR TITLE
Replace additional references to Jakarta Data Query Language

### DIFF
--- a/spec/src/main/asciidoc/architecture.asciidoc
+++ b/spec/src/main/asciidoc/architecture.asciidoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Contributors to the Eclipse Foundation
+// Copyright (c) 2022,2026 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -159,7 +159,7 @@ The previous example illustrates the design of a repository interface which capt
 Jakarta Data provides two core ways to express queries:
 
 - <<Parameter-based automatic query methods,parameter-based automatic query methods>>, that is, `@Find` and `@Delete`, and
-- <<Annotated query methods,annotated query methods>>, that is `@Query` and <<Jakarta Data Query Language>> or Jakarta Persistence Query Language.
+- <<Annotated query methods,annotated query methods>>, that is `@Query` and <<Jakarta Common Query Language>> or Jakarta Persistence Query Language.
 
 Newly written code should use these approaches.
 A typical application based on Jakarta Data uses a mix of both approaches, with the choice of approach depending on the complexity of the query.

--- a/spec/src/main/asciidoc/entity.asciidoc
+++ b/spec/src/main/asciidoc/entity.asciidoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
+// Copyright (c) 2022,2026 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -323,7 +323,7 @@ NOTE: Support for entity associations is not required by this specification.
 
 === Entity names and persistent attribute names
 
-Entities and their persistent attributes may be referenced by name in the query language defined in <<Jakarta Data Query Language>>.
+Entities and their persistent attributes may be referenced by name in the query language defined in <<Jakarta Common Query Language>>.
 
 ==== Entity names
 

--- a/spec/src/main/asciidoc/method-query.asciidoc
+++ b/spec/src/main/asciidoc/method-query.asciidoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
+// Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -66,7 +66,7 @@ public interface ProductRepository extends BasicRepository<Product, Long> {
 The functionality described here overlaps significantly with both:
 
 - parameter-based automatic query methods, that is, `@Find` and `@Delete`, and
-- annotated query methods, that is `@Query` and Jakarta Data Query Language or Jakarta Persistence Query Language.
+- annotated query methods, that is `@Query` and Jakarta Common Query Language or Jakarta Persistence Query Language.
 
 Therefore, these alternative approaches are strongly preferred for newly-written code.
 

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
+// Copyright (c) 2022,2026 Contributors to the Eclipse Foundation
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -144,7 +144,7 @@ However, Jakarta Data implementations are strongly encouraged to support the fol
 Furthermore, implementations are encouraged to support `void` as the return type for a query which never returns a result.
 ====
 
-This specification defines the built-in `@Query` annotation, which may be used to specify a query written in the <<Jakarta Data Query Language>> defined in the next chapter.
+This specification defines the built-in `@Query` annotation, which may be used to specify a query written in the <<Jakarta Common Query Language>> defined in the next chapter.
 
 For example, using a named parameter:
 


### PR DESCRIPTION
In a prior PR, I replaced occurrences of JDQL with JCQL, but missed updating some occurrences of "Jakarta Data Query Language".  This PR updates the remaining occurrences.