### PR TITLE
how to sort nulls

### DIFF
--- a/api/src/main/java/jakarta/data/Sort.java
+++ b/api/src/main/java/jakarta/data/Sort.java
@@ -231,8 +231,13 @@ public record Sort<T>(String property,
     }
 
     /**
-     * Create a {@link Sort} instance, indicating how {@code null} values are
-     * ordered.
+     * <p>Create a {@link Sort} instance, indicating how {@code null} values
+     * are ordered.</p>
+     *
+     * <p>If the data store is a non-relational database that is not capable
+     * of ordering {@code null} values according to the given
+     * {@code nullsFirst} argument, then repository methods to which this
+     * instance is supplied must raise {@link IllegalArgumentException}.</p>
      *
      * @param <T>        entity class of the sortable entity attribute.
      * @param attribute  name of the entity attribute to order by
@@ -315,11 +320,8 @@ public record Sort<T>(String property,
 
     /**
      * <p>Returns an otherwise-equivalent sort that orders {@code null} values
-     * first. If the data store is not capable of ordering {@code null} values
-     * first, then repository methods to which this instance is supplied must
-     * raise {@link UnsupportedOperationException}.</p>
+     * first. For example,</p>
      *
-     * <p>For example,</p>
      * <pre>{@code
      * page1 = customers.livingIn(country,
      *                            PageRequest.ofSize(50),
@@ -327,6 +329,11 @@ public record Sort<T>(String property,
      *                                     _Customer.cityName.asc().nullsFirst(),
      *                                     _Customer.id.asc()));
      * }</pre>
+     *
+     * <p>If the data store is a non-relational database that is not capable
+     * of ordering {@code null} values first, then repository methods to which
+     * this instance is supplied must raise {@link IllegalArgumentException}.
+     * </p>
      *
      * @return a sort with {@link #orderNullsFirst} set to {@code TRUE}.
      */
@@ -336,11 +343,8 @@ public record Sort<T>(String property,
 
     /**
      * <p>Returns an otherwise-equivalent sort that orders {@code null} values
-     * last. If the data store is not capable of ordering {@code null} values
-     * last, then repository methods to which this instance is supplied must
-     * raise {@link UnsupportedOperationException}.</p>
+     * last. For example,</p>
      *
-     * <p>For example,</p>
      * <pre>{@code
      * page1 = products.namedLike(namePattern,
      *                            PageRequest.ofSize(25),
@@ -348,6 +352,11 @@ public record Sort<T>(String property,
      *                                     _Product.name.asc(),
      *                                     _Product.id.asc()));
      * }</pre>
+     *
+     * <p>If the data store is a non-relational database that is not capable
+     * of ordering {@code null} values last, then repository methods to which
+     * this instance is supplied must raise {@link IllegalArgumentException}.
+     * </p>
      *
      * @return a sort with {@link #orderNullsFirst} set to {@code FALSE}.
      */

--- a/api/src/main/java/jakarta/data/Sort.java
+++ b/api/src/main/java/jakarta/data/Sort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2026 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,27 +78,46 @@ import jakarta.data.repository.OrderBy;
  * if the database is incapable of ordering the query results using the given
  * sort criteria.</p>
  *
- * @param <T>         entity class of the entity attribute upon which to sort.
- * @param property    name of the entity attribute to order by.
- * @param isAscending whether ordering for this attribute is ascending (true) or
- *                    descending (false).
- * @param ignoreCase  whether or not to request case insensitive ordering from a
- *                    database with case sensitive collation.
+ * @param <T>             entity class of the entity attribute upon which to
+ *                        sort.
+ * @param property        name of the entity attribute to order by.
+ * @param isAscending     whether ordering for this attribute is ascending
+ *                        ({@code true}) or descending ({@code false}).
+ * @param ignoreCase      whether or not to request case insensitive ordering
+ *                        from a database with case sensitive collation.
+ * @param orderNullsFirst whether {@code null} values are ordered first
+ *                        ({@code TRUE}), last ({@code FALSE}), or according
+ *                        to the capability and behavior of the underlying
+ *                        data store ({@code null}).
  */
-public record Sort<T>(String property, boolean isAscending,
-                      boolean ignoreCase) {
+public record Sort<T>(String property,
+                      boolean isAscending,
+                      boolean ignoreCase,
+                      Boolean orderNullsFirst) {
     /**
      * <p>Defines sort criteria for an entity attribute. For more descriptive
      * code, use:</p>
      * <ul>
      * <li>{@link #asc(String) Sort.asc(attributeName)}
      *     for ascending sort on an entity attribute.</li>
+     * <li>{@link #asc(String) Sort.asc(attributeName)}.{@link #nullsFirst()}
+     *     for ascending sort on an entity attribute,
+     *     where {@code null} values are ordered first.</li>
      * <li>{@link #ascIgnoreCase(String) Sort.ascIgnoreCase(attributeName)}
      *     for case insensitive ascending sort on an entity attribute.</li>
+     * <li>{@link #ascIgnoreCase(String) Sort.ascIgnoreCase(attributeName)}.{@link #nullsFirst()}
+     *     for case insensitive ascending sort on an entity attribute,
+     *     where {@code null} values are ordered first.</li>
      * <li>{@link #desc(String) Sort.desc(attributeName)}
      *     for descending sort on an entity attribute.</li>
+     * <li>{@link #desc(String) Sort.desc(attributeName)}.{@link #nullsLast()}
+     *     for descending sort on an entity attribute,
+     *     where {@code null} values are ordered last.</li>
      * <li>{@link #descIgnoreCase(String) Sort.descIgnoreCase(attributeName)}
-     *      for case insensitive descending sort on an entity attribute.</li>
+     *     for case insensitive descending sort on an entity attribute.</li>
+     * <li>{@link #descIgnoreCase(String) Sort.descIgnoreCase(attributeName)}.{@link #nullsLast()}
+     *     for case insensitive descending sort on an entity attribute,
+     *     where {@code null} values are ordered last.</li>
      * </ul>
      *
      * @param property    name of the entity attribute to order by.
@@ -112,6 +131,20 @@ public record Sort<T>(String property, boolean isAscending,
             throw new NullPointerException(
                 Messages.get("001.arg.required", "attribute"));
         }
+    }
+
+    /**
+     * <p>Constructor for compatibility with Jakarta Data 1.0. Use the
+     * {@link #of(String, Direction, boolean)} method instead.</p>
+     *
+     * @param property    name of the entity attribute to order by.
+     * @param isAscending whether ordering for this attribute is ascending
+     *                    ({@code true}) or descending ({@code false}).
+     * @param ignoreCase  whether or not to request case insensitive ordering
+     *                    from a database with case sensitive collation.
+     */
+    public Sort(String property, boolean isAscending, boolean ignoreCase) {
+        this(property, isAscending, ignoreCase, null);
     }
 
     // Override to provide method documentation:
@@ -163,7 +196,18 @@ public record Sort<T>(String property, boolean isAscending,
     }
 
     /**
-     * Create a {@link Sort} instance
+     * Indicates whether {@code null} values are ordered first ({@code TRUE}),
+     * last ({@code FALSE}), or according to the capability and behavior of the
+     * underlying data store ({@code null}).
+     *
+     * @return indication of how {@code null} values are ordered.
+     */
+    public Boolean orderNullsFirst() {
+        return orderNullsFirst;
+    }
+
+    /**
+     * Create a {@link Sort} instance.
      *
      * @param <T>        entity class of the sortable entity attribute.
      * @param attribute  name of the entity attribute to order by
@@ -172,13 +216,46 @@ public record Sort<T>(String property, boolean isAscending,
      * @return a {@link Sort} instance. Never {@code null}.
      * @throws NullPointerException when there is a null parameter
      */
-    public static <T> Sort<T> of(String attribute, Direction direction, boolean ignoreCase) {
+    public static <T> Sort<T> of(String attribute,
+                                 Direction direction,
+                                 boolean ignoreCase) {
         if (direction == null) {
             throw new NullPointerException(
                     Messages.get("001.arg.required", "direction"));
         }
 
-        return new Sort<>(attribute, Direction.ASC.equals(direction), ignoreCase);
+        return new Sort<>(attribute,
+                          Direction.ASC.equals(direction),
+                          ignoreCase,
+                          null);
+    }
+
+    /**
+     * Create a {@link Sort} instance, indicating how {@code null} values are
+     * ordered.
+     *
+     * @param <T>        entity class of the sortable entity attribute.
+     * @param attribute  name of the entity attribute to order by
+     * @param direction  the direction in which to order.
+     * @param ignoreCase whether to request a case insensitive ordering.
+     * @param nullsFirst whether {@code null} values are ordered first
+     *                   ({@code true}) or last ({@code false}).
+     * @return a {@link Sort} instance. Never {@code null}.
+     * @throws NullPointerException when there is a {@code null} parameter.
+     */
+    public static <T> Sort<T> of(String attribute,
+                                 Direction direction,
+                                 boolean ignoreCase,
+                                 boolean nullsFirst) {
+        if (direction == null) {
+            throw new NullPointerException(
+                    Messages.get("001.arg.required", "direction"));
+        }
+
+        return new Sort<>(attribute,
+                          Direction.ASC.equals(direction),
+                          ignoreCase,
+                          nullsFirst);
     }
 
     /**
@@ -192,7 +269,7 @@ public record Sort<T>(String property, boolean isAscending,
      * @throws NullPointerException when the attribute name is null
      */
     public static <T> Sort<T> asc(String attribute) {
-        return new Sort<>(attribute, true, false);
+        return new Sort<>(attribute, true, false, null);
     }
 
     /**
@@ -205,7 +282,7 @@ public record Sort<T>(String property, boolean isAscending,
      * @throws NullPointerException when the attribute name is null.
      */
     public static <T> Sort<T> ascIgnoreCase(String attribute) {
-        return new Sort<>(attribute, true, true);
+        return new Sort<>(attribute, true, true, null);
     }
 
     /**
@@ -219,7 +296,7 @@ public record Sort<T>(String property, boolean isAscending,
      * @throws NullPointerException when the attribute name is null
      */
     public static <T> Sort<T> desc(String attribute) {
-        return new Sort<>(attribute, false, false);
+        return new Sort<>(attribute, false, false, null);
     }
 
     /**
@@ -233,6 +310,48 @@ public record Sort<T>(String property, boolean isAscending,
      * @throws NullPointerException when the attribute name is null.
      */
     public static <T> Sort<T> descIgnoreCase(String attribute) {
-        return new Sort<>(attribute, false, true);
+        return new Sort<>(attribute, false, true, null);
+    }
+
+    /**
+     * <p>Returns an otherwise-equivalent sort that orders {@code null} values
+     * first. If the data store is not capable of ordering {@code null} values
+     * first, then repository methods to which this instance is supplied must
+     * raise {@link UnsupportedOperationException}.</p>
+     *
+     * <p>For example,</p>
+     * <pre>{@code
+     * page1 = customers.livingIn(country,
+     *                            PageRequest.ofSize(50),
+     *                            Order.by(_Customer.stateName.asc().nullsFirst(),
+     *                                     _Customer.cityName.asc().nullsFirst(),
+     *                                     _Customer.id.asc()));
+     * }</pre>
+     *
+     * @return a sort with {@link #orderNullsFirst} set to {@code TRUE}.
+     */
+    public Sort<T> nullsFirst() {
+        return new Sort<>(property, isAscending, ignoreCase, true);
+    }
+
+    /**
+     * <p>Returns an otherwise-equivalent sort that orders {@code null} values
+     * last. If the data store is not capable of ordering {@code null} values
+     * last, then repository methods to which this instance is supplied must
+     * raise {@link UnsupportedOperationException}.</p>
+     *
+     * <p>For example,</p>
+     * <pre>{@code
+     * page1 = products.namedLike(namePattern,
+     *                            PageRequest.ofSize(25),
+     *                            Order.by(_Product.price.desc().nullsLast(),
+     *                                     _Product.name.asc(),
+     *                                     _Product.id.asc()));
+     * }</pre>
+     *
+     * @return a sort with {@link #orderNullsFirst} set to {@code FALSE}.
+     */
+    public Sort<T> nullsLast() {
+        return new Sort<>(property, isAscending, ignoreCase, false);
     }
 }

--- a/api/src/main/java/jakarta/data/Sort.java
+++ b/api/src/main/java/jakarta/data/Sort.java
@@ -78,22 +78,50 @@ import jakarta.data.repository.OrderBy;
  * if the database is incapable of ordering the query results using the given
  * sort criteria.</p>
  *
- * @param <T>             entity class of the entity attribute upon which to
- *                        sort.
- * @param property        name of the entity attribute to order by.
- * @param isAscending     whether ordering for this attribute is ascending
- *                        ({@code true}) or descending ({@code false}).
- * @param ignoreCase      whether or not to request case insensitive ordering
- *                        from a database with case sensitive collation.
- * @param orderNullsFirst whether {@code null} values are ordered first
- *                        ({@code TRUE}), last ({@code FALSE}), or according
- *                        to the capability and behavior of the underlying
- *                        data store ({@code null}).
+ * @param <T>          entity class of the entity attribute upon which to sort.
+ * @param property     name of the entity attribute to order by.
+ * @param isAscending  whether ordering for this attribute is ascending
+ *                     ({@code true}) or descending ({@code false}).
+ * @param ignoreCase   whether or not to request case insensitive ordering
+ *                     from a database with case sensitive collation.
+ * @param nullOrdering whether {@code null} values are ordered
+ *                     {@link Nulls#FIRST FIRST}, {@link Nulls#LAST LAST}, or
+ *                     {@linkplain Nulls#UNSPECIFIED by the data store}.
  */
 public record Sort<T>(String property,
                       boolean isAscending,
                       boolean ignoreCase,
-                      Boolean orderNullsFirst) {
+                      Nulls nullOrdering) {
+
+    /**
+     * Indicates how {@code null} values are ordered.
+     *
+     * @since 1.1
+     */
+    public enum Nulls {
+        /**
+         * Values that are {@code null} are ordered before values that are
+         * non-{@code null}. If the data store is a non-relational database
+         * that is not capable of ordering {@code null} values, then
+         * repository methods to which this value is supplied must raise
+         * {@link IllegalArgumentException}.
+         */
+        FIRST,
+        /**
+         * Values that are not {@code null} are ordered before values that
+         * are {@code null}. If the data store is a non-relational database
+         * that is not capable of ordering {@code null} values, then
+         * repository methods to which this value is supplied must raise
+         * {@link IllegalArgumentException}.
+         */
+        LAST,
+        /**
+         * Ordering of {@code null} values is not indicated by the application
+         * and is left the capability and behavior of the data store.
+         */
+        UNSPECIFIED
+    }
+
     /**
      * <p>Defines sort criteria for an entity attribute. For more descriptive
      * code, use:</p>
@@ -120,16 +148,25 @@ public record Sort<T>(String property,
      *     where {@code null} values are ordered last.</li>
      * </ul>
      *
-     * @param property    name of the entity attribute to order by.
-     * @param isAscending whether ordering for this attribute is ascending
-     *                    (true) or descending (false).
-     * @param ignoreCase  whether or not to request case insensitive ordering
-     *                    from a database with case sensitive collation.
+     * @param property     name of the entity attribute to order by.
+     * @param isAscending  whether ordering for this attribute is ascending
+     *                     (true) or descending (false).
+     * @param ignoreCase   whether or not to request case insensitive ordering
+     *                     from a database with case sensitive collation.
+     * @param nullOrdering whether {@code null} values are ordered
+     *                     {@link Nulls#FIRST FIRST}, {@link Nulls#LAST LAST},
+     *                     or {@linkplain Nulls#UNSPECIFIED by the data store}.
+     * @since 1.1
      */
     public Sort {
         if (property == null) {
             throw new NullPointerException(
                 Messages.get("001.arg.required", "attribute"));
+        }
+
+        if (nullOrdering == null) {
+            throw new NullPointerException(
+                Messages.get("001.arg.required", "nullOrdering"));
         }
     }
 
@@ -144,7 +181,7 @@ public record Sort<T>(String property,
      *                    from a database with case sensitive collation.
      */
     public Sort(String property, boolean isAscending, boolean ignoreCase) {
-        this(property, isAscending, ignoreCase, null);
+        this(property, isAscending, ignoreCase, Nulls.UNSPECIFIED);
     }
 
     // Override to provide method documentation:
@@ -196,14 +233,15 @@ public record Sort<T>(String property,
     }
 
     /**
-     * Indicates whether {@code null} values are ordered first ({@code TRUE}),
-     * last ({@code FALSE}), or according to the capability and behavior of the
-     * underlying data store ({@code null}).
+     * Indicates whether {@code null} values are ordered
+     * {@link Nulls#FIRST FIRST}, {@link Nulls#LAST LAST}, or
+     * {@linkplain Nulls#UNSPECIFIED by the data store}.
      *
      * @return indication of how {@code null} values are ordered.
+     * @since 1.1
      */
-    public Boolean orderNullsFirst() {
-        return orderNullsFirst;
+    public Nulls nullOrdering() {
+        return nullOrdering;
     }
 
     /**
@@ -227,31 +265,28 @@ public record Sort<T>(String property,
         return new Sort<>(attribute,
                           Direction.ASC.equals(direction),
                           ignoreCase,
-                          null);
+                          Nulls.UNSPECIFIED);
     }
 
     /**
      * <p>Create a {@link Sort} instance, indicating how {@code null} values
      * are ordered.</p>
      *
-     * <p>If the data store is a non-relational database that is not capable
-     * of ordering {@code null} values according to the given
-     * {@code nullsFirst} argument, then repository methods to which this
-     * instance is supplied must raise {@link IllegalArgumentException}.</p>
-     *
-     * @param <T>        entity class of the sortable entity attribute.
-     * @param attribute  name of the entity attribute to order by
-     * @param direction  the direction in which to order.
-     * @param ignoreCase whether to request a case insensitive ordering.
-     * @param nullsFirst whether {@code null} values are ordered first
-     *                   ({@code true}) or last ({@code false}).
+     * @param <T>         entity class of the sortable entity attribute.
+     * @param attribute    name of the entity attribute to order by
+     * @param direction    the direction in which to order.
+     * @param ignoreCase   whether to request a case insensitive ordering.
+     * @param nullOrdering whether {@code null} values are ordered
+     *                     {@link Nulls#FIRST FIRST}, {@link Nulls#LAST LAST},
+     *                     or {@linkplain Nulls#UNSPECIFIED by the data store}.
      * @return a {@link Sort} instance. Never {@code null}.
      * @throws NullPointerException when there is a {@code null} parameter.
+     * @since 1.1
      */
     public static <T> Sort<T> of(String attribute,
                                  Direction direction,
                                  boolean ignoreCase,
-                                 boolean nullsFirst) {
+                                 Nulls nullOrdering) {
         if (direction == null) {
             throw new NullPointerException(
                     Messages.get("001.arg.required", "direction"));
@@ -260,7 +295,7 @@ public record Sort<T>(String property,
         return new Sort<>(attribute,
                           Direction.ASC.equals(direction),
                           ignoreCase,
-                          nullsFirst);
+                          nullOrdering);
     }
 
     /**
@@ -274,7 +309,7 @@ public record Sort<T>(String property,
      * @throws NullPointerException when the attribute name is null
      */
     public static <T> Sort<T> asc(String attribute) {
-        return new Sort<>(attribute, true, false, null);
+        return new Sort<>(attribute, true, false, Nulls.UNSPECIFIED);
     }
 
     /**
@@ -287,7 +322,7 @@ public record Sort<T>(String property,
      * @throws NullPointerException when the attribute name is null.
      */
     public static <T> Sort<T> ascIgnoreCase(String attribute) {
-        return new Sort<>(attribute, true, true, null);
+        return new Sort<>(attribute, true, true, Nulls.UNSPECIFIED);
     }
 
     /**
@@ -301,7 +336,7 @@ public record Sort<T>(String property,
      * @throws NullPointerException when the attribute name is null
      */
     public static <T> Sort<T> desc(String attribute) {
-        return new Sort<>(attribute, false, false, null);
+        return new Sort<>(attribute, false, false, Nulls.UNSPECIFIED);
     }
 
     /**
@@ -315,7 +350,7 @@ public record Sort<T>(String property,
      * @throws NullPointerException when the attribute name is null.
      */
     public static <T> Sort<T> descIgnoreCase(String attribute) {
-        return new Sort<>(attribute, false, true, null);
+        return new Sort<>(attribute, false, true, Nulls.UNSPECIFIED);
     }
 
     /**
@@ -335,10 +370,11 @@ public record Sort<T>(String property,
      * this instance is supplied must raise {@link IllegalArgumentException}.
      * </p>
      *
-     * @return a sort with {@link #orderNullsFirst} set to {@code TRUE}.
+     * @return a sort with {@link #nullOrdering} set to {@link Nulls#FIRST}.
+     * @since 1.1
      */
     public Sort<T> nullsFirst() {
-        return new Sort<>(property, isAscending, ignoreCase, true);
+        return new Sort<>(property, isAscending, ignoreCase, Nulls.FIRST);
     }
 
     /**
@@ -358,9 +394,10 @@ public record Sort<T>(String property,
      * this instance is supplied must raise {@link IllegalArgumentException}.
      * </p>
      *
-     * @return a sort with {@link #orderNullsFirst} set to {@code FALSE}.
+     * @return a sort with {@link #nullOrdering} set to {@link Nulls#LAST}.
+     * @since 1.1
      */
     public Sort<T> nullsLast() {
-        return new Sort<>(property, isAscending, ignoreCase, false);
+        return new Sort<>(property, isAscending, ignoreCase, Nulls.LAST);
     }
 }

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -936,7 +936,7 @@ import java.util.Set;
  *
  * <p>When a page is requested with a {@code PageRequest}, dynamic sorting
  * criteria may be supplied by passing instances of {@link Sort} to an
- * {@link Order}. parameter. For example,</p>
+ * {@link Order} parameter. For example,</p>
  *
  * <pre>{@code
  * @Find
@@ -973,7 +973,7 @@ import java.util.Set;
  * found = products.nameLiked(namePattern,
  *                            Limit.of(25),
  *                            Order.by(Sort.desc("price"),
- *                                     Sort.desc("amountSold"),
+ *                                     Sort.desc("amountSold").nullsFirst(),
  *                                     Sort.asc("id")));
  * }</pre>
  *

--- a/api/src/test/java/jakarta/data/SortTest.java
+++ b/api/src/test/java/jakarta/data/SortTest.java
@@ -19,6 +19,7 @@ package jakarta.data;
 
 import jakarta.data.mock.entity._Book;
 import jakarta.data.mock.entity.Book;
+import jakarta.data.Sort.Nulls;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,11 +40,13 @@ class SortTest {
         assertThatNullPointerException().isThrownBy(() ->
                 Sort.of(null, Direction.ASC, false));
         assertThatNullPointerException().isThrownBy(() ->
-                Sort.of(null, null, false, true));
+                Sort.of(null, null, false, Sort.Nulls.FIRST));
         assertThatNullPointerException().isThrownBy(() ->
-                Sort.of(NAME, null, true, false));
+                Sort.of(NAME, null, true, Sort.Nulls.LAST));
         assertThatNullPointerException().isThrownBy(() ->
-                Sort.of(null, Direction.ASC, false, true));
+                Sort.of(null, Direction.ASC, false, Sort.Nulls.UNSPECIFIED));
+        assertThatNullPointerException().isThrownBy(() ->
+        Sort.of(NAME, Direction.ASC, false, null));
     }
 
     @Test
@@ -57,7 +60,7 @@ class SortTest {
             softly.assertThat(order.isAscending()).isTrue();
             softly.assertThat(order.isDescending()).isFalse();
             softly.assertThat(order.ignoreCase()).isFalse();
-            softly.assertThat(order.orderNullsFirst()).isNull();
+            softly.assertThat(order.nullOrdering()).isEqualTo(Nulls.UNSPECIFIED);
         });
     }
 
@@ -72,7 +75,7 @@ class SortTest {
             softly.assertThat(order.isAscending()).isFalse();
             softly.assertThat(order.isDescending()).isTrue();
             softly.assertThat(order.ignoreCase()).isTrue();
-            softly.assertThat(order.orderNullsFirst()).isNull();
+            softly.assertThat(order.nullOrdering()).isEqualTo(Nulls.UNSPECIFIED);
         });
     }
 
@@ -87,7 +90,7 @@ class SortTest {
             softly.assertThat(order.isAscending()).isTrue();
             softly.assertThat(order.isDescending()).isFalse();
             softly.assertThat(order.ignoreCase()).isFalse();
-            softly.assertThat(order.orderNullsFirst()).isNull();
+            softly.assertThat(order.nullOrdering()).isEqualTo(Nulls.UNSPECIFIED);
         });
     }
 
@@ -102,7 +105,7 @@ class SortTest {
             softly.assertThat(order.isAscending()).isTrue();
             softly.assertThat(order.isDescending()).isFalse();
             softly.assertThat(order.ignoreCase()).isTrue();
-            softly.assertThat(order.orderNullsFirst()).isNull();
+            softly.assertThat(order.nullOrdering()).isEqualTo(Nulls.UNSPECIFIED);
         });
     }
 
@@ -117,7 +120,7 @@ class SortTest {
             softly.assertThat(order.isAscending()).isFalse();
             softly.assertThat(order.isDescending()).isTrue();
             softly.assertThat(order.ignoreCase()).isFalse();
-            softly.assertThat(order.orderNullsFirst()).isNull();
+            softly.assertThat(order.nullOrdering()).isEqualTo(Nulls.UNSPECIFIED);
         });
     }
 
@@ -132,7 +135,7 @@ class SortTest {
             softly.assertThat(order.isAscending()).isFalse();
             softly.assertThat(order.isDescending()).isTrue();
             softly.assertThat(order.ignoreCase()).isTrue();
-            softly.assertThat(order.orderNullsFirst()).isNull();
+            softly.assertThat(order.nullOrdering()).isEqualTo(Nulls.UNSPECIFIED);
         });
     }
 
@@ -151,7 +154,7 @@ class SortTest {
             softly.assertThat(sort.isAscending()).isTrue();
             softly.assertThat(sort.isDescending()).isFalse();
             softly.assertThat(sort.ignoreCase()).isFalse();
-            softly.assertThat(sort.orderNullsFirst()).isEqualTo(Boolean.TRUE);
+            softly.assertThat(sort.nullOrdering()).isEqualTo(Nulls.FIRST);
         });
     }
 
@@ -170,7 +173,7 @@ class SortTest {
             softly.assertThat(sort.isAscending()).isFalse();
             softly.assertThat(sort.isDescending()).isTrue();
             softly.assertThat(sort.ignoreCase()).isTrue();
-            softly.assertThat(sort.orderNullsFirst()).isEqualTo(Boolean.FALSE);
+            softly.assertThat(sort.nullOrdering()).isEqualTo(Nulls.LAST);
         });
     }
 }

--- a/api/src/test/java/jakarta/data/SortTest.java
+++ b/api/src/test/java/jakarta/data/SortTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022,2023 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2026 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,9 @@
  */
 package jakarta.data;
 
+import jakarta.data.mock.entity._Book;
+import jakarta.data.mock.entity.Book;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -29,9 +32,18 @@ class SortTest {
     @Test
     @DisplayName("Should throw NullPointerException when one of the properties are null")
     void shouldReturnErrorWhenPropertyDirectionNull() {
-        assertThatNullPointerException().isThrownBy(() -> Sort.of(null, null, false));
-        assertThatNullPointerException().isThrownBy(() -> Sort.of(NAME, null, true));
-        assertThatNullPointerException().isThrownBy(() -> Sort.of(null, Direction.ASC, false));
+        assertThatNullPointerException().isThrownBy(() ->
+                Sort.of(null, null, false));
+        assertThatNullPointerException().isThrownBy(() ->
+                Sort.of(NAME, null, true));
+        assertThatNullPointerException().isThrownBy(() ->
+                Sort.of(null, Direction.ASC, false));
+        assertThatNullPointerException().isThrownBy(() ->
+                Sort.of(null, null, false, true));
+        assertThatNullPointerException().isThrownBy(() ->
+                Sort.of(NAME, null, true, false));
+        assertThatNullPointerException().isThrownBy(() ->
+                Sort.of(null, Direction.ASC, false, true));
     }
 
     @Test
@@ -45,6 +57,7 @@ class SortTest {
             softly.assertThat(order.isAscending()).isTrue();
             softly.assertThat(order.isDescending()).isFalse();
             softly.assertThat(order.ignoreCase()).isFalse();
+            softly.assertThat(order.orderNullsFirst()).isNull();
         });
     }
 
@@ -59,6 +72,7 @@ class SortTest {
             softly.assertThat(order.isAscending()).isFalse();
             softly.assertThat(order.isDescending()).isTrue();
             softly.assertThat(order.ignoreCase()).isTrue();
+            softly.assertThat(order.orderNullsFirst()).isNull();
         });
     }
 
@@ -73,6 +87,7 @@ class SortTest {
             softly.assertThat(order.isAscending()).isTrue();
             softly.assertThat(order.isDescending()).isFalse();
             softly.assertThat(order.ignoreCase()).isFalse();
+            softly.assertThat(order.orderNullsFirst()).isNull();
         });
     }
 
@@ -87,6 +102,7 @@ class SortTest {
             softly.assertThat(order.isAscending()).isTrue();
             softly.assertThat(order.isDescending()).isFalse();
             softly.assertThat(order.ignoreCase()).isTrue();
+            softly.assertThat(order.orderNullsFirst()).isNull();
         });
     }
 
@@ -101,6 +117,7 @@ class SortTest {
             softly.assertThat(order.isAscending()).isFalse();
             softly.assertThat(order.isDescending()).isTrue();
             softly.assertThat(order.ignoreCase()).isFalse();
+            softly.assertThat(order.orderNullsFirst()).isNull();
         });
     }
 
@@ -115,6 +132,45 @@ class SortTest {
             softly.assertThat(order.isAscending()).isFalse();
             softly.assertThat(order.isDescending()).isTrue();
             softly.assertThat(order.ignoreCase()).isTrue();
+            softly.assertThat(order.orderNullsFirst()).isNull();
+        });
+    }
+
+    @DisplayName("""
+            The nullsFirst method must create a new instance of Sort in which
+            orderNullsFirst is TRUE and all other record component values
+            from the original instance are preserved.
+            """)
+    @Test
+    void testNullsFirst() {
+        Sort<Book> sort = _Book.numChapters.asc().nullsFirst();
+
+        assertSoftly(softly -> {
+            softly.assertThat(sort).isNotNull();
+            softly.assertThat(sort.property()).isEqualTo(_Book.NUMCHAPTERS);
+            softly.assertThat(sort.isAscending()).isTrue();
+            softly.assertThat(sort.isDescending()).isFalse();
+            softly.assertThat(sort.ignoreCase()).isFalse();
+            softly.assertThat(sort.orderNullsFirst()).isEqualTo(Boolean.TRUE);
+        });
+    }
+
+    @DisplayName("""
+            The nullsLast method must create a new instance of Sort in which
+            orderNullsFirst is FALSE and all other record component values
+            from the original instance are preserved.
+            """)
+    @Test
+    void testNullsLast() {
+        Sort<Book> sort = _Book.title.descIgnoreCase().nullsLast();
+
+        assertSoftly(softly -> {
+            softly.assertThat(sort).isNotNull();
+            softly.assertThat(sort.property()).isEqualTo(_Book.TITLE);
+            softly.assertThat(sort.isAscending()).isFalse();
+            softly.assertThat(sort.isDescending()).isTrue();
+            softly.assertThat(sort.ignoreCase()).isTrue();
+            softly.assertThat(sort.orderNullsFirst()).isEqualTo(Boolean.FALSE);
         });
     }
 }


### PR DESCRIPTION
Resolves #1416 which requested a way to indicate whether null values should be sorted first or last.  This is done with methods `.nullsFirst()` and `.nullsLast()` that can be invoked on a `Sort` instance to obtain an otherwise equivalent instance that specifies how to sort nulls.  This pattern aligns with designed `PageRequest` in Jakarta Data.  I have included language that allows NoSQL databases to reject a `Sort` instance that has `nullsFirst` or `nullsLast` if the NoSQL database is not capable of it.