### PR TITLE
Always return same instance of CurrentDate, CurrentTime, or CurrentDateTime

### DIFF
--- a/api/src/main/java/jakarta/data/spi/expression/function/CurrentDate.java
+++ b/api/src/main/java/jakarta/data/spi/expression/function/CurrentDate.java
@@ -47,6 +47,9 @@ public interface CurrentDate<T> extends TemporalExpression<T, LocalDate> {
 class CurrentDateInstance implements CurrentDate<Object> {
     static final CurrentDate<?> instance = new CurrentDateInstance();
 
+    private CurrentDateInstance() {
+    }
+
     @Override
     public Class<LocalDate> type() {
         return LocalDate.class;

--- a/api/src/main/java/jakarta/data/spi/expression/function/CurrentDate.java
+++ b/api/src/main/java/jakarta/data/spi/expression/function/CurrentDate.java
@@ -37,17 +37,23 @@ public interface CurrentDate<T> extends TemporalExpression<T, LocalDate> {
      *
      * @return an expression representing the current date.
      */
+    @SuppressWarnings("unchecked")
     static <T> CurrentDate<T> now() {
-        return new CurrentDate<>() {
-            @Override
-            public Class<LocalDate> type() {
-                return LocalDate.class;
-            }
+        return (CurrentDate<T>) CurrentDateInstance.instance;
+    }
+}
 
-            @Override
-            public String toString() {
-                return "LOCAL DATE";
-            }
-        };
+// Internal implementation of single instance obtained from CurrentDate.now()
+class CurrentDateInstance implements CurrentDate<Object> {
+    static final CurrentDate<?> instance = new CurrentDateInstance();
+
+    @Override
+    public Class<LocalDate> type() {
+        return LocalDate.class;
+    }
+
+    @Override
+    public String toString() {
+        return "LOCAL DATE";
     }
 }

--- a/api/src/main/java/jakarta/data/spi/expression/function/CurrentDateTime.java
+++ b/api/src/main/java/jakarta/data/spi/expression/function/CurrentDateTime.java
@@ -47,6 +47,9 @@ public interface CurrentDateTime<T> extends TemporalExpression<T, LocalDateTime>
 class CurrentDateTimeInstance implements CurrentDateTime<Object> {
     static final CurrentDateTime<?> instance = new CurrentDateTimeInstance();
 
+    private CurrentDateTimeInstance() {
+    }
+
     @Override
     public Class<LocalDateTime> type() {
         return LocalDateTime.class;

--- a/api/src/main/java/jakarta/data/spi/expression/function/CurrentDateTime.java
+++ b/api/src/main/java/jakarta/data/spi/expression/function/CurrentDateTime.java
@@ -37,17 +37,24 @@ public interface CurrentDateTime<T> extends TemporalExpression<T, LocalDateTime>
      *
      * @return an expression representing the current date and time.
      */
+    @SuppressWarnings("unchecked")
     static <T> CurrentDateTime<T> now() {
-        return new CurrentDateTime<>() {
-            @Override
-            public Class<LocalDateTime> type() {
-                return LocalDateTime.class;
-            }
-
-            @Override
-            public String toString() {
-                return "LOCAL DATETIME";
-            }
-        };
+        return (CurrentDateTime<T>) CurrentDateTimeInstance.instance;
     }
 }
+
+// Internal implementation of single instance obtained from CurrentDateTime.now()
+class CurrentDateTimeInstance implements CurrentDateTime<Object> {
+    static final CurrentDateTime<?> instance = new CurrentDateTimeInstance();
+
+    @Override
+    public Class<LocalDateTime> type() {
+        return LocalDateTime.class;
+    }
+
+    @Override
+    public String toString() {
+        return "LOCAL DATETIME";
+    }
+}
+

--- a/api/src/main/java/jakarta/data/spi/expression/function/CurrentTime.java
+++ b/api/src/main/java/jakarta/data/spi/expression/function/CurrentTime.java
@@ -47,6 +47,9 @@ public interface CurrentTime<T> extends TemporalExpression<T, LocalTime> {
 class CurrentTimeInstance implements CurrentTime<Object> {
     static final CurrentTime<?> instance = new CurrentTimeInstance();
 
+    private CurrentTimeInstance() {
+    }
+
     @Override
     public Class<LocalTime> type() {
         return LocalTime.class;

--- a/api/src/main/java/jakarta/data/spi/expression/function/CurrentTime.java
+++ b/api/src/main/java/jakarta/data/spi/expression/function/CurrentTime.java
@@ -37,17 +37,23 @@ public interface CurrentTime<T> extends TemporalExpression<T, LocalTime> {
      *
      * @return an expression representing the current time.
      */
+    @SuppressWarnings("unchecked")
     static <T> CurrentTime<T> now() {
-        return new CurrentTime<>() {
-            @Override
-            public Class<LocalTime> type() {
-                return LocalTime.class;
-            }
+        return (CurrentTime<T>) CurrentTimeInstance.instance;
+    }
+}
 
-            @Override
-            public String toString() {
-                return "LOCAL TIME";
-            }
-        };
+// Internal implementation of single instance obtained from CurrentTime.now()
+class CurrentTimeInstance implements CurrentTime<Object> {
+    static final CurrentTime<?> instance = new CurrentTimeInstance();
+
+    @Override
+    public Class<LocalTime> type() {
+        return LocalTime.class;
+    }
+
+    @Override
+    public String toString() {
+        return "LOCAL TIME";
     }
 }

--- a/api/src/test/java/jakarta/data/expression/TemporalExpressionTest.java
+++ b/api/src/test/java/jakarta/data/expression/TemporalExpressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025,2026 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
  */
 package jakarta.data.expression;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import jakarta.data.constraint.Between;
 import jakarta.data.constraint.LessThan;
 import jakarta.data.mock.entity.Book;
@@ -24,6 +26,8 @@ import jakarta.data.mock.entity._Book;
 import jakarta.data.restrict.BasicRestriction;
 import jakarta.data.restrict.Restriction;
 import jakarta.data.spi.expression.function.CurrentDate;
+import jakarta.data.spi.expression.function.CurrentDateTime;
+import jakarta.data.spi.expression.function.CurrentTime;
 import jakarta.data.spi.expression.literal.TemporalLiteral;
 
 import java.time.LocalDate;
@@ -97,5 +101,23 @@ class TemporalExpressionTest {
             soft.assertThat(upperLiteral.value())
                 .isEqualTo(LocalDate.of(2025, Month.APRIL, 30));
         });
+    }
+
+    @Test
+    void testCurrentDateEqualsCurrentDate() {
+        assertEquals(CurrentDate.now(),
+                     CurrentDate.now());
+    }
+
+    @Test
+    void testCurrentDateTimeEqualsCurrentDateTime() {
+        assertEquals(CurrentDateTime.now(),
+                     CurrentDateTime.now());
+    }
+
+    @Test
+    void testCurrentTimeEqualsCurrentTime() {
+        assertEquals(CurrentTime.now(),
+                     CurrentTime.now());
     }
 }

--- a/api/src/test/java/jakarta/data/expression/TemporalExpressionTest.java
+++ b/api/src/test/java/jakarta/data/expression/TemporalExpressionTest.java
@@ -17,7 +17,7 @@
  */
 package jakarta.data.expression;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import jakarta.data.constraint.Between;
 import jakarta.data.constraint.LessThan;
@@ -105,19 +105,19 @@ class TemporalExpressionTest {
 
     @Test
     void testCurrentDateEqualsCurrentDate() {
-        assertEquals(CurrentDate.now(),
-                     CurrentDate.now());
+        assertThat(CurrentDate.now())
+            .isSameAs(CurrentDate.now());
     }
 
     @Test
     void testCurrentDateTimeEqualsCurrentDateTime() {
-        assertEquals(CurrentDateTime.now(),
-                     CurrentDateTime.now());
+        assertThat(CurrentDateTime.now())
+            .isSameAs(CurrentDateTime.now());
     }
 
     @Test
     void testCurrentTimeEqualsCurrentTime() {
-        assertEquals(CurrentTime.now(),
-                     CurrentTime.now());
+        assertThat(CurrentTime.now())
+            .isSameAs(CurrentTime.now());
     }
 }


### PR DESCRIPTION
Currently we are creating a new instance of CurrentDate (and likewise for CurrentTime/CurrentDateTime) every time the TemporalExpression.localDate or CurrentDate.now method is invoked, such that CurrentDate.now() is unequal to CurrentDate.now() even though both represent the same datetime expression, `LOCAL DATE`.