### PR TITLE
Alignment with Persistence annotation names

### DIFF
--- a/api/src/main/java/jakarta/data/page/CursoredPage.java
+++ b/api/src/main/java/jakarta/data/page/CursoredPage.java
@@ -111,7 +111,7 @@ import java.util.NoSuchElementException;
  * <h2>Cursor-based Pagination with {@code @Query}</h2>
  *
  * <p>The {@link Query} annotation from Jakarta Data and the similar
- * {@code jakarta.persistence.query.StaticQuery} annotation from Jakarta Persistence
+ * {@code jakarta.persistence.query.JakartaQuery} annotation from Jakarta Persistence
  * allow the application to supply a Jakarta Common Query Language (JCQL) or
  * Jakarta Persistence Query Language (JPQL) query for the repository method
  * to perform.</p>

--- a/api/src/main/java/jakarta/data/repository/Delete.java
+++ b/api/src/main/java/jakarta/data/repository/Delete.java
@@ -107,7 +107,7 @@ import jakarta.data.restrict.Restriction;
  *
  * <p>If the Jakarta Data provider is backed by a Jakarta Persistence provider,
  * an automatic query method annotated {@code Find} can also be annotated
- * {@code jakarta.persistence.query.WriteQueryOptions} to supply additional
+ * {@code jakarta.persistence.query.QueryOptions} to supply additional
  * query options that are specific to Jakarta Persistence.</p>
  *
  * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Insert}, {@code @Update}, {@code @Delete}, and
@@ -117,7 +117,7 @@ import jakarta.data.restrict.Restriction;
  *
  * @see By
  */
-// TODO switch @code to @link for jakarta.persistence.query.* once Persistence 4.0 M1 is available
+// TODO switch @code to @link for jakarta.persistence.query.* once Persistence 4.0 M3 is available
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/api/src/main/java/jakarta/data/repository/Find.java
+++ b/api/src/main/java/jakarta/data/repository/Find.java
@@ -142,7 +142,7 @@ import java.lang.annotation.Target;
  *
  * <p>If the Jakarta Data provider is backed by a Jakarta Persistence provider,
  * an automatic query method annotated {@code Find} can also be annotated
- * {@code jakarta.persistence.query.ReadQueryOptions} to supply additional
+ * {@code jakarta.persistence.query.QueryOptions} to supply additional
  * query options that are specific to Jakarta Persistence.</p>
  *
  * <p>Annotations such as {@code @Find}, {@code @Query}, {@code @Insert}, {@code @Update}, {@code @Delete}, and
@@ -154,7 +154,7 @@ import java.lang.annotation.Target;
  * @see First
  * @see Select
  */
-//TODO switch @code to @link for jakarta.persistence.query.* once Persistence 4.0 M1 is available
+//TODO switch @code to @link for jakarta.persistence.query.* once Persistence 4.0 M3 is available
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/api/src/main/java/jakarta/data/repository/OrderBy.java
+++ b/api/src/main/java/jakarta/data/repository/OrderBy.java
@@ -73,9 +73,9 @@ import java.lang.annotation.Target;
  * <ul>
  * <li>the <em>Query by Method Name</em> {@code OrderBy} keyword in its
  *     name,</li>
- * <li>a {@link Query} or {@code jakarta.persistence.query.StaticQuery}
+ * <li>a {@link Query} or {@code jakarta.persistence.query.JakartaQuery}
  *     annotation specifying a query with an {@code ORDER BY} clause, nor</li>
- * <li>a {@code jakarta.persistence.query.StaticNativeQuery} annotation.</li>
+ * <li>a {@code jakarta.persistence.query.NativeQuery} annotation.</li>
  * </ul>
  * <p>A Jakarta Data provider is permitted to reject such a repository
  * method declaration at compile time or to implement the method to
@@ -86,7 +86,7 @@ import java.lang.annotation.Target;
  * or a more specific subclass if the database is incapable of
  * ordering with the requested sort criteria.</p>
  */
-// TODO replace @code with @link to StaticQuery/StaticNativeQuery once Persistence 4.0 M1 is available
+// TODO replace @code with @link to JakartaQuery/NativeQuery once Persistence 4.0 M3 is available
 @Repeatable(OrderBy.List.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/api/src/main/java/jakarta/data/repository/Param.java
+++ b/api/src/main/java/jakarta/data/repository/Param.java
@@ -48,7 +48,7 @@ import java.lang.annotation.Target;
  * runtime.</p>
  *
  * <p>Named parameters are not supported on repository methods annotated
- * {@code jakarta.persistence.query.StaticNativeQuery}.</p>
+ * {@code jakarta.persistence.query.NativeQuery}.</p>
  *
  * @see Query
  */

--- a/api/src/main/java/jakarta/data/repository/Select.java
+++ b/api/src/main/java/jakarta/data/repository/Select.java
@@ -51,7 +51,7 @@ import java.lang.annotation.Target;
  *
  * <p>This annotation must not be used in other locations; in particular,
  * it must not be used on repository methods annotated
- * {@code jakarta.persistence.query.StaticNativeQuery}.</p>
+ * {@code jakarta.persistence.query.NativeQuery}.</p>
  *
  * <p>Sort criteria for a repository method that returns a projection
  * can include any of the returned entity attributes that are of sortable type.

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -494,10 +494,10 @@ import java.util.Set;
  * annotations that can annotate repository methods in place of {@link Query}:
  *
  * <ul>
- * <li>{@code jakarta.persistence.query.StaticNativeQuery} - supplies a native
+ * <li>{@code jakarta.persistence.query.NativeQuery} - supplies a native
  * SQL query instead of a query that is written in Jakarta Persistence Query
  * Language (JPQL) or the Jakarta Common Query Language (JCQL).</li>
- * <li>{@code jakarta.persistence.query.StaticQuery} - behaves identically to
+ * <li>{@code jakarta.persistence.query.JakartaQuery} - behaves identically to
  * Jakarta Data's {@code Query} annotation in allowing JPQL and JCQL to be
  * supplied.</li>
  * </ul>
@@ -521,8 +521,8 @@ import java.util.Set;
  * for native SQL queries. Use positional parameters instead. For example,</p>
 
  * <pre>{@code
- * @StaticNativeQuery("SELECT * FROM Person WHERE ssn = ? AND alive = ?")
- * @ReadQueryOptions(lockMode = LockModeType.PESSIMISTIC_WRITE)
+ * @NativeQuery("SELECT * FROM Person WHERE ssn = ? AND alive = ?")
+ * @QueryOptions(lockMode = LockModeType.PESSIMISTIC_WRITE)
  * Optional<Person> findIfLiving(String ssn, boolean isAlive);
  * }</pre>
  *

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -183,13 +183,19 @@ The Jakarta Data implementation automatically recognizes the query annotations i
 
 The Jakarta Persistence specification defines several annotations in the `jakarta.persistence.query` package that can be used on Jakarta Data repositories.
 
-- `@StaticNativeQuery`, which can annotate a Jakarta Data repository method in place of Jakarta Data's `@Query` to supply a native SQL query.
+- `@NativeQuery`, which can annotate a Jakarta Data repository method in place of Jakarta Data's `@Query` to supply a native SQL query.
 
-- `@StaticQuery`, which can annotate a Jakarta Data repository method in place of Jakarta Data's `@Query` to supply a JPQL query.
+- `@JakartaQuery`, which can annotate a Jakarta Data repository method in place of Jakarta Data's `@Query` to supply a JPQL query.
 
-- `@ReadQueryOptions`, which can annotate a Jakarta Data repository method annotated `@Query`, `@StaticQuery`, or `@StaticNativeQuery` that performs a `SELECT` operation. Alternatively, it can annotate a Jakarta Data repository method annotated `@Find`. The `ReadQueryOptions` annotation allows the application to supply additional options defined by Jakarta Persistence for queries that perform read operations.
+- `@QueryOptions`, which can annotate a Jakarta Data repository method to supply additional options defined by Jakarta Persistence. The Jakarta Data repository method must also
 
-- `@WriteQueryOptions`, which can annotate a Jakarta Data repository method annotated `@Query`, `@StaticQuery`, or `@StaticNativeQuery` that performs a `DELETE` or `UPDATE` operation. Alternatively, it can annotate a Jakarta Data repository method annotated `@Delete` when the latter is not used as a lifecycle annotation.  The `WriteQueryOptions` annotation allows the application to supply additional options defined by Jakarta Persistence for queries that perform write operations.
+** be annotated `@Query`, `@JakartaQuery`, or `@NativeQuery` and perform a `SELECT` operation,
+
+** be annotated `@Find`,
+
+** be annotated `@Query`, `@JakartaQuery`, or `@NativeQuery` and perform a `DELETE` or `UPDATE` operation, or
+
+** be annotated `@Delete` and not define a lifecycle operation.
 
 ==== Limitations of JPQL and native SQL queries
 


### PR DESCRIPTION
Jakarta Persistence (992) updated annotations names to:
`@JakartaQuery`
`@NativeQuery`
`@QueryOptions`

This PR updates Jakarta Data javadoc and specification text to refer to these names instead of those that were previously being used during earlier milestones of Persistence 4.0.