### PR TITLE
refactor: avoid using Maven.resolver() in TCK

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/framework/arquillian/extensions/TCKArchiveProcessor.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/arquillian/extensions/TCKArchiveProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -15,7 +15,6 @@
  */
 package ee.jakarta.tck.data.framework.arquillian.extensions;
 
-import java.io.File;
 import java.util.Arrays;
 import java.util.logging.Logger;
 
@@ -25,7 +24,6 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.container.ClassContainer;
 import org.jboss.shrinkwrap.api.container.LibraryContainer;
 import org.jboss.shrinkwrap.api.container.ResourceContainer;
-import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 
 import ee.jakarta.tck.data.framework.junit.anno.Platform;
 import ee.jakarta.tck.data.framework.junit.anno.Signature;
@@ -95,9 +93,8 @@ public class TCKArchiveProcessor implements ApplicationArchiveProcessor {
             ((ClassContainer<?>) applicationArchive).addPackage(signaturePackage);
 
             // Add the sigtest plugin library
-            File sigTestDep = Maven.resolver().resolve("jakarta.tck:sigtest-maven-plugin:2.3").withoutTransitivity().asSingleFile();
-            log.info("Application Archive [" + applicationName + "] is being appended with library " + sigTestDep.getName());
-            ((LibraryContainer<?>) applicationArchive).addAsLibrary(sigTestDep);
+            log.info("Application Archive [" + applicationName + "] is being appended with library sigtest-maven-plugin.jar");
+            ((LibraryContainer<?>) applicationArchive).addAsLibrary(TCKDependencyProcessor.SigTestArchive.get());
 
             // Add signature resources
             log.info("Application Archive [" + applicationName + "] is being appended with resources "

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/arquillian/extensions/TCKDependencyProcessor.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/arquillian/extensions/TCKDependencyProcessor.java
@@ -15,41 +15,138 @@
  */
 package ee.jakarta.tck.data.framework.arquillian.extensions;
 
-import java.io.File;
-import java.util.Arrays;
-import java.util.List;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.JarURLConnection;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.Objects;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 import java.util.logging.Logger;
 
-import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.container.test.spi.client.deployment.CachedAuxilliaryArchiveAppender;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.container.LibraryContainer;
-import org.jboss.arquillian.test.spi.TestClass;
-import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 
-public class TCKDependencyProcessor implements ApplicationArchiveProcessor {
+
+/**
+ * Creates and appends archive dependencies to TCK application deployments. 
+ */
+public class TCKDependencyProcessor {
+    
     private static final Logger log = Logger.getLogger(TCKDependencyProcessor.class.getCanonicalName());
 
-    // List of dependencies to be added to the application archive
-    private static final List<String> TCK_DEPENDENCIES = List.of(
-            "org.assertj:assertj-core:3.27.7");
-
-    @Override
-    public void process(Archive<?> applicationArchive, TestClass testClass) {
-        if(! (applicationArchive instanceof LibraryContainer) ) {
-            return;
+    /**
+     * An archive appender that gets applied to ALL TCK application deployments.
+     * This appender re-creates the assertj-core artifact with the classes/resources
+     * on the classpath on the client at runtime.
+     * 
+     * Note: removed the use of Maven.resolver() because many enterprise industries use 
+     * maven central mirrors (like Artifactory) and the resolver at runtime does not
+     * have the maven context that started the test.
+     * Therefore, Maven.resolver() will always pull directly from Maven Central and
+     * can cause rate limiting.
+     */
+    public static class AssertJArchiveAppender extends CachedAuxilliaryArchiveAppender {
+        @Override
+        protected Archive<?> buildArchive() {
+            final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "assertj-core.jar");
+            archive.addPackages(true, "org.assertj.core");
+            
+            addManifestDirectoryResources(archive, "org.assertj.core.api.Assertions");
+            
+            log.info("Recreated assertj-core.jar archive with contents: " + archive.toString(true));
+            
+            return archive;
         }
+    }
+    
+    /**
+     * An archive appender that get's applied selectively in the 
+     * {@link TCKArchiveProcessor#process(Archive, org.jboss.arquillian.test.spi.TestClass)} method.
+     */
+    public static class SigTestArchive {
 
-        String applicationName = applicationArchive.getName() == null
-                ? applicationArchive.getId()
-                : applicationArchive.getName();
+        private static Archive<?> instance;
         
-        for(String dependency : TCK_DEPENDENCIES) {
-            File[] resolvedDependencies = Maven.resolver()
-                .resolve(dependency)
-                .withTransitivity()
-                .asFile();
-            log.info("Application Archive [" + applicationName + "] is being appended with dependencies [" + Arrays.asList(resolvedDependencies) + "]");
-            ((LibraryContainer) applicationArchive).addAsLibraries(resolvedDependencies);
+        private SigTestArchive() {
+            // Only access via static method
+        }
+        
+        private static Archive<?> buildArchive() {
+            final JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "sigtest-maven-plugin.jar");
+            archive.addPackages(true, "com.sun.tdk");
+            archive.addPackages(true, "org.netbeans.apitest");
+            archive.addPackages(true, "jakarta.tck.sigtest_maven_plugin");
+            
+            addManifestDirectoryResources(archive, "com.sun.tdk.signaturetest.Version");
+            
+            log.info("Recreated sigtest-maven-plugin.jar archive with contents: " + archive.toString(true));
+            
+            return instance = archive;
+        }
+        
+        public static Archive<?> get() {
+            return Objects.requireNonNullElseGet(instance, () -> buildArchive());
+        }
+        
+    }
+
+
+    /**
+     * Adds all META-INF directory resources from the JAR file containing the specified
+     * reference class to the provided archive. This is used to preserve manifest and
+     * service provider configuration files when recreating dependency archives.
+     *
+     * @param archive the JavaArchive to add META-INF resources to
+     * @param refClass the fully qualified name of a class within the source JAR
+     * @throws RuntimeException if the reference class cannot be found, is not loaded
+     *         from a JAR file, or if an I/O error occurs while copying resources
+     */
+    private static void addManifestDirectoryResources(final JavaArchive archive, final String refClass) {
+
+       // Get classloader to reference class
+       ClassLoader artifactClassloader;
+       try {
+          artifactClassloader = Class.forName(refClass).getClassLoader();
+       } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Could not find reference class for assertj", e);
+        }
+       
+       // Construct reference resource
+       String refResrouce = refClass.replace('.', '/') + ".class";
+       
+        try {
+           
+           // Find artifact's location on the file system and verify it's a JAR
+            URL classUrl = artifactClassloader.getResource(refResrouce);
+            if (classUrl == null) {
+                throw new RuntimeException("Could not locate reference class resource for " + refClass);
+            }
+            if (!"jar".equals(classUrl.getProtocol())) {
+                throw new RuntimeException("Expected "+ archive.getName() + 
+                      " classes to be loaded from a jar but found protocol: " + classUrl.getProtocol());
+            }
+
+            // Add all META-INF/ resources to the re-create archive
+            JarURLConnection connection = (JarURLConnection) classUrl.openConnection();
+            try (JarFile jarFile = connection.getJarFile()) {
+                Enumeration<JarEntry> entries = jarFile.entries();
+                while (entries.hasMoreElements()) {
+                    JarEntry entry = entries.nextElement();
+                    if (!entry.isDirectory() && entry.getName().startsWith("META-INF/")) {
+                        try (InputStream input = jarFile.getInputStream(entry)) {
+                            archive.add(new ByteArrayAsset(input.readAllBytes()), entry.getName());
+                        }
+                    }
+                }
+            }
+            
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to copy META-INF resources into recreated archive", e);
         }
     }
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/arquillian/extensions/TCKLoadableExtension.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/arquillian/extensions/TCKLoadableExtension.java
@@ -27,7 +27,7 @@ public class TCKLoadableExtension implements LoadableExtension {
     @Override
     public void register(ExtensionBuilder builder) {
         builder.service(ApplicationArchiveProcessor.class, TCKArchiveProcessor.class);
-        builder.service(ApplicationArchiveProcessor.class, TCKDependencyProcessor.class);
+        builder.service(AuxiliaryArchiveAppender.class, TCKDependencyProcessor.AssertJArchiveAppender.class);
         builder.service(AuxiliaryArchiveAppender.class, TCKFrameworkAppender.class);
     }
 }

--- a/tck/src/test/java/ee/jakarta/tck/data/framework/arquillian/extensions/TCKArchiveProcessorTest.java
+++ b/tck/src/test/java/ee/jakarta/tck/data/framework/arquillian/extensions/TCKArchiveProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,6 +16,7 @@
 package ee.jakarta.tck.data.framework.arquillian.extensions;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.jboss.arquillian.test.spi.TestClass;
@@ -67,6 +68,31 @@ public class TCKArchiveProcessorTest {
         
         // Should append signature packages
         assertTrue(testWAR.getContent().containsKey(new BasicPath("/WEB-INF/classes/ee/jakarta/tck/data/framework/signature")));
+        assertTrue(testWAR.getContent().containsKey(new BasicPath("/WEB-INF/lib/sigtest-maven-plugin.jar")));
+    }
+
+    @Test
+    public void assertJArchiveAppenderShouldBuildArchiveFromClasspath() {
+        TCKDependencyProcessor.AssertJArchiveAppender appender = new TCKDependencyProcessor.AssertJArchiveAppender();
+        
+        assertNotNull(appender.createAuxiliaryArchive());
+        assertTrue(appender.createAuxiliaryArchive()
+                .contains(new BasicPath("/org/assertj/core/api/Assertions.class")));
+        assertTrue(appender.createAuxiliaryArchive()
+                .contains(new BasicPath("/META-INF/MANIFEST.MF")));
+    }
+
+    @Test
+    public void sigTestArchiveShouldIncludePluginClassesAndSignatureResources() {
+        assertNotNull(TCKDependencyProcessor.SigTestArchive.get());
+        assertTrue(TCKDependencyProcessor.SigTestArchive.get()
+                .contains(new BasicPath("/com/sun/tdk/signaturetest/SigTest.class")));
+        assertTrue(TCKDependencyProcessor.SigTestArchive.get()
+                .contains(new BasicPath("/org/netbeans/apitest/Sigtest.class")));
+        assertTrue(TCKDependencyProcessor.SigTestArchive.get()
+                .contains(new BasicPath("/jakarta/tck/sigtest_maven_plugin/HelpMojo.class")));
+        assertTrue(TCKDependencyProcessor.SigTestArchive.get()
+                .contains(new BasicPath("/META-INF/MANIFEST.MF")));
     }
     
 }


### PR DESCRIPTION
- No need to update source code for new versions, instead find dependencies for TCK via runner's classpath
- Avoid pulling from maven central, when runner might be running on a system that pulls artifacts from a mirror.
- Avoid maven central rate limits. 