### PR TITLE
Refactor TCK compability proposal

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/AbstractDatabaseCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/AbstractDatabaseCapability.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.framework.utilities;
+/**
+ * Base implementation for {@link DatabaseCapability}.
+ *
+ * <p>This class represents a conservative capability profile where no
+ * database features are assumed to be supported by default.</p>
+ *
+ * <p>Concrete implementations should explicitly override only the
+ * capabilities they are expected to support. This avoids implicit
+ * assumptions and ensures that support is always intentional and
+ * documented.</p>
+ *
+ * <p><strong>Design note:</strong> Capability support may vary not only
+ * by database family but also by specific provider and configuration.
+ * Therefore, this base class does not assume any capability, even if it
+ * is commonly available in certain database categories.</p>
+ */
+public abstract class AbstractDatabaseCapability implements DatabaseCapability {
+
+    @Override public boolean capableOfAddition() { return false; }
+
+    @Override public boolean capableOfAnd() { return false; }
+
+    @Override public boolean capableOfAssignmentToExpression() { return false; }
+
+    @Override public boolean capableOfBetween() { return false; }
+
+    @Override public boolean capableOfAttributeVsAttributeComparison() { return false; }
+
+    @Override public boolean capableOfConcat() { return false; }
+
+    @Override public boolean capableOfConditionalDelete() { return false; }
+
+    @Override public boolean capableOfConditionalUpdate() { return false; }
+
+    @Override public boolean capableOfConstraintsOnNonIdAttributes() { return false; }
+
+    @Override public boolean capableOfCount() { return false; }
+
+    @Override public boolean capableOfCountingDeletes() { return false; }
+
+    @Override public boolean capableOfCountingUpdates() { return false; }
+
+    @Override public boolean capableOfDivision() { return false; }
+
+    @Override public boolean capableOfGreaterThan() { return false; }
+
+    @Override public boolean capableOfGreaterThanEqual() { return false; }
+
+    @Override public boolean capableOfIn() { return false; }
+
+    @Override public boolean capableOfLeft() { return false; }
+
+    @Override public boolean capableOfLength() { return false; }
+
+    @Override public boolean capableOfLessThan() { return false; }
+
+    @Override public boolean capableOfLessThanEqual() { return false; }
+
+    @Override public boolean capableOfLike() { return false; }
+
+    @Override public boolean capableOfLower() { return false; }
+
+    @Override public boolean capableOfMultipleSort() { return false; }
+
+    @Override public boolean capableOfMultiplication() { return false; }
+
+    @Override public boolean capableOfNotBetween() { return false; }
+
+    @Override public boolean capableOfNotEqual() { return false; }
+
+    @Override public boolean capableOfNotIn() { return false; }
+
+    @Override public boolean capableOfNotLike() { return false; }
+
+    @Override public boolean capableOfNotNull() { return false; }
+
+    @Override public boolean capableOfNull() { return false; }
+
+    @Override public boolean capableOfOr() { return false; }
+
+    @Override public boolean capableOfParentheses() { return false; }
+
+    @Override public boolean capableOfQueryWithoutWhere() { return false; }
+
+    @Override public boolean capableOfRight() { return false; }
+
+    @Override public boolean capableOfSingleSort() { return false; }
+
+    @Override public boolean capableOfSubtraction() { return false; }
+
+    @Override public boolean capableOfUpper() { return false; }
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/ColumnCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/ColumnCapability.java
@@ -14,19 +14,20 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 package ee.jakarta.tck.data.framework.utilities;
+
 /**
  * Capability profile for Column-oriented databases based on the current behavior model.
  *
  * <p>In the existing model, column databases introduce basic comparison and
- * filtering capabilities beyond simple key-based access. This includes support
- * for range queries, null checks, and inclusion-based filtering.</p>
+ * filtering capabilities beyond simple key-based access. This includes support for range queries, null checks, and
+ * inclusion-based filtering.</p>
  *
  * <p>More advanced features such as arithmetic operations, string manipulation,
  * sorting, and conditional updates are not assumed to be supported at this level.</p>
  *
  * <p><strong>Note:</strong> Actual support may vary depending on the specific
- * implementation (e.g., wide-column vs analytical column stores), but this
- * profile reflects the conservative baseline defined in the current TCK behavior.</p>
+ * implementation (e.g., wide-column vs analytical column stores), but this profile reflects the conservative baseline
+ * defined in the current TCK behavior.</p>
  */
 public final class ColumnCapability extends MinimalDatabaseCapability {
 

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/ColumnCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/ColumnCapability.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.framework.utilities;
+/**
+ * Capability profile for Column-oriented databases based on the current behavior model.
+ *
+ * <p>In the existing model, column databases introduce basic comparison and
+ * filtering capabilities beyond simple key-based access. This includes support
+ * for range queries, null checks, and inclusion-based filtering.</p>
+ *
+ * <p>More advanced features such as arithmetic operations, string manipulation,
+ * sorting, and conditional updates are not assumed to be supported at this level.</p>
+ *
+ * <p><strong>Note:</strong> Actual support may vary depending on the specific
+ * implementation (e.g., wide-column vs analytical column stores), but this
+ * profile reflects the conservative baseline defined in the current TCK behavior.</p>
+ */
+public final class ColumnCapability extends AbstractDatabaseCapability {
+
+    @Override
+    public boolean capableOfBetween() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfGreaterThan() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfGreaterThanEqual() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfIn() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfLessThan() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfLessThanEqual() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNotBetween() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNotEqual() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNotIn() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNotNull() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNull() {
+        return true;
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/ColumnCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/ColumnCapability.java
@@ -28,7 +28,7 @@ package ee.jakarta.tck.data.framework.utilities;
  * implementation (e.g., wide-column vs analytical column stores), but this
  * profile reflects the conservative baseline defined in the current TCK behavior.</p>
  */
-public final class ColumnCapability extends AbstractDatabaseCapability {
+public final class ColumnCapability extends MinimalDatabaseCapability {
 
     @Override
     public boolean capableOfBetween() {

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/DatabaseCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/DatabaseCapability.java
@@ -13,6 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
+package ee.jakarta.tck.data.framework.utilities;
 /**
  * Defines the capability profile of a database family or provider.
  *

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/DatabaseCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/DatabaseCapability.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+/**
+ * Defines the capability profile of a database family or provider.
+ *
+ * <p>This interface represents what operations and expressions are expected
+ * to be supported by a given database type. Implementations should document
+ * nuances such as partial support, vendor-specific behavior, or limitations.</p>
+ *
+ * <p><strong>Important:</strong> A {@code true} value indicates expected support,
+ * but does not guarantee uniform behavior across all vendors of the same family.</p>
+ */
+public interface DatabaseCapability {
+
+    boolean capableOfAddition();
+
+    boolean capableOfAnd();
+
+    boolean capableOfAssignmentToExpression();
+
+    boolean capableOfBetween();
+
+    boolean capableOfAttributeVsAttributeComparison();
+
+    boolean capableOfConcat();
+
+    boolean capableOfConditionalDelete();
+
+    boolean capableOfConditionalUpdate();
+
+    boolean capableOfConstraintsOnNonIdAttributes();
+
+    boolean capableOfCount();
+
+    boolean capableOfCountingDeletes();
+
+    boolean capableOfCountingUpdates();
+
+    boolean capableOfDivision();
+
+    boolean capableOfGreaterThan();
+
+    boolean capableOfGreaterThanEqual();
+
+    boolean capableOfIn();
+
+    boolean capableOfLeft();
+
+    boolean capableOfLength();
+
+    boolean capableOfLessThan();
+
+    boolean capableOfLessThanEqual();
+
+    boolean capableOfLike();
+
+    boolean capableOfLower();
+
+    boolean capableOfMultipleSort();
+
+    boolean capableOfMultiplication();
+
+    boolean capableOfNotBetween();
+
+    boolean capableOfNotEqual();
+
+    boolean capableOfNotIn();
+
+    boolean capableOfNotLike();
+
+    boolean capableOfNotNull();
+
+    boolean capableOfNull();
+
+    boolean capableOfOr();
+
+    boolean capableOfParentheses();
+
+    boolean capableOfQueryWithoutWhere();
+
+    boolean capableOfRight();
+
+    boolean capableOfSingleSort();
+
+    boolean capableOfSubtraction();
+
+    boolean capableOfUpper();
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/DatabaseType.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/DatabaseType.java
@@ -30,16 +30,16 @@ public enum DatabaseType {
     COLUMN(20, new ColumnCapability()),
     KEY_VALUE(10, new KeyValueCapability());
 
-    private final int level;
+    private final int flexibility;
     private final DatabaseCapability capability;
 
-    DatabaseType(int level, DatabaseCapability capability) {
-        this.level = level;
+    DatabaseType(int flexibility, DatabaseCapability capability) {
+        this.flexibility = flexibility;
         this.capability = capability;
     }
 
-    public int level() {
-        return level;
+    public int flexibility() {
+        return flexibility;
     }
 
     public DatabaseCapability capability() {

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/DatabaseType.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/DatabaseType.java
@@ -22,173 +22,187 @@ import java.util.Arrays;
  * {@link TestProperty} databaseType
  */
 public enum DatabaseType {
-    OTHER(Integer.MAX_VALUE), //No database type was configured
-    RELATIONAL(100),
-    GRAPH(50),
-    DOCUMENT(40),
-    TIME_SERIES(30),
-    COLUMN(20),
-    KEY_VALUE(10);
+    OTHER(Integer.MAX_VALUE, new OtherCapability()),// No database type was configured
+    RELATIONAL(100, new RelationalCapability()),
+    GRAPH(50, new GraphCapability()),
+    DOCUMENT(40, new DocumentCapability()),
+    TIME_SERIES(30, new TimeSeriesCapability()),
+    COLUMN(20, new ColumnCapability()),
+    KEY_VALUE(10, new KeyValueCapability());
 
-    private int flexibility;
+    private final int level;
+    private final DatabaseCapability capability;
 
-    private DatabaseType(int flexibility) {
-        this.flexibility = flexibility;
+    DatabaseType(int level, DatabaseCapability capability) {
+        this.level = level;
+        this.capability = capability;
+    }
+
+    public int level() {
+        return level;
+    }
+
+    public DatabaseCapability capability() {
+        return capability;
     }
 
     public boolean capableOfAddition() {
-        return flexibility >= RELATIONAL.flexibility;
+        return capability.capableOfAddition();
     }
 
     public boolean capableOfAnd() {
-        return flexibility >= DOCUMENT.flexibility;
+        return capability.capableOfAnd();
     }
 
     public boolean capableOfAssignmentToExpression() {
-        return flexibility >= RELATIONAL.flexibility;
+        return capability.capableOfAssignmentToExpression();
     }
 
     public boolean capableOfBetween() {
-        return flexibility >= COLUMN.flexibility;
+        return capability.capableOfBetween();
     }
 
     public boolean capableOfAttributeVsAttributeComparison() {
-        return flexibility >= RELATIONAL.flexibility;
+        return capability.capableOfAttributeVsAttributeComparison();
     }
 
     public boolean capableOfConcat() {
-        return flexibility >= GRAPH.flexibility;
+        return capability.capableOfConcat();
     }
 
     public boolean capableOfConditionalDelete() {
-        return flexibility >= RELATIONAL.flexibility;
+        return capability.capableOfConditionalDelete();
     }
 
     public boolean capableOfConditionalUpdate() {
-        return flexibility >= RELATIONAL.flexibility;
+        return capability.capableOfConditionalUpdate();
     }
 
     public boolean capableOfConstraintsOnNonIdAttributes() {
-        return flexibility >= DOCUMENT.flexibility;
+        return capability.capableOfConstraintsOnNonIdAttributes();
     }
 
     public boolean capableOfCount() {
-        return flexibility >= DOCUMENT.flexibility;
+        return capability.capableOfCount();
     }
 
     public boolean capableOfCountingDeletes() {
-        return flexibility >= RELATIONAL.flexibility;
+        return capability.capableOfCountingDeletes();
     }
 
     public boolean capableOfCountingUpdates() {
-        return flexibility >= RELATIONAL.flexibility;
+        return capability.capableOfCountingUpdates();
     }
 
     public boolean capableOfDivision() {
-        return flexibility >= RELATIONAL.flexibility;
+        return capability.capableOfDivision();
     }
 
     public boolean capableOfGreaterThan() {
-        return flexibility >= COLUMN.flexibility;
+        return capability.capableOfGreaterThan();
     }
 
     public boolean capableOfGreaterThanEqual() {
-        return flexibility >= COLUMN.flexibility;
+        return capability.capableOfGreaterThanEqual();
     }
 
     public boolean capableOfIn() {
-        return flexibility >= COLUMN.flexibility;
+        return capability.capableOfIn();
     }
 
     public boolean capableOfLeft() {
-        return flexibility >= GRAPH.flexibility;
+        return capability.capableOfLeft();
     }
 
     public boolean capableOfLength() {
-        return flexibility >= GRAPH.flexibility;
+        return capability.capableOfLength();
     }
 
     public boolean capableOfLessThan() {
-        return flexibility >= COLUMN.flexibility;
+        return capability.capableOfLessThan();
     }
 
     public boolean capableOfLessThanEqual() {
-        return flexibility >= COLUMN.flexibility;
+        return capability.capableOfLessThanEqual();
     }
 
     public boolean capableOfLike() {
-        return flexibility >= RELATIONAL.flexibility;
+        return capability.capableOfLike();
     }
 
     public boolean capableOfLower() {
-        return flexibility >= GRAPH.flexibility;
+        return capability.capableOfLower();
     }
 
     public boolean capableOfMultipleSort() {
-        return flexibility >= RELATIONAL.flexibility;
+        return capability.capableOfMultipleSort();
     }
 
     public boolean capableOfMultiplication() {
-        return flexibility >= RELATIONAL.flexibility;
+        return capability.capableOfMultiplication();
     }
 
-
     public boolean capableOfNotBetween() {
-        return flexibility >= COLUMN.flexibility;
+        return capability.capableOfNotBetween();
     }
 
     public boolean capableOfNotEqual() {
-        return flexibility >= COLUMN.flexibility;
+        return capability.capableOfNotEqual();
     }
 
     public boolean capableOfNotIn() {
-        return flexibility >= COLUMN.flexibility;
+        return capability.capableOfNotIn();
     }
 
     public boolean capableOfNotLike() {
-        return flexibility >= RELATIONAL.flexibility;
+        return capability.capableOfNotLike();
     }
 
     public boolean capableOfNotNull() {
-        return flexibility >= COLUMN.flexibility;
+        return capability.capableOfNotNull();
     }
 
     public boolean capableOfNull() {
-        return flexibility >= COLUMN.flexibility;
+        return capability.capableOfNull();
     }
 
     public boolean capableOfOr() {
-        return flexibility >= DOCUMENT.flexibility;
+        return capability.capableOfOr();
     }
 
     public boolean capableOfParentheses() {
-        return flexibility >= RELATIONAL.flexibility;
+        return capability.capableOfParentheses();
     }
 
     public boolean capableOfQueryWithoutWhere() {
-        return flexibility >= DOCUMENT.flexibility;
+        return capability.capableOfQueryWithoutWhere();
     }
 
     public boolean capableOfRight() {
-        return flexibility >= GRAPH.flexibility;
+        return capability.capableOfRight();
     }
 
     public boolean capableOfSingleSort() {
-        return flexibility >= DOCUMENT.flexibility;
+        return capability.capableOfSingleSort();
     }
 
     public boolean capableOfSubtraction() {
-        return flexibility >= RELATIONAL.flexibility;
+        return capability.capableOfSubtraction();
     }
 
     public boolean capableOfUpper() {
-        return flexibility >= GRAPH.flexibility;
+        return capability.capableOfUpper();
     }
+
 
     public static DatabaseType valueOfIgnoreCase(String value) {
         return Arrays.stream(DatabaseType.values()).filter(type -> type.name().equalsIgnoreCase(value)).findAny().orElse(DatabaseType.OTHER);
     }
 
+    /**
+     * @deprecated Use explicit capability checks instead.
+     */
+    @Deprecated
     public boolean isKeywordSupportAtOrBelow(DatabaseType benchmark) {
         return this.flexibility <= benchmark.flexibility;
     }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/DocumentCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/DocumentCapability.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.framework.utilities;
+
+/**
+ * Capability profile for Document databases based on the current behavior model.
+ *
+ * <p>In the existing model, document databases introduce logical composition,
+ * basic aggregation, and query flexibility beyond simple comparisons. This
+ * includes support for logical operators, counting, sorting (single field),
+ * and filtering without requiring a strict schema.</p>
+ *
+ * <p>While document databases often provide rich querying capabilities,
+ * support may vary significantly across vendors, especially for advanced
+ * expressions, arithmetic operations, and string manipulation functions.</p>
+ *
+ * <p>This profile reflects a conservative baseline consistent with the current
+ * TCK behavior, enabling capabilities expected at the document level while
+ * leaving more advanced features to higher categories.</p>
+ */
+public final class DocumentCapability extends AbstractDatabaseCapability {
+
+    @Override
+    public boolean capableOfAnd() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfConstraintsOnNonIdAttributes() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfCount() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfOr() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfQueryWithoutWhere() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfSingleSort() {
+        return true;
+    }
+
+    // Inherited from COLUMN level
+
+    @Override
+    public boolean capableOfBetween() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfGreaterThan() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfGreaterThanEqual() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfIn() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfLessThan() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfLessThanEqual() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNotBetween() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNotEqual() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNotIn() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNotNull() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNull() {
+        return true;
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/DocumentCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/DocumentCapability.java
@@ -15,7 +15,7 @@
  */
 package ee.jakarta.tck.data.framework.utilities;
 
-public final class DocumentCapability extends AbstractDatabaseCapability {
+public final class DocumentCapability extends MinimalDatabaseCapability {
 
     @Override
     public boolean capableOfAnd() {

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/DocumentCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/DocumentCapability.java
@@ -15,22 +15,6 @@
  */
 package ee.jakarta.tck.data.framework.utilities;
 
-/**
- * Capability profile for Document databases based on the current behavior model.
- *
- * <p>In the existing model, document databases introduce logical composition,
- * basic aggregation, and query flexibility beyond simple comparisons. This
- * includes support for logical operators, counting, sorting (single field),
- * and filtering without requiring a strict schema.</p>
- *
- * <p>While document databases often provide rich querying capabilities,
- * support may vary significantly across vendors, especially for advanced
- * expressions, arithmetic operations, and string manipulation functions.</p>
- *
- * <p>This profile reflects a conservative baseline consistent with the current
- * TCK behavior, enabling capabilities expected at the document level while
- * leaving more advanced features to higher categories.</p>
- */
 public final class DocumentCapability extends AbstractDatabaseCapability {
 
     @Override

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/GraphCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/GraphCapability.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.framework.utilities;
+
+/**
+ * Capability profile for Graph databases based on the current behavior model.
+ *
+ * <p>In the existing model, graph databases extend document-level capabilities
+ * by introducing support for string manipulation and function-based expressions,
+ * such as substring operations and case transformations.</p>
+ *
+ * <p>This includes operations like LEFT, RIGHT, LENGTH, LOWER, and UPPER, which
+ * are typically associated with query languages capable of traversing and
+ * transforming data within relationships.</p>
+ *
+ * <p>While graph databases are often highly expressive in traversal and pattern
+ * matching, this profile focuses only on the capabilities defined in the current
+ * TCK behavior model.</p>
+ *
+ * <p><strong>Note:</strong> Actual support may vary by vendor and query language.
+ * This implementation reflects a conservative baseline consistent with the
+ * existing capability thresholds.</p>
+ */
+public final class GraphCapability extends AbstractDatabaseCapability {
+
+    // Graph-specific capabilities
+
+    @Override
+    public boolean capableOfConcat() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfLeft() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfLength() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfLower() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfRight() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfUpper() {
+        return true;
+    }
+
+    // Inherited from DOCUMENT level
+
+    @Override
+    public boolean capableOfAnd() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfConstraintsOnNonIdAttributes() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfCount() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfOr() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfQueryWithoutWhere() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfSingleSort() {
+        return true;
+    }
+
+    // Inherited from COLUMN level
+
+    @Override
+    public boolean capableOfBetween() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfGreaterThan() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfGreaterThanEqual() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfIn() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfLessThan() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfLessThanEqual() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNotBetween() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNotEqual() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNotIn() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNotNull() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNull() {
+        return true;
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/GraphCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/GraphCapability.java
@@ -15,7 +15,7 @@
  */
 package ee.jakarta.tck.data.framework.utilities;
 
-public final class GraphCapability extends AbstractDatabaseCapability {
+public final class GraphCapability extends MinimalDatabaseCapability {
 
     @Override
     public boolean capableOfConcat() {

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/GraphCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/GraphCapability.java
@@ -36,8 +36,6 @@ package ee.jakarta.tck.data.framework.utilities;
  */
 public final class GraphCapability extends AbstractDatabaseCapability {
 
-    // Graph-specific capabilities
-
     @Override
     public boolean capableOfConcat() {
         return true;
@@ -68,8 +66,6 @@ public final class GraphCapability extends AbstractDatabaseCapability {
         return true;
     }
 
-    // Inherited from DOCUMENT level
-
     @Override
     public boolean capableOfAnd() {
         return true;
@@ -99,8 +95,6 @@ public final class GraphCapability extends AbstractDatabaseCapability {
     public boolean capableOfSingleSort() {
         return true;
     }
-
-    // Inherited from COLUMN level
 
     @Override
     public boolean capableOfBetween() {

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/GraphCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/GraphCapability.java
@@ -15,25 +15,6 @@
  */
 package ee.jakarta.tck.data.framework.utilities;
 
-/**
- * Capability profile for Graph databases based on the current behavior model.
- *
- * <p>In the existing model, graph databases extend document-level capabilities
- * by introducing support for string manipulation and function-based expressions,
- * such as substring operations and case transformations.</p>
- *
- * <p>This includes operations like LEFT, RIGHT, LENGTH, LOWER, and UPPER, which
- * are typically associated with query languages capable of traversing and
- * transforming data within relationships.</p>
- *
- * <p>While graph databases are often highly expressive in traversal and pattern
- * matching, this profile focuses only on the capabilities defined in the current
- * TCK behavior model.</p>
- *
- * <p><strong>Note:</strong> Actual support may vary by vendor and query language.
- * This implementation reflects a conservative baseline consistent with the
- * existing capability thresholds.</p>
- */
 public final class GraphCapability extends AbstractDatabaseCapability {
 
     @Override

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/KeyValueCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/KeyValueCapability.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.framework.utilities;
+
+/**
+ * Capability profile for Key-Value databases based on the current behavior model.
+ *
+ * <p>In the existing model, key-value databases are considered the least flexible
+ * category. As a result, no query-related capabilities are assumed to be supported.</p>
+ *
+ * <p>This implementation reflects that behavior by not enabling any capabilities.
+ * All operations beyond basic key-based access (put/get/delete) are treated as
+ * unsupported at the database level.</p>
+ *
+ * <p><strong>Note:</strong> While some key-value databases may offer extended features,
+ * this profile intentionally remains conservative to match the current TCK behavior.</p>
+ */
+public final class KeyValueCapability extends AbstractDatabaseCapability {
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/KeyValueCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/KeyValueCapability.java
@@ -15,5 +15,5 @@
  */
 package ee.jakarta.tck.data.framework.utilities;
 
-public final class KeyValueCapability extends AbstractDatabaseCapability {
+public final class KeyValueCapability extends MinimalDatabaseCapability {
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/MinimalDatabaseCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/MinimalDatabaseCapability.java
@@ -30,7 +30,7 @@ package ee.jakarta.tck.data.framework.utilities;
  * Therefore, this base class does not assume any capability, even if it
  * is commonly available in certain database categories.</p>
  */
-public abstract class AbstractDatabaseCapability implements DatabaseCapability {
+public abstract class MinimalDatabaseCapability implements DatabaseCapability {
 
     @Override public boolean capableOfAddition() { return false; }
 

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/MinimalDatabaseCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/MinimalDatabaseCapability.java
@@ -14,22 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 package ee.jakarta.tck.data.framework.utilities;
-/**
- * Base implementation for {@link DatabaseCapability}.
- *
- * <p>This class represents a conservative capability profile where no
- * database features are assumed to be supported by default.</p>
- *
- * <p>Concrete implementations should explicitly override only the
- * capabilities they are expected to support. This avoids implicit
- * assumptions and ensures that support is always intentional and
- * documented.</p>
- *
- * <p><strong>Design note:</strong> Capability support may vary not only
- * by database family but also by specific provider and configuration.
- * Therefore, this base class does not assume any capability, even if it
- * is commonly available in certain database categories.</p>
- */
+
 public abstract class MinimalDatabaseCapability implements DatabaseCapability {
 
     @Override public boolean capableOfAddition() { return false; }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/MinimalDatabaseCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/MinimalDatabaseCapability.java
@@ -17,77 +17,188 @@ package ee.jakarta.tck.data.framework.utilities;
 
 public abstract class MinimalDatabaseCapability implements DatabaseCapability {
 
-    @Override public boolean capableOfAddition() { return false; }
+    @Override
+    public boolean capableOfAddition() {
+        return false;
+    }
 
-    @Override public boolean capableOfAnd() { return false; }
+    @Override
+    public boolean capableOfAnd() {
+        return false;
+    }
 
-    @Override public boolean capableOfAssignmentToExpression() { return false; }
+    @Override
+    public boolean capableOfAssignmentToExpression() {
+        return false;
+    }
 
-    @Override public boolean capableOfBetween() { return false; }
+    @Override
+    public boolean capableOfBetween() {
+        return false;
+    }
 
-    @Override public boolean capableOfAttributeVsAttributeComparison() { return false; }
+    @Override
+    public boolean capableOfAttributeVsAttributeComparison() {
+        return false;
+    }
 
-    @Override public boolean capableOfConcat() { return false; }
+    @Override
+    public boolean capableOfConcat() {
+        return false;
+    }
 
-    @Override public boolean capableOfConditionalDelete() { return false; }
+    @Override
+    public boolean capableOfConditionalDelete() {
+        return false;
+    }
 
-    @Override public boolean capableOfConditionalUpdate() { return false; }
+    @Override
+    public boolean capableOfConditionalUpdate() {
+        return false;
+    }
 
-    @Override public boolean capableOfConstraintsOnNonIdAttributes() { return false; }
+    @Override
+    public boolean capableOfConstraintsOnNonIdAttributes() {
+        return false;
+    }
 
-    @Override public boolean capableOfCount() { return false; }
+    @Override
+    public boolean capableOfCount() {
+        return false;
+    }
 
-    @Override public boolean capableOfCountingDeletes() { return false; }
+    @Override
+    public boolean capableOfCountingDeletes() {
+        return false;
+    }
 
-    @Override public boolean capableOfCountingUpdates() { return false; }
+    @Override
+    public boolean capableOfCountingUpdates() {
+        return false;
+    }
 
-    @Override public boolean capableOfDivision() { return false; }
+    @Override
+    public boolean capableOfDivision() {
+        return false;
+    }
 
-    @Override public boolean capableOfGreaterThan() { return false; }
+    @Override
+    public boolean capableOfGreaterThan() {
+        return false;
+    }
 
-    @Override public boolean capableOfGreaterThanEqual() { return false; }
+    @Override
+    public boolean capableOfGreaterThanEqual() {
+        return false;
+    }
 
-    @Override public boolean capableOfIn() { return false; }
+    @Override
+    public boolean capableOfIn() {
+        return false;
+    }
 
-    @Override public boolean capableOfLeft() { return false; }
+    @Override
+    public boolean capableOfLeft() {
+        return false;
+    }
 
-    @Override public boolean capableOfLength() { return false; }
+    @Override
+    public boolean capableOfLength() {
+        return false;
+    }
 
-    @Override public boolean capableOfLessThan() { return false; }
+    @Override
+    public boolean capableOfLessThan() {
+        return false;
+    }
 
-    @Override public boolean capableOfLessThanEqual() { return false; }
+    @Override
+    public boolean capableOfLessThanEqual() {
+        return false;
+    }
 
-    @Override public boolean capableOfLike() { return false; }
+    @Override
+    public boolean capableOfLike() {
+        return false;
+    }
 
-    @Override public boolean capableOfLower() { return false; }
+    @Override
+    public boolean capableOfLower() {
+        return false;
+    }
 
-    @Override public boolean capableOfMultipleSort() { return false; }
+    @Override
+    public boolean capableOfMultipleSort() {
+        return false;
+    }
 
-    @Override public boolean capableOfMultiplication() { return false; }
+    @Override
+    public boolean capableOfMultiplication() {
+        return false;
+    }
 
-    @Override public boolean capableOfNotBetween() { return false; }
+    @Override
+    public boolean capableOfNotBetween() {
+        return false;
+    }
 
-    @Override public boolean capableOfNotEqual() { return false; }
+    @Override
+    public boolean capableOfNotEqual() {
+        return false;
+    }
 
-    @Override public boolean capableOfNotIn() { return false; }
+    @Override
+    public boolean capableOfNotIn() {
+        return false;
+    }
 
-    @Override public boolean capableOfNotLike() { return false; }
+    @Override
+    public boolean capableOfNotLike() {
+        return false;
+    }
 
-    @Override public boolean capableOfNotNull() { return false; }
+    @Override
+    public boolean capableOfNotNull() {
+        return false;
+    }
 
-    @Override public boolean capableOfNull() { return false; }
+    @Override
+    public boolean capableOfNull() {
+        return false;
+    }
 
-    @Override public boolean capableOfOr() { return false; }
+    @Override
+    public boolean capableOfOr() {
+        return false;
+    }
 
-    @Override public boolean capableOfParentheses() { return false; }
+    @Override
+    public boolean capableOfParentheses() {
+        return false;
+    }
 
-    @Override public boolean capableOfQueryWithoutWhere() { return false; }
+    @Override
+    public boolean capableOfQueryWithoutWhere() {
+        return false;
+    }
 
-    @Override public boolean capableOfRight() { return false; }
+    @Override
+    public boolean capableOfRight() {
+        return false;
+    }
 
-    @Override public boolean capableOfSingleSort() { return false; }
+    @Override
+    public boolean capableOfSingleSort() {
+        return false;
+    }
 
-    @Override public boolean capableOfSubtraction() { return false; }
+    @Override
+    public boolean capableOfSubtraction() {
+        return false;
+    }
 
-    @Override public boolean capableOfUpper() { return false; }
+    @Override
+    public boolean capableOfUpper() {
+        return false;
+    }
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/OtherCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/OtherCapability.java
@@ -15,5 +15,5 @@
  */
 package ee.jakarta.tck.data.framework.utilities;
 
-public final class KeyValueCapability extends AbstractDatabaseCapability {
+public final class OtherCapability extends RelationalCapability {
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/RelationalCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/RelationalCapability.java
@@ -15,21 +15,6 @@
  */
 package ee.jakarta.tck.data.framework.utilities;
 
-/**
- * Capability profile for Relational databases based on the current behavior model.
- *
- * <p>In the existing model, relational databases represent the highest level of
- * capability, supporting the full range of query operations, expressions, and
- * data manipulation features defined in the TCK.</p>
- *
- * <p>This includes arithmetic operations, logical composition, string functions,
- * sorting, aggregation, conditional updates and deletes, and complex expressions
- * involving multiple attributes.</p>
- *
- * <p><strong>Note:</strong> While relational databases generally provide the most
- * comprehensive feature set, specific behavior and edge cases may still vary
- * depending on the SQL dialect and vendor implementation.</p>
- */
 public final class RelationalCapability extends AbstractDatabaseCapability {
 
     @Override public boolean capableOfAddition() { return true; }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/RelationalCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/RelationalCapability.java
@@ -15,7 +15,7 @@
  */
 package ee.jakarta.tck.data.framework.utilities;
 
-public final class RelationalCapability extends AbstractDatabaseCapability {
+public final class RelationalCapability implements DatabaseCapability {
 
     @Override public boolean capableOfAddition() { return true; }
     @Override public boolean capableOfAnd() { return true; }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/RelationalCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/RelationalCapability.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.framework.utilities;
+
+/**
+ * Capability profile for Relational databases based on the current behavior model.
+ *
+ * <p>In the existing model, relational databases represent the highest level of
+ * capability, supporting the full range of query operations, expressions, and
+ * data manipulation features defined in the TCK.</p>
+ *
+ * <p>This includes arithmetic operations, logical composition, string functions,
+ * sorting, aggregation, conditional updates and deletes, and complex expressions
+ * involving multiple attributes.</p>
+ *
+ * <p><strong>Note:</strong> While relational databases generally provide the most
+ * comprehensive feature set, specific behavior and edge cases may still vary
+ * depending on the SQL dialect and vendor implementation.</p>
+ */
+public final class RelationalCapability extends AbstractDatabaseCapability {
+
+    @Override public boolean capableOfAddition() { return true; }
+    @Override public boolean capableOfAnd() { return true; }
+    @Override public boolean capableOfAssignmentToExpression() { return true; }
+    @Override public boolean capableOfBetween() { return true; }
+    @Override public boolean capableOfAttributeVsAttributeComparison() { return true; }
+    @Override public boolean capableOfConcat() { return true; }
+    @Override public boolean capableOfConditionalDelete() { return true; }
+    @Override public boolean capableOfConditionalUpdate() { return true; }
+    @Override public boolean capableOfConstraintsOnNonIdAttributes() { return true; }
+    @Override public boolean capableOfCount() { return true; }
+    @Override public boolean capableOfCountingDeletes() { return true; }
+    @Override public boolean capableOfCountingUpdates() { return true; }
+    @Override public boolean capableOfDivision() { return true; }
+    @Override public boolean capableOfGreaterThan() { return true; }
+    @Override public boolean capableOfGreaterThanEqual() { return true; }
+    @Override public boolean capableOfIn() { return true; }
+    @Override public boolean capableOfLeft() { return true; }
+    @Override public boolean capableOfLength() { return true; }
+    @Override public boolean capableOfLessThan() { return true; }
+    @Override public boolean capableOfLessThanEqual() { return true; }
+    @Override public boolean capableOfLike() { return true; }
+    @Override public boolean capableOfLower() { return true; }
+    @Override public boolean capableOfMultipleSort() { return true; }
+    @Override public boolean capableOfMultiplication() { return true; }
+    @Override public boolean capableOfNotBetween() { return true; }
+    @Override public boolean capableOfNotEqual() { return true; }
+    @Override public boolean capableOfNotIn() { return true; }
+    @Override public boolean capableOfNotLike() { return true; }
+    @Override public boolean capableOfNotNull() { return true; }
+    @Override public boolean capableOfNull() { return true; }
+    @Override public boolean capableOfOr() { return true; }
+    @Override public boolean capableOfParentheses() { return true; }
+    @Override public boolean capableOfQueryWithoutWhere() { return true; }
+    @Override public boolean capableOfRight() { return true; }
+    @Override public boolean capableOfSingleSort() { return true; }
+    @Override public boolean capableOfSubtraction() { return true; }
+    @Override public boolean capableOfUpper() { return true; }
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/RelationalCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/RelationalCapability.java
@@ -15,7 +15,7 @@
  */
 package ee.jakarta.tck.data.framework.utilities;
 
-public final class RelationalCapability implements DatabaseCapability {
+public class RelationalCapability implements DatabaseCapability {
 
     @Override public boolean capableOfAddition() { return true; }
     @Override public boolean capableOfAnd() { return true; }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/RelationalCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/RelationalCapability.java
@@ -17,41 +17,188 @@ package ee.jakarta.tck.data.framework.utilities;
 
 public class RelationalCapability implements DatabaseCapability {
 
-    @Override public boolean capableOfAddition() { return true; }
-    @Override public boolean capableOfAnd() { return true; }
-    @Override public boolean capableOfAssignmentToExpression() { return true; }
-    @Override public boolean capableOfBetween() { return true; }
-    @Override public boolean capableOfAttributeVsAttributeComparison() { return true; }
-    @Override public boolean capableOfConcat() { return true; }
-    @Override public boolean capableOfConditionalDelete() { return true; }
-    @Override public boolean capableOfConditionalUpdate() { return true; }
-    @Override public boolean capableOfConstraintsOnNonIdAttributes() { return true; }
-    @Override public boolean capableOfCount() { return true; }
-    @Override public boolean capableOfCountingDeletes() { return true; }
-    @Override public boolean capableOfCountingUpdates() { return true; }
-    @Override public boolean capableOfDivision() { return true; }
-    @Override public boolean capableOfGreaterThan() { return true; }
-    @Override public boolean capableOfGreaterThanEqual() { return true; }
-    @Override public boolean capableOfIn() { return true; }
-    @Override public boolean capableOfLeft() { return true; }
-    @Override public boolean capableOfLength() { return true; }
-    @Override public boolean capableOfLessThan() { return true; }
-    @Override public boolean capableOfLessThanEqual() { return true; }
-    @Override public boolean capableOfLike() { return true; }
-    @Override public boolean capableOfLower() { return true; }
-    @Override public boolean capableOfMultipleSort() { return true; }
-    @Override public boolean capableOfMultiplication() { return true; }
-    @Override public boolean capableOfNotBetween() { return true; }
-    @Override public boolean capableOfNotEqual() { return true; }
-    @Override public boolean capableOfNotIn() { return true; }
-    @Override public boolean capableOfNotLike() { return true; }
-    @Override public boolean capableOfNotNull() { return true; }
-    @Override public boolean capableOfNull() { return true; }
-    @Override public boolean capableOfOr() { return true; }
-    @Override public boolean capableOfParentheses() { return true; }
-    @Override public boolean capableOfQueryWithoutWhere() { return true; }
-    @Override public boolean capableOfRight() { return true; }
-    @Override public boolean capableOfSingleSort() { return true; }
-    @Override public boolean capableOfSubtraction() { return true; }
-    @Override public boolean capableOfUpper() { return true; }
+    @Override
+    public boolean capableOfAddition() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfAnd() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfAssignmentToExpression() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfBetween() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfAttributeVsAttributeComparison() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfConcat() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfConditionalDelete() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfConditionalUpdate() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfConstraintsOnNonIdAttributes() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfCount() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfCountingDeletes() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfCountingUpdates() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfDivision() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfGreaterThan() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfGreaterThanEqual() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfIn() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfLeft() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfLength() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfLessThan() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfLessThanEqual() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfLike() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfLower() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfMultipleSort() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfMultiplication() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNotBetween() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNotEqual() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNotIn() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNotLike() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNotNull() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNull() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfOr() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfParentheses() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfQueryWithoutWhere() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfRight() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfSingleSort() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfSubtraction() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfUpper() {
+        return true;
+    }
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TimeSeriesCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TimeSeriesCapability.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 22025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -13,6 +13,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
+package ee.jakarta.tck.data.framework.utilities;
+
 public final class TimeSeriesCapability extends MinimalDatabaseCapability {
 
     @Override

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TimeSeriesCapability.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/utilities/TimeSeriesCapability.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 22025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+public final class TimeSeriesCapability extends MinimalDatabaseCapability {
+
+    @Override
+    public boolean capableOfBetween() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfGreaterThan() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfGreaterThanEqual() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfIn() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfLessThan() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfLessThanEqual() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNotBetween() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNotEqual() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNotIn() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNotNull() {
+        return true;
+    }
+
+    @Override
+    public boolean capableOfNull() {
+        return true;
+    }
+}


### PR DESCRIPTION
Hey @njr-11 , I’m aligned with your proposal, especially the idea of clarifying this in the vendor documentation.

That said, I think we should go one step further and make the capabilities themselves more explicit, including stronger documentation around what each one actually means.

For example, capableOfNull it can be misleading. NoSQL databases may handle null, but not necessarily in the same way as a relational database. The behavior may vary depending on whether the database is schema-based or schemaless.

The same applies to count. Supporting count does not always mean supporting count in every context, such as pagination or conditional queries. A database may support counting the total number of records, or counting only by key or id access, while still not supporting count with broader restrictions.

Because of that, I would suggest using polymorphism. It would let us make the behavior more explicit and improve the documentation incrementally, class by class.

PS: for now, I have not changed the behavior itself. I only proposed the interfaces and structure, this change would become much bigger.

If you agree, we can go deeper and review the interfaces and implementations one by one, using the spec as the reference.