### PR TITLE
fix: use different plugin to stage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,15 @@
                     <artifactId>central-staging-plugins</artifactId>
                     <version>1.3.0</version>
                 </plugin>
+                <!-- 
+                TODO - remove once parent is updated 
+                        https://github.com/eclipse-ee4j/ee4j/pull/115/
+                -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.1.4</version>
+                </plugin>
                 <plugin>
                     <groupId>org.sonarsource.scanner.maven</groupId>
                     <artifactId>sonar-maven-plugin</artifactId>
@@ -410,17 +419,14 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.central</groupId>
-                        <artifactId>central-publishing-maven-plugin</artifactId>
-                        <extensions>true</extensions>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-deploy-plugin</artifactId>
                         <configuration>
-                            <autoPublish>true</autoPublish>
-                            <deploymentName>${project.name} ${project.version}</deploymentName>
-                            <publishingServerId>repo3.eclipse.org</publishingServerId>
-                            <waitUntil>validated</waitUntil>
-                            <!-- TODO verify this is the correct URL -->
-                            <centralBaseUrl>https://repo3.eclipse.org/repository/${nexus.staging.repository}/</centralBaseUrl>
-                            <!-- TODO - would projects want to stage snapshots as well? -->
+                            <altReleaseDeploymentRepository>
+                                repo3.eclipse.org::default::https://repo3.eclipse.org/repository/${nexus.staging.repository}/
+                            </altReleaseDeploymentRepository>
+                            <deployAtEnd>true</deployAtEnd> <!-- Do not deploy if build failure -->
+                            <skip>snapshots</skip>          <!-- Skip if SNAPSHOT version - Disallow staging SNAPSHOT-->
                         </configuration>
                     </plugin>
                 </plugins>
@@ -495,12 +501,11 @@
             <repositories>
                 <repository>
                     <name>Nexus staging</name>
-                    <id>Nexus staging</id>
+                    <id>repo3.eclipse.org</id>
                     <url>https://repo3.eclipse.org/repository/ee4j-staging/</url>
                     <releases>
                         <enabled>true</enabled>
                     </releases>
-                    <!-- TODO - would projects want to stage snapshots as well? -->
                     <snapshots>
                         <enabled>false</enabled>
                     </snapshots>


### PR DESCRIPTION
replace `central-publishing-maven-plugin` with `maven-deploy-plugin` to upload artifacts to the staging repository. 
As suggested here: https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6890#note_5887257