### PR TITLE
fix: staging plugin needs to create bearer token

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -484,6 +484,9 @@
                                     <goal>rc-sync</goal>
                                 </goals>
                                 <configuration>
+                                    <bearerCreate>true</bearerCreate>
+                                    <generateChecksums256>true</generateChecksums256>
+                                    <generateChecksums512>true</generateChecksums512>
                                     <repositoryUrl>https://repo3.eclipse.org/repository/${nexus.staging.repository}/</repositoryUrl>
                                     <signArtifacts>true</signArtifacts>
                                     <syncAutoPublish>true</syncAutoPublish>


### PR DESCRIPTION
bearer token and higher order checksums are not created by default.