### PR TITLE
Rename artifactId to jakarta.data.stateful-api in pom.xml

### DIFF
--- a/stateful/pom.xml
+++ b/stateful/pom.xml
@@ -27,7 +27,7 @@
         <version>1.1.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>jakarta.data-stateful</artifactId>
+    <artifactId>jakarta.data.stateful-api</artifactId>
     <name>Jakarta Data Stateful Repository API</name>
     <description>Jakarta Data :: Stateful Repository API</description>
 


### PR DESCRIPTION
This pull request makes a minor update to the `stateful/pom.xml` file, renaming the Maven artifact from `jakarta.data-stateful` to `jakarta.data.stateful-api` to better reflect naming conventions.

Fixes: https://github.com/jakartaee/data/issues/1423