### PR TITLE
Add `@NativeQuery` annotation

### DIFF
--- a/api/src/main/java/jakarta/data/exceptions/NonUniqueResultException.java
+++ b/api/src/main/java/jakarta/data/exceptions/NonUniqueResultException.java
@@ -19,6 +19,7 @@ package jakarta.data.exceptions;
 
 import jakarta.data.repository.Find;
 import jakarta.data.repository.First;
+import jakarta.data.repository.NativeQuery;
 import jakarta.data.repository.Query;
 
 /**
@@ -27,7 +28,8 @@ import jakarta.data.repository.Query;
  *
  * <p>This error can be circumvented by applying the {@link First @First}
  * annotation
- * to a repository {@link Find} or {@link Query} method to explicitly request
+ * to a repository {@link Find}, {@link Query} or {@link NativeQuery} method
+ * to explicitly request
  * that at most one result be returned. Alternatively, if using the Query by
  * Method Name pattern, the {@code findFirst...} method name pattern can be used
  * to explicitly request that at most one result be returned.</p>

--- a/api/src/main/java/jakarta/data/repository/Delete.java
+++ b/api/src/main/java/jakarta/data/repository/Delete.java
@@ -110,7 +110,7 @@ import jakarta.data.restrict.Restriction;
  * {@code jakarta.persistence.query.WriteQueryOptions} to supply additional
  * query options that are specific to Jakarta Persistence.</p>
  *
- * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Insert}, {@code @Update}, {@code @Delete}, and
+ * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @NativeQuery}, {@code @Update}, {@code @Delete}, and
  * {@code @Save} are mutually-exclusive. A given method of a repository interface may have at most one {@code @Find}
  * annotation, lifecycle annotation, or query annotation.
  * </p>

--- a/api/src/main/java/jakarta/data/repository/Find.java
+++ b/api/src/main/java/jakarta/data/repository/Find.java
@@ -145,7 +145,7 @@ import java.lang.annotation.Target;
  * {@code jakarta.persistence.query.ReadQueryOptions} to supply additional
  * query options that are specific to Jakarta Persistence.</p>
  *
- * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Insert}, {@code @Update}, {@code @Delete}, and
+ * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @NativeQuery}, {@code @Update}, {@code @Delete}, and
  * {@code @Save} are mutually-exclusive. A given method of a repository interface may have at most one {@code @Find}
  * annotation, lifecycle annotation, or query annotation.
  *

--- a/api/src/main/java/jakarta/data/repository/Insert.java
+++ b/api/src/main/java/jakarta/data/repository/Insert.java
@@ -74,7 +74,7 @@ import java.lang.annotation.Target;
  * method before each record is inserted. An event of type {@link jakarta.data.event.PostInsertEvent}
  * must be raised by the annotated lifecycle method after each record is successfully inserted.
  * </p>
- * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Insert}, {@code @Update}, {@code @Delete}, and
+ * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @NativeQuery}, {@code @Update}, {@code @Delete}, and
  * {@code @Save} are mutually-exclusive. A given method of a repository interface may have at most one {@code @Find}
  * annotation, lifecycle annotation, or query annotation.
  * </p>

--- a/api/src/main/java/jakarta/data/repository/NativeQuery.java
+++ b/api/src/main/java/jakarta/data/repository/NativeQuery.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2022,2026 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data.repository;
+
+import jakarta.data.Limit;
+import jakarta.data.Order;
+import jakarta.data.Sort;
+import jakarta.data.page.PageRequest;
+import jakarta.data.restrict.Restriction;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <p>Annotates a repository method as a native query method, specifying a query
+ * written in a native query language specific to the underlying datastore.
+ * The syntax and capabilities of the native query language are determined
+ * by the Jakarta Data provider and the target datastore technology.</p>
+ *
+ * <p>This specification does not define or constrain the syntax of native
+ * queries, which is expected to be distinct from JCQL or JPQL.
+ * For that reason, repository methods using {@code @NativeQuery}
+ * are inherently non-portable between different types of datastores,
+ * and possibly even between different Jakarta Data providers targeting
+ * the same type of datastore.</p>
+ *
+ * <p>The required {@link #value} member specifies the native query as a
+ * string, using whatever query language is appropriate for the datastore.</p>
+ *
+ * <p>For queries that return data extracted from the datastore (e.g. SQL {@code select}),
+ * the return type of the native query method must be consistent with the type returned by
+ * the query. The exact meaning of "consistent", as well as the rules for mapping between
+ * native query results and Java types, is determined by the Jakarta Data provider.</p>
+ *
+ * <p>For queries that do not return data extracted from the datastore
+ * (e.g. the simplest forms of SQL {@code insert}/{@code update}/{@code delete}),
+ * the return value must be one of:</p>
+ * <ul>
+ * <li>{@code void}</li>
+ * <li>{@code int} or {@code long}, where the value is the number of matching
+ *     records affected by the operation. The Jakarta Data provider
+ *     may throw {@link UnsupportedOperationException} if the datastore cannot
+ *     reliably determine this count.
+ *     </li>
+ * </ul>
+ *
+ * <p>A query might involve parameters.
+ * The syntax of parameters in the native query string,
+ * as well as the mapping mechanism from Java parameters to native parameters,
+ * are determined by the Jakarta Data provider and the underlying datastore.</p>
+ *
+ * <p>Each parameter of an annotated native query method must either:</p>
+ * <ul>
+ * <li>have exactly the same name (the parameter name in the Java source, or
+ *     a name assigned by {@link Param @Param}) and type as a named parameter
+ *     of the native query, if the Jakarta Data provider supports named parameters,</li>
+ * <li>have exactly the same type and position within the parameter list of
+ *     the method as a positional parameter of the native query,
+ *     if the Jakarta Data provider supports positional parameters, or</li>
+ * <li>be of type {@link Limit} or {@link PageRequest}.</li>
+ * </ul>
+ * <p>{@link Restriction}, {@link Sort} and {@link Order} are not valid parameter types
+ * in native query methods.</p>
+ * <p>The Jakarta Data provider may throw {@link UnsupportedOperationException}
+ * when passed a cursor-based {@link PageRequest}
+ * if the provider doesn't support cursors (key-based pagination).</p>
+ *
+ * <p>The {@link Param} annotation associates a method parameter with a named
+ * parameter. The {@code Param} annotation is unnecessary when the method
+ * parameter name matches the name of a named parameter and the application is
+ * compiled with the {@code -parameters} compiler option making parameter names
+ * available at runtime.</p>
+ *
+ * <p>For example (note that the query syntax and parameter syntax shown below
+ * are for illustration only; actual syntax is determined by the Jakarta Data
+ * provider):</p>
+ *
+ * <pre>{@code
+ * @Repository
+ * public interface Products extends CrudRepository<Product, Long> {
+ *
+ *     // Native SQL query with positional parameter (example syntax)
+ *     @NativeQuery("SELECT * FROM product WHERE price > ? ORDER BY price DESC")
+ *     List<Product> findExpensiveProducts(double minPrice);
+ *
+ *     // Native query with named parameter (example syntax)
+ *     @NativeQuery("SELECT * FROM product WHERE name LIKE :pattern")
+ *     List<Product> searchByName(@Param("pattern") String pattern);
+ *
+ *     // Native delete operation
+ *     @NativeQuery("DELETE FROM product WHERE discontinued = true")
+ *     long removeDiscontinuedProducts();
+ *
+ *     ...
+ * }
+ * }</pre>
+ *
+ * <p>A method annotated with {@code @NativeQuery} must return one of the following types:</p>
+ * <ul>
+ *     <li>the query result type {@code R}, when the query returns a single result,</li>
+ *     <li>{@code Optional<R>}, when the query returns at most a single result,</li>
+ *     <li>an array type {@code R[]},
+ *     <li>{@code List<R>},</li>
+ *     <li>{@code Stream<R>}, or</li>
+ *     <li>{@code Page<R>}, or</li>
+ *     <li>or {@code CursoredPage<R>}, if supported by the
+ *         Jakarta Data provider for native queries.</li>
+ * </ul>
+ * <p>The method returns an object for every query result.</p>
+ * <p>The number of query results may be limited using the {@link First} annotation.</p>
+ * <ul>
+ * <li>If the return type of the annotated method is {@code R} or {@code Optional<R>}
+ *     and more than one record satisfies the query restriction, the method must throw
+ *     {@link jakarta.data.exceptions.NonUniqueResultException}.</li>
+ * <li>If the return type of the annotated method is {@code R} and no record satisfies
+ *     the query restriction, the method must throw
+ *     {@link jakarta.data.exceptions.EmptyResultException}.</li>
+ * </ul>
+ *
+ * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @NativeQuery}, {@code @Insert},
+ * {@code @Update}, {@code @Delete}, and {@code @Save} are mutually-exclusive. A given method
+ * of a repository interface may have at most one {@code @Find} annotation, lifecycle annotation,
+ * or query annotation.
+ *
+ * @see Query
+ * @see Param
+ * @see First
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface NativeQuery {
+
+    /**
+     * <p>Specifies the native query executed by the annotated repository method,
+     * using the query language of the underlying datastore.</p>
+     *
+     * <p>The syntax and semantics of the native query are determined by the
+     * Jakarta Data provider and are specific to the target datastore technology.</p>
+     *
+     * @return the native query to be executed when the annotated method is called.
+     */
+    String value();
+}

--- a/api/src/main/java/jakarta/data/repository/OrderBy.java
+++ b/api/src/main/java/jakarta/data/repository/OrderBy.java
@@ -74,7 +74,8 @@ import java.lang.annotation.Target;
  *     name,</li>
  * <li>a {@link Query} or {@code jakarta.persistence.query.StaticQuery}
  *     annotation specifying a query with an {@code ORDER BY} clause, nor</li>
- * <li>a {@code jakarta.persistence.query.StaticNativeQuery} annotation.</li>
+ * <li>a {@link NativeQuery} or {@code jakarta.persistence.query.StaticNativeQuery}
+ *     annotation.</li>
  * </ul>
  * <p>A Jakarta Data provider is permitted to reject such a repository
  * method declaration at compile time or to implement the method to

--- a/api/src/main/java/jakarta/data/repository/Param.java
+++ b/api/src/main/java/jakarta/data/repository/Param.java
@@ -47,9 +47,6 @@ import java.lang.annotation.Target;
  * {@code -parameters} compiler option making parameter names available at
  * runtime.</p>
  *
- * <p>Named parameters are not supported on repository methods annotated
- * {@code jakarta.persistence.query.StaticNativeQuery}.</p>
- *
  * @see Query
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/jakarta/data/repository/Query.java
+++ b/api/src/main/java/jakarta/data/repository/Query.java
@@ -164,7 +164,7 @@ import java.lang.annotation.Target;
  *     {@link jakarta.data.exceptions.EmptyResultException}.</li>
  * </ul>
  *
- * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Insert}, {@code @Update}, {@code @Delete}, and
+ * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @NativeQuery}, {@code @Update}, {@code @Delete}, and
  * {@code @Save} are mutually-exclusive. A given method of a repository interface may have at most one {@code @Find}
  * annotation, lifecycle annotation, or query annotation.
  *

--- a/api/src/main/java/jakarta/data/repository/Save.java
+++ b/api/src/main/java/jakarta/data/repository/Save.java
@@ -68,7 +68,7 @@ import java.lang.annotation.Target;
  *     and {@link jakarta.data.event.PostUpsertEvent} instead of {@link jakarta.data.event.PreInsertEvent} and
  *     {@link jakarta.data.event.PostInsertEvent} respectively.
  * </ul>
- * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Insert}, {@code @Update}, {@code @Delete}, and
+ * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @NativeQuery}, {@code @Update}, {@code @Delete}, and
  * {@code @Save} are mutually-exclusive. A given method of a repository interface may have at most one {@code @Find}
  * annotation, lifecycle annotation, or query annotation.
  * </p>

--- a/api/src/main/java/jakarta/data/repository/Select.java
+++ b/api/src/main/java/jakarta/data/repository/Select.java
@@ -51,6 +51,7 @@ import java.lang.annotation.Target;
  *
  * <p>This annotation must not be used in other locations; in particular,
  * it must not be used on repository methods annotated
+ * with {@link NativeQuery} or
  * {@code jakarta.persistence.query.StaticNativeQuery}.</p>
  *
  * <p>Sort criteria for a repository method that returns a projection

--- a/api/src/main/java/jakarta/data/repository/Update.java
+++ b/api/src/main/java/jakarta/data/repository/Update.java
@@ -74,7 +74,7 @@ import java.lang.annotation.Target;
  * method before each record is updated. An event of type {@link jakarta.data.event.PostUpdateEvent}
  * must be raised by the annotated lifecycle method after each record is successfully updated.
  * </p>
- * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Insert}, {@code @Update}, {@code @Delete}, and
+ * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @NativeQuery}, {@code @Update}, {@code @Delete}, and
  * {@code @Save} are mutually-exclusive. A given method of a repository interface may have at most one {@code @Find}
  * annotation, lifecycle annotation, or query annotation.
  * </p>

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -171,6 +171,28 @@ void deleteBook(String isbn);
 Programs which make use of annotated query methods are not in general portable between providers.
 However, when the `@Query` annotation specifies a query written in JCQL, the annotated query method is portable between providers to the extent to which its semantics can be implemented on the underlying data store.
 
+This specification also defines the built-in `@NativeQuery` annotation, which may be used to specify a query written in a native query language specific to the underlying datastore.
+The syntax and capabilities of the native query language are determined by the Jakarta Data provider and the target datastore technology.
+
+The Jakarta Data provider may decide to not support the `@NativeQuery` annotation at all.
+Repository methods using `@NativeQuery` are inherently non-portable between different Jakarta Data providers or different types of datastores, as they directly access datastore-specific query capabilities.
+
+For example:
+
+[source,java]
+----
+// Example: Native SQL query with positional parameter (syntax is implementation-specific)
+@NativeQuery("SELECT * FROM Product WHERE price > ?1 ORDER BY price DESC")
+List<Product> findExpensiveProducts(double minPrice);
+----
+
+[source,java]
+----
+// Example: Native query with named parameter (syntax is implementation-specific)
+@NativeQuery("SELECT * FROM Product WHERE name LIKE :pattern")
+List<Product> searchByName(@Param("pattern") String pattern);
+----
+
 [NOTE]
 ====
 A Jakarta Data provider might extend this specification to define its own query annotation types.
@@ -187,13 +209,13 @@ The Jakarta Persistence specification defines several annotations in the `jakart
 
 - `@StaticQuery`, which can annotate a Jakarta Data repository method in place of Jakarta Data's `@Query` to supply a JPQL query.
 
-- `@ReadQueryOptions`, which can annotate a Jakarta Data repository method annotated `@Query`, `@StaticQuery`, or `@StaticNativeQuery` that performs a `SELECT` operation. Alternatively, it can annotate a Jakarta Data repository method annotated `@Find`. The `ReadQueryOptions` annotation allows the application to supply additional options defined by Jakarta Persistence for queries that perform read operations.
+- `@ReadQueryOptions`, which can annotate a Jakarta Data repository method annotated `@Query`, `@NativeQuery`, `@StaticQuery`, or `@StaticNativeQuery` that performs a `SELECT` operation. Alternatively, it can annotate a Jakarta Data repository method annotated `@Find`. The `ReadQueryOptions` annotation allows the application to supply additional options defined by Jakarta Persistence for queries that perform read operations.
 
-- `@WriteQueryOptions`, which can annotate a Jakarta Data repository method annotated `@Query`, `@StaticQuery`, or `@StaticNativeQuery` that performs a `DELETE` or `UPDATE` operation. Alternatively, it can annotate a Jakarta Data repository method annotated `@Delete` when the latter is not used as a lifecycle annotation.  The `WriteQueryOptions` annotation allows the application to supply additional options defined by Jakarta Persistence for queries that perform write operations.
+- `@WriteQueryOptions`, which can annotate a Jakarta Data repository method annotated `@Query`, `@NativeQuery`, `@StaticQuery`, or `@StaticNativeQuery` that performs a `DELETE` or `UPDATE` operation. Alternatively, it can annotate a Jakarta Data repository method annotated `@Delete` when the latter is not used as a lifecycle annotation.  The `WriteQueryOptions` annotation allows the application to supply additional options defined by Jakarta Persistence for queries that perform write operations.
 
-==== Limitations of JPQL and native SQL queries
+==== Limitations of JPQL and native queries
 
-The Jakarta Data provider is not required to support JPQL or native SQL for repository query methods that require generating or modifying the query, including repository methods with any of the following:
+The Jakarta Data provider is not required to support JPQL or native queries for repository query methods that require generating or modifying the query, including repository methods with any of the following:
 
 - Projections
 - `Restriction` and `Constraint`-typed parameters
@@ -284,7 +306,7 @@ A resource accessor method with return type `jakarta.persistence.EntityManager` 
 
 === Conflicting repository method annotations
 
-Annotations like `@Find`, `@Query`, `@Insert`, `@Update`, `@Delete`, and `@Save` are mutually-exclusive. A given method of a repository interface may have at most one:
+Annotations like `@Find`, `@Query`, `@NativeQuery`, `@Insert`, `@Update`, `@Delete`, and `@Save` are mutually-exclusive. A given method of a repository interface may have at most one:
 
 - `@Find` annotation,
 - lifecycle annotation, or
@@ -420,7 +442,7 @@ List<User> findByNamePrefix(String namePrefix, Sort<User> sort);
 
 === Restrictions
 
-A method annotated `@Find`, `@Delete`, or `@Query` may have a <<special-parameters,special parameter>> of type `Restriction<T>`.
+A method annotated `@Find`, `@Delete`, `@Query`, or `@NativeQuery` may have a <<special-parameters,special parameter>> of type `Restriction<T>`.
 This parameter allows the caller of a repository method to programmatically express additional restrictions on the results returned by the repository method, often using a <<metamodel-java-processor,generated metamodel class>> for type safety.
 
 For example:


### PR DESCRIPTION
Opening as a draft to gauge the appeal... I mostly focused on javadoc for now and have not looked in details at the spec. I will push an update to address that later.

---

Jakarta Data has `@Query`, Jakarta Persistence has `@StaticQuery`.

Jakarta Persistence also has `@StaticNativeQuery`, but Jakarta Data has... nothing?

This is an attempt at filling the gap, so that applications can rely on Jakarta Data to write (some) native queries, and more importantly (for me) can use an annotation with a simple, intuitive name to do so.

Note this is an entirely optional feature, and the syntax of native queries is implementation-dependent. As such, I do not know how to add TCK tests.

cc @gavinking