### PR TITLE
fix: skip default deploy plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -466,6 +466,13 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin> <!-- Skip the default deploy plugin -->
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                            <configuration>
+                                <skip>true</skip>
+                            </configuration>
+                    </plugin>
                     <plugin>
                         <groupId>org.eclipse.cbi.central</groupId>
                         <artifactId>central-staging-plugins</artifactId>


### PR DESCRIPTION
Cannot use the staging plugin to sync artifacts from stage to maven central when the default deploy plugin is enabled. 