### PR TITLE
Consistent case for example queries

### DIFF
--- a/api/src/main/java/jakarta/data/repository/First.java
+++ b/api/src/main/java/jakarta/data/repository/First.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2026 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import java.lang.annotation.Target;
  *
  * <pre>{@code
  * @First(10)
- * @Query("order by playCount desc")
+ * @Query("ORDER BY playCount DESC")
  * List<Song> topTen();
  * }</pre>
  *

--- a/api/src/main/java/jakarta/data/repository/Query.java
+++ b/api/src/main/java/jakarta/data/repository/Query.java
@@ -121,20 +121,20 @@ import java.lang.annotation.Target;
  * public interface People extends CrudRepository<Person, Long> {
  *
  *     // JCQL with positional parameters
- *     @Query("where firstName = ?1 and lastName = ?2")
+ *     @Query("WHERE firstName = ?1 AND lastName = ?2")
  *     List<Person> byName(String first, String last);
  *
  *     // JCQL with a named parameter
- *     @Query("where firstName || ' ' || lastName like :pattern")
+ *     @Query("WHERE firstName || ' ' || lastName LIKE :pattern")
  *     List<Person> byName(String pattern);
  *
  *     // JPQL using a positional parameter
- *     @Query("from Person where extract(year from birthdate) = ?1")
+ *     @Query("FROM Person WHERE EXTRACT(year FROM birthdate) = ?1")
  *     List<Person> bornIn(int year);
  *
  *     // JPQL using named parameters
- *     @Query("select distinct name from Person " +
- *            "where length(name) >= :min and length(name) <= :max")
+ *     @Query("SELECT DISTINCT name FROM Person " +
+ *            "WHERE LENGTH(name) >= :min AND LENGTH(name) <= :max")
  *     Page<String> namesOfLength(@Param("min") int minLength,
  *                                @Param("max") int maxLength,
  *                                PageRequest pageRequest,

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -487,13 +487,13 @@ import java.util.Set;
  *
  * <pre>
  * // example using named parameters
- * &#64;Query("where age between :min and :max order by age")
+ * &#64;Query("WHERE age BETWEEN :min AND :max ORDER BY age")
  * List&lt;Person&gt; peopleInAgeRange(int min, int max);
  * </pre>
  *
  * <pre>
  * // example using an ordinal parameter
- * &#64;Query("where ssn = ?1 and deceased = false")
+ * &#64;Query("WHERE ssn = ?1 AND deceased = FALSE")
  * Optional&lt;Person&gt; person(String ssn);
  * </pre>
  *

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -93,7 +93,7 @@ For example:
 
 [source,java]
 ----
-@Insert 
+@Insert
 void insertBook(Book book);
 ----
 
@@ -151,13 +151,13 @@ For example, using a named parameter:
 
 [source,java]
 ----
-@Query("where title like :title order by title asc, id asc")
+@Query("WHERE title LIKE :title ORDER BY title ASC, id ASC")
 Page<Book> booksByTitle(String title, PageRequest pageRequest);
 ----
 
 [source,java]
 ----
-@Query("where p.name = :prodname")
+@Query("WHERE p.name = :prodname")
 Optional<Product> findByName(@Param("prodname") String name);
 ----
 
@@ -165,7 +165,7 @@ Or, using a positional parameter:
 
 [source,java]
 ----
-@Query("delete from Book where isbn = ?1")
+@Query("DELETE FROM Book WHERE isbn = ?1")
 void deleteBook(String isbn);
 ----
 
@@ -357,7 +357,7 @@ public interface ProductRepository extends BasicRepository<Product, Long> {
     @Find
     Page<Product> findByName(String name, PageRequest pageRequest, Order<Product> order);
 
-    @Query("where name like :pattern")
+    @Query("WHERE name LIKE :pattern")
     List<Product> findByNameLike(String pattern, Limit max, Sort<Product> sort);
 
 }
@@ -760,7 +760,7 @@ In this example, the application uses a cursor to request pages in forward and p
 ----
 @Repository
 public interface Products extends CrudRepository<Product, Long> {
-    @Query("where name like ?1")
+    @Query("WHERE name LIKE ?1")
     CursoredPage<Product> findByNameLike(String namePattern,
                                          PageRequest pageRequest,
                                          Order<Product> sorts);

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -280,7 +280,7 @@ Connection connection();
 
 default void cleanup() {
     try (Statement s = connection().createStatement()) {
-        s.executeUpdate("truncate table books");
+        s.executeUpdate("TRUNCATE TABLE books");
     }
 }
 ----


### PR DESCRIPTION
In the Jakarta Data spec and Javadoc, examples involving query language are inconsistent about the case of keywords.  Many of them use upper case `SELECT`, `FROM`, `WHERE`, ... while some others are using lower case.  This PR makes all of the example usage consistent.