### PR TITLE
Some clarifications on stateful repositories around persistence context

### DIFF
--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -999,17 +999,19 @@ Support for stateful repositories is defined in the dedicated module `jakarta.da
 
 ==== Persistence contexts
 
-A stateful repository is backed by a _persistence context_, a set of managed entity instances in which at most one instance represents a given record in the database.
+Each operation on a stateful repository is associated with a _persistence context_, a set of managed entity instances in which at most one instance represents a given record in the database.
 
 - An entity instance never belongs to multiple persistence contexts.
 
 - The Jakarta Data implementation must ensure that a given persistence context never contains more than one entity instance representing the same record.
 
-- Multiple repositories might share a persistence context, especially if they share a datastore.
+- Multiple operations on a single repository, in particular those running in the same transaction or thread, can share a persistence context.
+
+- Operations on multiple repositories might share a persistence context, especially if the repositories share a datastore.
 
 - A persistence context is never shared across transactions.
 
-A query method of a stateful repository which returns an entity type always returns managed instances belonging to the persistence context associated with the repository.
+A query method of a stateful repository which returns an entity type always returns managed instances belonging to a persistence context associated with the repository.
 
 [WARNING]
 ====
@@ -1031,7 +1033,7 @@ A <<Lifecycle methods, lifecycle method>> of a stateful repository must be annot
 The annotations `@Save`, `@Insert`, `@Update`, `@Delete` are used to define stateless repositories and must not be used to declare lifecycle methods of a stateful repository.
 Instead, this specification defines the special lifecycle annotations `@Persist`, `@Merge`, `@Refresh`, `@Remove`, and `@Detach` for declaring lifecycle methods of stateful repositories.
 
-A lifecycle method annotated `@Remove` or `@Refresh` only accepts managed entities associated with the persistence context underlying the repository.
+A lifecycle method annotated `@Remove` or `@Refresh` only accepts managed entities belonging to a persistence context that is associated with the repository.
 On the other hand, a method annotated `@Persist`, `@Merge`, or `@Detach` also accepts unmanaged entities.
 
 ==== Automatic change detection

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -1020,9 +1020,13 @@ If an application program accesses an entity instance belonging to a persistence
 
 This specification does not define the lifecycle of a persistence context, nor how a persistence context is propagated across repositories.
 
+===== Persistence context within a transaction
+
+All operations performed on a given repository that participate in a given transaction must run under the same persistence context. The Jakarta Data provider must ensure that the persistence context is flushed prior to or during the before completion phase of transaction commit.
+
 [NOTE]
 ====
-Implementations of Jakarta Data are encouraged to propagate a single persistence context within a given transaction across repositories which share a given datasource.
+Implementations of Jakarta Data are encouraged to propagate a single persistence context within a given transaction across repositories which share a given data store.
 For example, a Jakarta Data provider backed by an implementation of Jakarta Persistence might take advantage of standard Jakarta EE transaction-scoped persistence context propagation.
 ====
 
@@ -1045,7 +1049,7 @@ Invocation of a lifecycle method or modification of the state of a managed entit
 Such changes to the database do not typically happen synchronously with invocation of the lifecycle method, or immediately after modification of the managed entity.
 Instead, such changes are made when the persistence context is periodically _flushed_.
 
-NOTE: This specification does not prescribe the timing of flush operations, but a flush typically happens before execution of a query or during the before completion phase of transaction commit.
+NOTE: This specification does not prescribe the timing of flush operations for persistence context that does not participate in a transaction.
 An implementation of Jakarta Data should flush as needed to ensure that query results are consistent with the current state of the persistence context.
 
 

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -999,19 +999,17 @@ Support for stateful repositories is defined in the dedicated module `jakarta.da
 
 ==== Persistence contexts
 
-Each operation on a stateful repository is associated with a _persistence context_, a set of managed entity instances in which at most one instance represents a given record in the database.
+A stateful repository operation applies to a _persistence context_, a set of managed entity instances in which at most one instance represents a given record in the database. Persistence context can span multiple repository operations, such as all operations performed within a transaction.
 
 - An entity instance never belongs to multiple persistence contexts.
 
 - The Jakarta Data implementation must ensure that a given persistence context never contains more than one entity instance representing the same record.
 
-- Multiple operations on a single repository, in particular those running in the same transaction or thread, can share a persistence context.
-
-- Operations on multiple repositories might share a persistence context, especially if the repositories share a datastore.
+- Multiple repositories might share a persistence context, especially if they share a datastore.
 
 - A persistence context is never shared across transactions.
 
-A query method of a stateful repository which returns an entity type always returns managed instances belonging to a persistence context associated with the repository.
+A query method of a stateful repository which returns an entity type always returns managed instances belonging to the persistence context in which the repository operation is running.
 
 [WARNING]
 ====
@@ -1019,10 +1017,6 @@ If an application program accesses an entity instance belonging to a persistence
 ====
 
 This specification does not define the lifecycle of a persistence context, nor how a persistence context is propagated across repositories.
-
-===== Persistence context within a transaction
-
-All operations performed on a given repository that participate in a given transaction must run under the same persistence context. The Jakarta Data provider must ensure that the persistence context is flushed prior to or during the before completion phase of transaction commit.
 
 [NOTE]
 ====
@@ -1037,7 +1031,7 @@ A <<Lifecycle methods, lifecycle method>> of a stateful repository must be annot
 The annotations `@Save`, `@Insert`, `@Update`, `@Delete` are used to define stateless repositories and must not be used to declare lifecycle methods of a stateful repository.
 Instead, this specification defines the special lifecycle annotations `@Persist`, `@Merge`, `@Refresh`, `@Remove`, and `@Detach` for declaring lifecycle methods of stateful repositories.
 
-A lifecycle method annotated `@Remove` or `@Refresh` only accepts managed entities belonging to a persistence context that is associated with the repository.
+A lifecycle method annotated `@Remove` or `@Refresh` only accepts managed entities associated with the persistence context under which the repository method is running.
 On the other hand, a method annotated `@Persist`, `@Merge`, or `@Detach` also accepts unmanaged entities.
 
 ==== Automatic change detection
@@ -1049,7 +1043,7 @@ Invocation of a lifecycle method or modification of the state of a managed entit
 Such changes to the database do not typically happen synchronously with invocation of the lifecycle method, or immediately after modification of the managed entity.
 Instead, such changes are made when the persistence context is periodically _flushed_.
 
-NOTE: This specification does not prescribe the timing of flush operations for persistence context that does not participate in a transaction.
+NOTE: This specification does not prescribe the timing of flush operations, but a flush typically happens before execution of a query or during the before completion phase of transaction commit.
 An implementation of Jakarta Data should flush as needed to ensure that query results are consistent with the current state of the persistence context.
 
 

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -999,7 +999,9 @@ Support for stateful repositories is defined in the dedicated module `jakarta.da
 
 ==== Persistence contexts
 
-A stateful repository operation applies to a _persistence context_, a set of managed entity instances in which at most one instance represents a given record in the database. Persistence context can span multiple repository operations, such as all operations performed within a transaction.
+A stateful repository operation is always performed in a _persistence context_, operating on a set of managed entity instances in which at most one instance represents a given record in the database.
+A given persistence context might span multiple repository operations. 
+For example, a persistence context often spans the operations performed within a given transaction.
 
 - An entity instance never belongs to multiple persistence contexts.
 

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -1011,7 +1011,7 @@ For example, a persistence context often spans the operations performed within a
 
 - A persistence context is never shared across transactions.
 
-A query method of a stateful repository which returns an entity type always returns managed instances belonging to the persistence context in which the repository operation is running.
+A query method of a stateful repository which returns an entity type always returns managed instances belonging to the persistence context in which the repository operation is performed.
 
 [WARNING]
 ====
@@ -1033,7 +1033,7 @@ A <<Lifecycle methods, lifecycle method>> of a stateful repository must be annot
 The annotations `@Save`, `@Insert`, `@Update`, `@Delete` are used to define stateless repositories and must not be used to declare lifecycle methods of a stateful repository.
 Instead, this specification defines the special lifecycle annotations `@Persist`, `@Merge`, `@Refresh`, `@Remove`, and `@Detach` for declaring lifecycle methods of stateful repositories.
 
-A lifecycle method annotated `@Remove` or `@Refresh` only accepts managed entities associated with the persistence context under which the repository method is running.
+A lifecycle method annotated `@Remove` or `@Refresh` only accepts managed entities associated with the persistence context in which the repository method is performed.
 On the other hand, a method annotated `@Persist`, `@Merge`, or `@Detach` also accepts unmanaged entities.
 
 ==== Automatic change detection


### PR DESCRIPTION
The language we currently have implies in some places there is only one persistence context associated with a repository:

> A query method of a stateful repository which returns an entity type always returns managed instances belonging to **the persistence context** associated with the repository.

> A lifecycle method annotated `@Remove` or `@Refresh` only accepts managed entities associated with **the persistence context** underlying the repository.

> A stateful repository is backed by a _persistence context_

Methods of a repository can be invoked by multiple threads at the same time. Persistence context is not designed to be accessed by multiple threads or from multiple transactions, as stated in another line from the Data spec

> A persistence context is never shared across transactions.

The first 3 references cited above need to be adjusted, which is done in commit 1.


Commit 2 strengthens requirements and guarantees to the developer around using a stateful repository within a transaction.


Usage of a stateless repository outside of a transaction is another problem.  Considering the following pattern,

```java
person = people.find(id);
person.setStreetAddress(newAddress);
person.setCity(newCity);
person.setState(newState);
```

How does the Jakarta Data provider know that the application is done with the persistence context such that updates ought to be flushed to the database versus whether the application intends to make another update,

```java
person.setZipCode(newZipCode);
```

The only way I know of to indicate this currently is to use a resource accessor method on a JPA-backed Data provider to explicitly flush,

```java
EntityManager em = people.getEntityManager();
em.flush();
em.close(); // ?
```

Resource accessor methods are an advanced pattern. I also don't like the problem the user is confronted with here of whether it's a good idea or terrible idea to close the EntityManager obtained from the stateful repository.  Assuming usage outside of a transaction is intended to be supported -- the Data spec doesn't currently require a transaction -- I think we can make this easier on users by providing a built-in `flush()` operation.  But that will require an interface for `StatefulRepository`.  I haven't included that in this PR because we should probably discuss it first.
