### PR TITLE
Update spec.version to 1.1 in pom.xml

### DIFF
--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -42,7 +42,7 @@
 
         <!-- default is the same for backward compatibility reason
         Easy to override when building with a system property -->
-        <spec.version>1.0</spec.version>
+        <spec.version>1.1</spec.version>
     </properties>
 
     <build>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -134,6 +134,19 @@
                     </attributes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.6.1</version>
+                <executions>
+                    <execution>
+                        <id>parse-version</id>
+                        <goals>
+                            <goal>parse-version</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -42,7 +42,7 @@
 
         <!-- default is the same for backward compatibility reason
         Easy to override when building with a system property -->
-        <spec.version>1.1</spec.version>
+        <spec.version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}</spec.version>
     </properties>
 
     <build>


### PR DESCRIPTION
This pull request updates the Maven build configuration in `spec/pom.xml` to improve version management by dynamically setting the specification version and introducing a new plugin for parsing version information.

**Build and versioning improvements:**

* The `spec.version` property is now set dynamically using the parsed major and minor version numbers from the project version, instead of being hardcoded.
* Added the `build-helper-maven-plugin` (version 3.6.1) with the `parse-version` goal to the build plugins, enabling automatic extraction of version components for use in properties.