### PR TITLE
Switch some Javadoc {@code} to {@link} to reference other spec API

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -63,6 +63,31 @@
             <version>${jakarta.annotation.version}</version>
             <scope>provided</scope>
         </dependency>
+        <!-- For Javadoc references only: -->
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <version>${jakarta.enterprise.cdi.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <version>${jakarta.inject.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>${jakarta.persistence.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+            <version>${jakarta.transaction.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api/src/main/java/jakarta/data/page/CursoredPage.java
+++ b/api/src/main/java/jakarta/data/page/CursoredPage.java
@@ -111,7 +111,7 @@ import java.util.NoSuchElementException;
  * <h2>Cursor-based Pagination with {@code @Query}</h2>
  *
  * <p>The {@link Query} annotation from Jakarta Data and the similar
- * {@code jakarta.persistence.StaticQuery} annotation from Jakarta Persistence
+ * {@code jakarta.persistence.query.StaticQuery} annotation from Jakarta Persistence
  * allow the application to supply a Jakarta Common Query Language (JCQL) or
  * Jakarta Persistence Query Language (JPQL) query for the repository method
  * to perform.</p>

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1166,7 +1166,7 @@ import java.util.Set;
  *
  * <p>In advanced scenarios, the application program might make direct use of
  * some underlying resource acquired by the Jakarta Data provider, such as a
- * {@code javax.sql.DataSource}, {@code java.sql.Connection}, or even an
+ * {@link javax.sql.DataSource}, {@link java.sql.Connection}, or even an
  * {@code jakarta.persistence.EntityManager}.</p>
  *
  * <p>To expose access to an instance of such a resource, the repository
@@ -1416,8 +1416,15 @@ import java.util.Set;
  * }
  * }</pre>
  */
-//TODO switch @code to @link for jakarta.persistence.query.* once Persistence 4.0 M1 is available
+//TODO switch @code to @link for jakarta.persistence.query.* once it is determined
+// why Javadoc links to API from other Jakarta spec modules are not working
 module jakarta.data {
+    // requires static jakarta.inject;      // compile time dependency for Javadoc
+    // requires static jakarta.persistence; // compile time dependency for Javadoc
+    // requires static jakarta.transaction; // compile time dependency for Javadoc
+    // The above is not working for Javadoc links to Jakarta API, even though
+    // the following does work for Javadoc links to JDBC API,
+    requires static java.sql; // compile time dependency for Javadoc
     exports jakarta.data;
     exports jakarta.data.constraint;
     exports jakarta.data.event;

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <jakarta.json.bind.version>3.0.0</jakarta.json.bind.version>
         <jakarta.json.version>2.1.3</jakarta.json.version>
         <jakarta.data.version>${project.version}</jakarta.data.version>
-        <jakarta.persistence.version>3.2.0</jakarta.persistence.version>
+        <jakarta.persistence.version>4.0.0-M1</jakarta.persistence.version>
         <jakarta.nosql.version>1.0.1</jakarta.nosql.version>
         <jakarta.servlet.version>6.1.0</jakarta.servlet.version> 
         <jakarta.transaction.version>2.0.1</jakarta.transaction.version>


### PR DESCRIPTION
The original purpose of the PR was to have Javadoc links to newly introduced Jakarta Persistence API (from 4.0.0 M1) instead of using `{@code}` to spell out the class name.  While working on that, I came across a couple of similar cases with `java.sql.Connection` and `javax.sql.DataSource` and turned those into links as well.  It turns out the latter ended up working when viewing the generated Javadoc, whereas the former (links to Jakarta spec API) does not.  At this point, I'm not sure why, but I'll at least add the updates with the working links to the latter, and maybe someone else will spot what is wrong with the links to Jakarta specs (other than needing to switch from `code` to `link`) before I do.