### PR TITLE
StatefulRepository with flush method?

### DIFF
--- a/stateful/src/main/java/jakarta/data/repository/stateful/StatefulRepository.java
+++ b/stateful/src/main/java/jakarta/data/repository/stateful/StatefulRepository.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+package jakarta.data.repository.stateful;
+
+import jakarta.data.repository.DataRepository;
+
+/**
+ * TODO documentation
+ *
+ * @param <T> the type of the primary entity class of the repository.
+ * @param <K> the type of the unique identifier attribute of the primary
+ *            entity.
+ * @since 1.1
+ */
+@SuppressWarnings("PMD.ImplicitFunctionalInterface")
+public interface StatefulRepository<T, K> extends DataRepository<T, K> {
+
+    /**
+     * <p>Flush all changes represented in the persistence context to the
+     * database.</p>
+     */
+    void flush();
+}


### PR DESCRIPTION
For discussion at the Jakarta Data meeting:
Do we need something like this for applications that use a stateful repository to modify a persistence context outside of a transaction?

```java
Person person = people.find(ssn);
person.setHomeAddress(newAddress);
person.setZipCode(newZipCode);
```

Without a flush operation, how can the application know that its changes will be persisted vs lost?
The same applies to our TCK tests.  In order to make assertions about what went in to the database, we need guarantees that operations we perform will be persisted after a certain point.