### PR TITLE
respecify EntityExistsException

### DIFF
--- a/api/src/main/java/jakarta/data/exceptions/EntityExistsException.java
+++ b/api/src/main/java/jakarta/data/exceptions/EntityExistsException.java
@@ -18,8 +18,10 @@
 package jakarta.data.exceptions;
 
 /**
- * Indicates that an entity cannot be inserted into the database because an
- * entity with same unique identifier already exists in the database.
+ * Indicates that an entity cannot be inserted into the database because
+ * insertion would violate a unique constraint. For example, this exception
+ * occurs when an entity with an identical unique identifier already exists
+ * in the database.
  */
 public class EntityExistsException extends DataException {
     private static final long serialVersionUID = -7275063477464065015L;

--- a/api/src/main/java/jakarta/data/repository/CrudRepository.java
+++ b/api/src/main/java/jakarta/data/repository/CrudRepository.java
@@ -97,12 +97,14 @@ import java.util.List;
 public interface CrudRepository<T, K> extends BasicRepository<T, K> {
 
     /**
-     * <p>Inserts an entity into the database. If an entity of this type with
-     * the same
-     * unique identifier already exists in the database and the database
-     * supports ACID transactions, then this method raises
-     * {@link EntityExistsException}. In databases that follow the BASE model or
-     * use an append model to write data, this exception is not thrown.</p>
+     * <p>Inserts an entity into the database.<p>
+     *
+     * <p>If the database supports ACID transactions and insertion of the given
+     * entity would violate a uniqueness constraint, for example, if an entity
+     * of this type with the same unique identifier already exists in the database,
+     * then this method raises {@link EntityExistsException}. In databases that
+     * follow the BASE model or use an append model to write data, this exception
+     * is not thrown.</p>
      *
      * <p>The entity instance returned as a result of this method must include
      * all values that were
@@ -117,21 +119,24 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * @return the inserted entity, which may or may not be a different instance
      * depending on whether the insert caused values to be generated or
      * automatically incremented.
-     * @throws EntityExistsException if the entity is already present in the
-     *                               database (in ACID-supported databases).
+     * @throws EntityExistsException (in ACID-supported databases) if the entity
+     *                               is already present in the database, or if
+     *                               its insertion would violate a uniqueness
+     *                               constraint
      * @throws NullPointerException  if the entity is null.
      */
     @Insert
     <S extends T> S insert(S entity);
 
     /**
-     * <p>Inserts multiple entities into the database. If any entity of this
-     * type with the same
-     * unique identifier as any of the given entities already exists in the
-     * database and the database supports ACID transactions, then this method
-     * raises {@link EntityExistsException}. In databases that follow the BASE
-     * model or use an append model to write data, this exception is not
-     * thrown.</p>
+     * <p>Inserts multiple entities into the database.</p>
+     *
+     * <p>If the database supports ACID transactions and insertion of one of the
+     * given entities would violate a uniqueness constraint, for example, if an
+     * entity of this type with the same unique identifier as one of the given
+     * entities already exists in the database, then this method raises
+     * {@link EntityExistsException}. In databases that follow the BASE model or
+     * use an append model to write data, this exception is not thrown.</p>
      *
      * <p>The entities within the returned {@link Iterable} must include all
      * values that were
@@ -149,9 +154,10 @@ public interface CrudRepository<T, K> extends BasicRepository<T, K> {
      * @return an iterable containing the inserted entities, which may or may
      * not be different instances depending on whether the insert caused values
      * to be generated or automatically incremented.
-     * @throws EntityExistsException if any of the entities are already present
-     *                               in the database (in ACID-supported
-     *                               databases).
+     * @throws EntityExistsException (in ACID-supported databases) if any of the
+     *                               entities are already present in the database,
+     *                               or if their insertion would violate a uniqueness
+     *                               constraint
      * @throws NullPointerException  if the iterable is null or any element is
      *                               null.
      */

--- a/api/src/main/java/jakarta/data/repository/Insert.java
+++ b/api/src/main/java/jakarta/data/repository/Insert.java
@@ -64,10 +64,11 @@ import java.lang.annotation.Target;
  * of entities in the argument. After the annotated method returns, an original entity instance supplied as an argument
  * might not accurately reflect the inserted state.
  * </p>
- * <p>If an entity of the given type, and with the same unique identifier already exists in the database when the
- * annotated method is called, and if the databases uses ACID (atomic, consistent, isolated, durable) transactions,
- * then the annotated method must raise {@link jakarta.data.exceptions.EntityExistsException}.
- * If the database follows the BASE model, or uses an append model to write data, this exception is not thrown.
+ * <p>If the databases uses ACID (atomic, consistent, isolated, durable) transactions, and insertion of an entity would
+ * result in a violation of a uniqueness constraint, for example, if an entity of the given type and with the same
+ * unique identifier already exists in the database when the annotated method is called, then the annotated method must
+ * raise {@link jakarta.data.exceptions.EntityExistsException}. If the database follows the BASE model, or uses an
+ * append model to write data, this exception is not thrown.
  * </p>
  * <p>
  * An event of type {@link jakarta.data.event.PreInsertEvent} must be raised by the annotated lifecycle

--- a/api/src/main/java/jakarta/data/repository/Insert.java
+++ b/api/src/main/java/jakarta/data/repository/Insert.java
@@ -64,7 +64,7 @@ import java.lang.annotation.Target;
  * of entities in the argument. After the annotated method returns, an original entity instance supplied as an argument
  * might not accurately reflect the inserted state.
  * </p>
- * <p>If the databases uses ACID (atomic, consistent, isolated, durable) transactions, and insertion of an entity would
+ * <p>If the database uses ACID (atomic, consistent, isolated, durable) transactions, and insertion of an entity would
  * result in a violation of a uniqueness constraint, for example, if an entity of the given type and with the same
  * unique identifier already exists in the database when the annotated method is called, then the annotated method must
  * raise {@link jakarta.data.exceptions.EntityExistsException}. If the database follows the BASE model, or uses an


### PR DESCRIPTION
This is needed because we cannot always determine the precise cause of a unique key violation. This change aligns the Data spec with a change already made in Persistence.