### PR TITLE
minimal API changes for 0-based offsets

### DIFF
--- a/api/src/main/java/jakarta/data/Limit.java
+++ b/api/src/main/java/jakarta/data/Limit.java
@@ -17,14 +17,22 @@
  */
 package jakarta.data;
 
+import jakarta.data.messages.Messages;
 import jakarta.data.page.PageRequest;
+import jakarta.data.repository.Find;
+import jakarta.data.repository.Query;
 
 /**
  * <p>Specifies a limit on the number of results retrieved by a repository
  * method. The results of a single invocation of a repository method may be
- * limited to a given {@linkplain #of(int) maximum number of results} or to a
- * given {@linkplain #range(long, long) positioned range} defined in terms of an
- * offset and maximum number of results.</p>
+ * limited to
+ * <ul>
+ * <li>a {@linkplain #of(int) maximum number of results},</li>
+ * <li>a {@linkplain #of(int, long) maximum number of results relative to an
+ *     offset}, or</li>
+ * <li>a {@linkplain #range(long, long) positioned range} defined in terms of
+ * a starting position and maximum number of results.</li>
+ * </ul></p>
  *
  * <p>A query method of a repository may have a parameter of type
  * {@code Limit} if its return type indicates that it may return multiple
@@ -105,14 +113,14 @@ public record Limit(int maxResults, long startAt) {
 
     /**
      * <p>The position at which to start when returning query results.</p>
-     * <p>The first query result is at position one. If the start position
+     * <p>The first query result is at position {@code 1}. If the start position
      * is greater than one, some results at the beginning of the result set
      * are skipped.</p>
      *
      * @return position of the first result.
      *
      * @apiNote Positions are indexed from one;
-     *          {@linkplain #startOffset offsets} are indexed from zero.
+     *          offsets are indexed from zero.
      */
     public long startAt() {
         return startAt;
@@ -129,6 +137,37 @@ public record Limit(int maxResults, long startAt) {
      */
     public static Limit of(int maxResults) {
         return new Limit(maxResults, DEFAULT_START_AT);
+    }
+
+    /**
+     * Create a limit that caps the number of results at the given maximum,
+     * starting at the given {@code offset} from the first result.
+     * <p>
+     * An {@code offset} of zero includes the first result. A positive
+     * {@code offset} skips the respective number of results.
+     *
+     * @param maxResults maximum number of results
+     * @param offset offset at which to start
+     * @return limit that can be supplied to a {@link Find} method or
+     *         {@link Query} method that performs a find operation;
+     *         will never be {@code null}
+     * @throws IllegalArgumentException if {@code maxResults} or
+     *         {@code offset} is negative or the {@code offset} is
+     *         {@link Long#MAX_VALUE}
+     * @since 1.1
+     */
+    public static Limit of(int maxResults, long offset) {
+        if (offset < 0) {
+            throw new IllegalArgumentException(
+                    Messages.get("004.arg.negative", "offset"));
+        }
+
+        if (offset == Long.MAX_VALUE) {
+            throw new IllegalArgumentException(
+                    Messages.get("013.arg.invalid", "offset", offset));
+        }
+
+        return new Limit(maxResults, offset + 1);
     }
 
     /**

--- a/api/src/main/java/jakarta/data/Limit.java
+++ b/api/src/main/java/jakarta/data/Limit.java
@@ -31,7 +31,7 @@ import jakarta.data.repository.Query;
  * <li>a {@linkplain #of(int, long) maximum number of results relative to an
  *     offset}, or</li>
  * <li>a {@linkplain #range(long, long) positioned range} defined in terms of
- * a starting position and maximum number of results.</li>
+ * a starting position and an ending position.</li>
  * </ul></p>
  *
  * <p>A query method of a repository may have a parameter of type

--- a/api/src/main/java/jakarta/data/Limit.java
+++ b/api/src/main/java/jakarta/data/Limit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2026 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,10 +104,15 @@ public record Limit(int maxResults, long startAt) {
     // Override to provide method documentation:
 
     /**
-     * <p>Offset at which to start when returning query results.
-     * The first query result is position {@code 1}.</p>
+     * <p>The position at which to start when returning query results.</p>
+     * <p>The first query result is at position one. If the start position
+     * is greater than one, some results at the beginning of the result set
+     * are skipped.</p>
      *
-     * @return offset of the first result.
+     * @return position of the first result.
+     *
+     * @apiNote Positions are indexed from one;
+     *          {@linkplain #startOffset offsets} are indexed from zero.
      */
     public long startAt() {
         return startAt;

--- a/api/src/main/java/jakarta/data/page/CursoredPage.java
+++ b/api/src/main/java/jakarta/data/page/CursoredPage.java
@@ -93,8 +93,8 @@ import java.util.NoSuchElementException;
  * <pre>{@code
  * Employee emp = ...
  * PageRequest pageRequest =
- *         PageRequest.ofPage(5)
- *                    .size(50)
+ *         PageRequest.ofSize(50)
+ *                    .pageNumber(5)
  *                    .afterCursor(Cursor.forKey(emp.lastName, emp.firstName, emp.id));
  * page = employees.withHoursOver(40, pageRequest);
  * }</pre>

--- a/api/src/main/java/jakarta/data/page/PageRequest.java
+++ b/api/src/main/java/jakarta/data/page/PageRequest.java
@@ -227,10 +227,21 @@ public interface PageRequest {
      * Returns the requested page number. Page numbers begin with {@code 1}.
      *
      * @return the requested page number
+     * @deprecated use {@link #pageNumber()} instead
+     */
+    @Deprecated(since = "1.1", forRemoval = true)
+    default long page() {
+        return pageNumber();
+    }
+
+    /**
+     * Returns the requested page number. Page numbers begin with {@code 1}.
+     *
+     * @return the requested page number
      * @apiNote Page <em>numbers</em> are indexed from one;
      *          page {@linkplain #pageOffset offsets} are indexed from zero.
      */
-    long page();
+    long pageNumber();
 
     /**
      * Returns the requested size of each page
@@ -272,7 +283,7 @@ public interface PageRequest {
      * @apiNote Page <em>numbers</em> are indexed from one;
      *          page {@linkplain #pageOffset offsets} are indexed from zero.
      */
-    PageRequest page(long pageNumber);
+    PageRequest pageNumber(long pageNumber);
 
     /**
      * Creates a new page request with the same pagination information,
@@ -290,7 +301,7 @@ public interface PageRequest {
      * @since 1.1
      *
      * @apiNote Page <em>offsets</em> are indexed from zero;
-     *          page {@linkplain #page numbers} are indexed from one.
+     *          page {@linkplain #pageNumber numbers} are indexed from one.
      */
     default PageRequest pageOffset(long offset) {
         if (mode() != Mode.OFFSET) {
@@ -308,7 +319,7 @@ public interface PageRequest {
                     Messages.get("013.arg.invalid", "offset", offset));
         }
 
-        return page(offset + 1);
+        return pageNumber(offset + 1);
     }
 
     /**

--- a/api/src/main/java/jakarta/data/page/PageRequest.java
+++ b/api/src/main/java/jakarta/data/page/PageRequest.java
@@ -223,11 +223,26 @@ public interface PageRequest {
     Mode mode();
 
     /**
-     * Returns the page to be returned.
+     * Returns the page number of the page to be returned.
      *
      * @return the page to be returned.
+     * @apiNote Page <em>numbers</em> are indexed from one;
+     *          page {@linkplain #pageOffset offsets} are indexed from zero.
      */
     long page();
+
+    /**
+     * Returns the page offset of the page to be returned.
+     *
+     * @return the page to be returned.
+     * @since 1.1
+     *
+     * @apiNote Page <em>offsets</em> are indexed from zero;
+     *          page {@linkplain #pageNumber numbers} are indexed from one.
+     */
+    default long pageOffset() {
+        return pageNumber() - 1;
+    }
 
     /**
      * Returns the requested size of each page
@@ -266,8 +281,26 @@ public interface PageRequest {
      * @return a new instance of {@code PageRequest}. This method never returns
      * {@code null}.
      * @since 1.1
+     * @apiNote Page <em>numbers</em> are indexed from one;
+     *          page {@linkplain #atPageOffset offsets} are indexed from zero.
      */
     PageRequest page(long pageNumber);
+
+    /**
+     * <p>Creates a new page request with the same pagination information,
+     * but with the specified page offset.</p>
+     *
+     * @param pageOffset the page offset.
+     * @return a new instance of {@code PageRequest}. This method never returns
+     * {@code null}.
+     * @since 1.1
+     *
+     * @apiNote Page <em>offsets</em> are indexed from zero;
+     *          page {@linkplain #atPageNumber numbers} are indexed from one.
+     */
+    default PageRequest atPageOffset(long pageOffset) {
+        return atPageNumber(pageOffset + 1);
+    }
 
     /**
      * <p>Creates a new page request with the same pagination information,

--- a/api/src/main/java/jakarta/data/page/PageRequest.java
+++ b/api/src/main/java/jakarta/data/page/PageRequest.java
@@ -20,6 +20,7 @@ package jakarta.data.page;
 import jakarta.data.Limit;
 import jakarta.data.Order;
 import jakarta.data.Sort;
+import jakarta.data.messages.Messages;
 import jakarta.data.repository.First;
 import jakarta.data.repository.OrderBy;
 
@@ -223,26 +224,13 @@ public interface PageRequest {
     Mode mode();
 
     /**
-     * Returns the page number of the page to be returned.
+     * Returns the requested page number. Page numbers begin with {@code 1}.
      *
-     * @return the page to be returned.
+     * @return the requested page number
      * @apiNote Page <em>numbers</em> are indexed from one;
      *          page {@linkplain #pageOffset offsets} are indexed from zero.
      */
     long page();
-
-    /**
-     * Returns the page offset of the page to be returned.
-     *
-     * @return the page to be returned.
-     * @since 1.1
-     *
-     * @apiNote Page <em>offsets</em> are indexed from zero;
-     *          page {@linkplain #pageNumber numbers} are indexed from one.
-     */
-    default long pageOffset() {
-        return pageNumber() - 1;
-    }
 
     /**
      * Returns the requested size of each page
@@ -274,32 +262,53 @@ public interface PageRequest {
     boolean requestTotal();
 
     /**
-     * <p>Creates a new page request with the same pagination information,
-     * but with the specified page number.</p>
+     * Creates a new page request with the same pagination information,
+     * but with the specified page number. The first page number is {@code 1}.
      *
      * @param pageNumber the page number.
      * @return a new instance of {@code PageRequest}. This method never returns
      * {@code null}.
      * @since 1.1
      * @apiNote Page <em>numbers</em> are indexed from one;
-     *          page {@linkplain #atPageOffset offsets} are indexed from zero.
+     *          page {@linkplain #pageOffset offsets} are indexed from zero.
      */
     PageRequest page(long pageNumber);
 
     /**
-     * <p>Creates a new page request with the same pagination information,
-     * but with the specified page offset.</p>
+     * Creates a new page request with the same pagination information,
+     * but with the given {@code offset}.
+     * <p>
+     * The offset is relative to the first page. An offset of {@code 0}
+     * requests the first page, and an offset of {@code 1} requests the
+     * second page.
      *
-     * @param pageOffset the page offset.
-     * @return a new instance of {@code PageRequest}. This method never returns
-     * {@code null}.
+     * @return the offset of the requested page
+     * @throws IllegalStateException if the {@link #mode()} is not
+     *         {@link Mode#OFFSET}
+     * @throws IllegalArgumentException if the {@code offset} is negative
+     *         or {@link Long#MAX_VALUE}
      * @since 1.1
      *
      * @apiNote Page <em>offsets</em> are indexed from zero;
-     *          page {@linkplain #atPageNumber numbers} are indexed from one.
+     *          page {@linkplain #page numbers} are indexed from one.
      */
-    default PageRequest atPageOffset(long pageOffset) {
-        return atPageNumber(pageOffset + 1);
+    default PageRequest pageOffset(long offset) {
+        if (mode() != Mode.OFFSET) {
+            throw new IllegalStateException(
+                    Messages.get("014.mode.disallows.offset", mode()));
+        }
+
+        if (offset < 0) {
+            throw new IllegalArgumentException(
+                    Messages.get("004.arg.negative", "offset"));
+        }
+
+        if (offset == Long.MAX_VALUE) {
+            throw new IllegalArgumentException(
+                    Messages.get("013.arg.invalid", "offset", offset));
+        }
+
+        return page(offset + 1);
     }
 
     /**

--- a/api/src/main/java/jakarta/data/page/Pagination.java
+++ b/api/src/main/java/jakarta/data/page/Pagination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022,2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2026 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,12 +24,12 @@ import jakarta.data.messages.Messages;
 /**
  * Built-in implementation of PageRequest.
  */
-record Pagination(long page, int size, Mode mode, Cursor type,
+record Pagination(long pageNumber, int size, Mode mode, Cursor type,
                   boolean requestTotal) implements PageRequest {
 
     Pagination {
-        if (page < 1) {
-            throw new IllegalArgumentException("pageNumber: " + page);
+        if (pageNumber < 1) {
+            throw new IllegalArgumentException("pageNumber: " + pageNumber);
         } else if (size < 1) {
             throw new IllegalArgumentException("maxPageSize: " + size);
         }
@@ -42,22 +42,30 @@ record Pagination(long page, int size, Mode mode, Cursor type,
 
     @Override
     public PageRequest withoutTotal() {
-        return new Pagination(page, size, mode, type, false);
+        return new Pagination(pageNumber, size, mode, type, false);
     }
 
     @Override
     public PageRequest withTotal() {
-        return new Pagination(page, size, mode, type, true);
+        return new Pagination(pageNumber, size, mode, type, true);
     }
 
     @Override
     public PageRequest afterCursor(Cursor cursor) {
-        return new Pagination(page, size, Mode.CURSOR_NEXT, cursor, requestTotal);
+        return new Pagination(pageNumber,
+                              size,
+                              Mode.CURSOR_NEXT,
+                              cursor,
+                              requestTotal);
     }
 
     @Override
     public PageRequest beforeCursor(Cursor cursor) {
-        return new Pagination(page, size, Mode.CURSOR_PREVIOUS, cursor, requestTotal);
+        return new Pagination(pageNumber,
+                              size,
+                              Mode.CURSOR_PREVIOUS,
+                              cursor,
+                              requestTotal);
     }
 
     @Override
@@ -68,7 +76,7 @@ record Pagination(long page, int size, Mode mode, Cursor type,
     @Override
     public String toString() {
         StringBuilder s = new StringBuilder(mode == Mode.OFFSET ? 100 : 150)
-                .append("PageRequest{page=").append(page)
+                .append("PageRequest{pageNumber=").append(pageNumber)
                 .append(", size=").append(size)
                 .append(", mode=").append(mode);
         if (type != null) {
@@ -79,11 +87,11 @@ record Pagination(long page, int size, Mode mode, Cursor type,
 
     @Override
     public PageRequest size(int maxPageSize) {
-        return new Pagination(page, maxPageSize, mode, type, requestTotal);
+        return new Pagination(pageNumber, maxPageSize, mode, type, requestTotal);
     }
 
     @Override
-    public PageRequest page(long pageNumber) {
+    public PageRequest pageNumber(long pageNumber) {
         return new Pagination(pageNumber, size, mode, type, requestTotal);
     }
 

--- a/api/src/main/java/jakarta/data/page/impl/CursoredPageRecord.java
+++ b/api/src/main/java/jakarta/data/page/impl/CursoredPageRecord.java
@@ -82,12 +82,14 @@ public record CursoredPageRecord<T>
         this(content, cursors, totalElements, pageRequest,
                 lastPage ? null : PageRequest.afterCursor(
                         cursors.get(cursors.size() - 1),
-                        pageRequest.page() + 1,
+                        pageRequest.pageNumber() + 1,
                         pageRequest.size(),
                         pageRequest.requestTotal()),
                 firstPage ? null : PageRequest.beforeCursor(
                         cursors.get(0),
-                        pageRequest.page() == 1 ? 1 : pageRequest.page() - 1,
+                        pageRequest.pageNumber() == 1
+                                ? 1
+                                : pageRequest.pageNumber() - 1,
                         pageRequest.size(),
                         pageRequest.requestTotal()));
     }

--- a/api/src/main/java/jakarta/data/page/impl/CursoredPageRecord.java
+++ b/api/src/main/java/jakarta/data/page/impl/CursoredPageRecord.java
@@ -125,7 +125,7 @@ public record CursoredPageRecord<T>
     public PageRequest nextPageRequest() {
         if (cursors.isEmpty())
             throw new UnsupportedOperationException(
-                    Messages.get("013.cursor.uncomputable"));
+                    Messages.get("015.cursor.uncomputable"));
         if (nextPageRequest == null)
             throw new NoSuchElementException();
         return nextPageRequest;
@@ -135,7 +135,7 @@ public record CursoredPageRecord<T>
     public PageRequest previousPageRequest() {
         if (cursors.isEmpty())
             throw new UnsupportedOperationException(
-                    Messages.get("013.cursor.uncomputable"));
+                    Messages.get("015.cursor.uncomputable"));
         if (previousPageRequest == null)
             throw new NoSuchElementException();
         return previousPageRequest;
@@ -150,7 +150,7 @@ public record CursoredPageRecord<T>
     public PageRequest.Cursor cursor(int index) {
         if (cursors.isEmpty())
             throw new UnsupportedOperationException(
-                    Messages.get("013.cursor.uncomputable"));
+                    Messages.get("015.cursor.uncomputable"));
         return cursors.get(index);
     }
 

--- a/api/src/main/java/jakarta/data/page/impl/PageRecord.java
+++ b/api/src/main/java/jakarta/data/page/impl/PageRecord.java
@@ -59,7 +59,7 @@ public record PageRecord<T>(PageRequest pageRequest, List<T> content,
      * as {@code true} if the page {@code content} is a full page of results and
      * the {@code totalElements} is either unavailable (indicated by a negative
      * value) or it exceeds the current
-     * {@linkplain PageRequest#page() page number} multiplied by the
+     * {@linkplain PageRequest#pageNumber() page number} multiplied by the
      * {@link PageRequest#size() size} of a full page.
      *
      * @param pageRequest   The {@link PageRequest page request} for which this
@@ -74,7 +74,7 @@ public record PageRecord<T>(PageRequest pageRequest, List<T> content,
         this(pageRequest, content, totalElements,
                 content.size() == pageRequest.size()
                         && (totalElements < 0
-                        || totalElements > pageRequest.size() * pageRequest.page()));
+                        || totalElements > pageRequest.size() * pageRequest.pageNumber()));
     }
 
     @Override
@@ -98,14 +98,14 @@ public record PageRecord<T>(PageRequest pageRequest, List<T> content,
             throw new NoSuchElementException();
         }
 
-        return PageRequest.ofPage(pageRequest.page() + 1,
+        return PageRequest.ofPage(pageRequest.pageNumber() + 1,
                 pageRequest.size(),
                 pageRequest.requestTotal());
     }
 
     @Override
     public boolean hasPrevious() {
-        return pageRequest.page() > 1;
+        return pageRequest.pageNumber() > 1;
     }
 
     @Override
@@ -114,7 +114,7 @@ public record PageRecord<T>(PageRequest pageRequest, List<T> content,
             throw new NoSuchElementException();
         }
 
-        return PageRequest.ofPage(pageRequest.page() - 1,
+        return PageRequest.ofPage(pageRequest.pageNumber() - 1,
                 pageRequest.size(),
                 pageRequest.requestTotal());
     }

--- a/api/src/main/resources/jakarta/data/messages/DataMessages.properties
+++ b/api/src/main/resources/jakarta/data/messages/DataMessages.properties
@@ -35,7 +35,6 @@
  identify the entity class that declares the attribute. For static metamodel \
  classes, use an .of method that is defined on an Attribute subtype to supply \
  the entity class and entity attribute type.
-
 013.arg.invalid=The {0} argument cannot be {1}
 014.mode.disallows.offset=A page cannot be requested to have an offset \
  and a mode of {0}

--- a/api/src/main/resources/jakarta/data/messages/DataMessages.properties
+++ b/api/src/main/resources/jakarta/data/messages/DataMessages.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2025 Contributors to the Eclipse Foundation
+# Copyright (c) 2025,2026 Contributors to the Eclipse Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,3 +35,6 @@
  identify the entity class that declares the attribute. For static metamodel \
  classes, use an .of method that is defined on an Attribute subtype to supply \
  the entity class and entity attribute type.
+013.arg.invalid=The {0} argument cannot be {1}
+014.mode.disallows.offset=A page cannot be requested to have an offset \
+ and a mode of {0}

--- a/api/src/test/java/jakarta/data/page/PageRequestCursorTest.java
+++ b/api/src/test/java/jakarta/data/page/PageRequestCursorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2026 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ class PageRequestCursorTest {
 
         assertSoftly(softly -> {
             softly.assertThat(pageRequest.size()).isEqualTo(20);
-            softly.assertThat(pageRequest.page()).isEqualTo(1L);
+            softly.assertThat(pageRequest.pageNumber()).isEqualTo(1L);
             softly.assertThat(pageRequest.requestTotal()).isEqualTo(false);
             softly.assertThat(pageRequest.mode()).isEqualTo(PageRequest.Mode.CURSOR_NEXT);
             softly.assertThat(pageRequest.cursor()).get().extracting(PageRequest.Cursor::size).isEqualTo(3);
@@ -54,7 +54,7 @@ class PageRequestCursorTest {
 
         assertSoftly(softly -> {
             softly.assertThat(pageRequest.size()).isEqualTo(35);
-            softly.assertThat(pageRequest.page()).isEqualTo(1L);
+            softly.assertThat(pageRequest.pageNumber()).isEqualTo(1L);
             softly.assertThat(pageRequest.mode()).isEqualTo(PageRequest.Mode.CURSOR_NEXT);
             softly.assertThat(pageRequest.cursor()).get().extracting(PageRequest.Cursor::size).isEqualTo(2);
             softly.assertThat(pageRequest.cursor()).get().extracting(c -> c.get(0)).isEqualTo("me");
@@ -70,7 +70,7 @@ class PageRequestCursorTest {
 
         assertSoftly(softly -> {
             softly.assertThat(pageRequest.size()).isEqualTo(30);
-            softly.assertThat(pageRequest.page()).isEqualTo(10L);
+            softly.assertThat(pageRequest.pageNumber()).isEqualTo(10L);
             softly.assertThat(pageRequest.requestTotal()).isEqualTo(false);            
             softly.assertThat(pageRequest.mode()).isEqualTo(PageRequest.Mode.CURSOR_PREVIOUS);
             softly.assertThat(pageRequest.cursor()).get().extracting(PageRequest.Cursor::size).isEqualTo(2);
@@ -87,7 +87,7 @@ class PageRequestCursorTest {
 
         assertSoftly(softly -> {
             softly.assertThat(pageRequest.size()).isEqualTo(10);
-            softly.assertThat(pageRequest.page()).isEqualTo(8L);
+            softly.assertThat(pageRequest.pageNumber()).isEqualTo(8L);
             softly.assertThat(pageRequest.mode()).isEqualTo(PageRequest.Mode.CURSOR_PREVIOUS);
             softly.assertThat(pageRequest.cursor()).get().extracting(PageRequest.Cursor::size).isEqualTo(5);
             softly.assertThat(pageRequest.cursor()).get().extracting(c -> c.get(0)).isEqualTo(900L);
@@ -130,10 +130,10 @@ class PageRequestCursorTest {
         assertSoftly(softly -> {
 
             softly.assertThat(afterKeySet.toString())
-              .isEqualTo("PageRequest{page=1, size=200, mode=CURSOR_NEXT, cursor size=2}");
+              .isEqualTo("PageRequest{pageNumber=1, size=200, mode=CURSOR_NEXT, cursor size=2}");
 
             softly.assertThat(beforeKeySet.toString())
-                    .isEqualTo("PageRequest{page=1, size=100, mode=CURSOR_PREVIOUS, cursor size=2}");
+                    .isEqualTo("PageRequest{pageNumber=1, size=100, mode=CURSOR_PREVIOUS, cursor size=2}");
 
         });
     }
@@ -215,8 +215,8 @@ class PageRequestCursorTest {
             softly.assertThat(p2.cursor()).get().extracting(c -> c.get(1)).isEqualTo("fname2");
             softly.assertThat(p2.cursor()).get().extracting(c -> c.get(2)).isEqualTo(200);
 
-            softly.assertThat(p1.page()).isEqualTo(12L);
-            softly.assertThat(p2.page()).isEqualTo(12L);
+            softly.assertThat(p1.pageNumber()).isEqualTo(12L);
+            softly.assertThat(p2.pageNumber()).isEqualTo(12L);
             softly.assertThat(p1.size()).isEqualTo(30);
             softly.assertThat(p2.size()).isEqualTo(30);
         });

--- a/api/src/test/java/jakarta/data/page/PageRequestTest.java
+++ b/api/src/test/java/jakarta/data/page/PageRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022,2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022,2026 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ class PageRequestTest {
         PageRequest pageRequest = PageRequest.ofPage(2).size(6);
 
         assertSoftly(softly -> {
-            softly.assertThat(pageRequest.page()).isEqualTo(2L);
+            softly.assertThat(pageRequest.pageNumber()).isEqualTo(2L);
             softly.assertThat(pageRequest.size()).isEqualTo(6);
         });
     }
@@ -42,7 +42,7 @@ class PageRequestTest {
         PageRequest pageRequest = PageRequest.ofSize(50);
 
         assertSoftly(softly -> {
-            softly.assertThat(pageRequest.page()).isEqualTo(1L);
+            softly.assertThat(pageRequest.pageNumber()).isEqualTo(1L);
             softly.assertThat(pageRequest.size()).isEqualTo(50);
         });
     }
@@ -53,7 +53,7 @@ class PageRequestTest {
         PageRequest pageRequest = PageRequest.ofPage(5);
 
         assertSoftly(softly -> {
-            softly.assertThat(pageRequest.page()).isEqualTo(5L);
+            softly.assertThat(pageRequest.pageNumber()).isEqualTo(5L);
             softly.assertThat(pageRequest.size()).isEqualTo(10);
         });
     }
@@ -63,10 +63,10 @@ class PageRequestTest {
     void shouldPageRequestDisplayAsString() {
         assertSoftly(softly -> {
             softly.assertThat(PageRequest.ofSize(60).toString())
-              .isEqualTo("PageRequest{page=1, size=60, mode=OFFSET}");
+              .isEqualTo("PageRequest{pageNumber=1, size=60, mode=OFFSET}");
 
             softly.assertThat(PageRequest.ofSize(80).toString())
-                    .isEqualTo("PageRequest{page=1, size=80, mode=OFFSET}");
+                    .isEqualTo("PageRequest{pageNumber=1, size=80, mode=OFFSET}");
         });
     }
 
@@ -76,7 +76,7 @@ class PageRequestTest {
         PageRequest pageRequest1 = PageRequest.ofPage(1).withTotal().size(70);
 
         assertSoftly(softly -> {
-            softly.assertThat(pageRequest1.page()).isEqualTo(1L);
+            softly.assertThat(pageRequest1.pageNumber()).isEqualTo(1L);
             softly.assertThat(pageRequest1.size()).isEqualTo(70);
             softly.assertThat(pageRequest1.requestTotal()).isEqualTo(true);
         });
@@ -84,7 +84,7 @@ class PageRequestTest {
         PageRequest pageRequest2 = PageRequest.ofPage(2).size(80).withoutTotal();
 
         assertSoftly(softly -> {
-            softly.assertThat(pageRequest2.page()).isEqualTo(2L);
+            softly.assertThat(pageRequest2.pageNumber()).isEqualTo(2L);
             softly.assertThat(pageRequest2.size()).isEqualTo(80);
             softly.assertThat(pageRequest2.requestTotal()).isEqualTo(false);
         });
@@ -112,8 +112,8 @@ class PageRequestTest {
         assertSoftly(softly -> {
             softly.assertThat(s80.size()).isEqualTo(80);
             softly.assertThat(s90.size()).isEqualTo(90);
-            softly.assertThat(s90.page()).isEqualTo(4L);
-            softly.assertThat(s80.page()).isEqualTo(4L);
+            softly.assertThat(s90.pageNumber()).isEqualTo(4L);
+            softly.assertThat(s80.pageNumber()).isEqualTo(4L);
         });
     }
 

--- a/api/src/test/java/jakarta/data/page/PaginationTest.java
+++ b/api/src/test/java/jakarta/data/page/PaginationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023,2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2023,2026 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,9 +97,10 @@ class PaginationTest {
     @DisplayName("should override page number")
     void shouldUpdatePageNumber() {
         var pagination = new Pagination(1, 10, PageRequest.Mode.OFFSET, null, false);
-        var updated = pagination.page(5);
+        var updated = pagination.pageNumber(5);
 
-        assertThat(updated).hasFieldOrPropertyWithValue("page", 5L);
+        assertThat(updated).hasFieldOrPropertyWithValue("page", 5L); // deprecated
+        assertThat(updated).hasFieldOrPropertyWithValue("pageNumber", 5L);
     }
 
     @Test
@@ -109,7 +110,7 @@ class PaginationTest {
         var pagination = new Pagination(2, 50, PageRequest.Mode.CURSOR_NEXT, cursor, true);
 
         assertThat(pagination.toString())
-                .contains("page=2", "size=50", "mode=CURSOR_NEXT", "cursor size=2");
+                .contains("pageNumber=2", "size=50", "mode=CURSOR_NEXT", "cursor size=2");
     }
 
 

--- a/api/src/test/java/jakarta/data/page/impl/CursoredPageRecordTest.java
+++ b/api/src/test/java/jakarta/data/page/impl/CursoredPageRecordTest.java
@@ -83,11 +83,10 @@ class CursoredPageRecordTest {
                 page4Request,
                 page2Request);
 
-        // Modify the values that were supplied to the CursoredPageRecord
-        // constructor
-        page2Request.page(5);
-        page3Request.page(6);
-        page4Request.page(7);
+        // Verify that these methods do not modify the original instances
+        page2Request.pageNumber(5);
+        page3Request.pageNumber(6);
+        page4Request.pageNumber(7);
 
         page2Request.size(9);
         page3Request.size(6);
@@ -117,19 +116,18 @@ class CursoredPageRecordTest {
                 .containsSequence(originalPage3Content);
         });
 
-        // Modify (or attempt to modify) values returned by the
-        // CursoredPageRecord
-        page3.previousPageRequest().page(1);
+        // Verify that these methods do not modify the original CursoredPageRecord
+        page3.previousPageRequest().pageNumber(1);
         page3.previousPageRequest().size(8);
         page3.previousPageRequest().withTotal();
         page3.previousPageRequest().beforeCursor(Cursor.forKey("50"));
 
-        page3.pageRequest().page(4);
+        page3.pageRequest().pageNumber(4);
         page3.pageRequest().size(7);
         page3.pageRequest().withTotal();
         page3.pageRequest().afterCursor(Cursor.forKey("101"));
 
-        page3.nextPageRequest().page(5);
+        page3.nextPageRequest().pageNumber(5);
         page3.nextPageRequest().size(3);
         page3.nextPageRequest().withTotal();
         page3.nextPageRequest().afterCursor(Cursor.forKey("115"));

--- a/api/src/test/java/jakarta/data/page/impl/PageRecordTest.java
+++ b/api/src/test/java/jakarta/data/page/impl/PageRecordTest.java
@@ -56,8 +56,8 @@ class PageRecordTest {
 
         Page<Book> page4 = new PageRecord<>(page4Request, page4Content, 44);
 
-        // Modify the values that were supplied to the PageRecord constructor
-        page4Request.page(5);
+        // Verify that these methods do not modify the values of the original
+        page4Request.pageNumber(5);
         page4Request.size(6);
         page4Request.withoutTotal();
         page4Request.afterCursor(Cursor.forKey("104"));
@@ -72,8 +72,8 @@ class PageRecordTest {
                 .containsSequence(originalPage4Content);
         });
 
-        // Modify values returned by the PageRecord
-        page4.pageRequest().page(3);
+        // Verify that these methods do not modify values of the original
+        page4.pageRequest().pageNumber(3);
         page4.pageRequest().size(7);
         page4.pageRequest().withoutTotal();
         page4.pageRequest().beforeCursor(Cursor.forKey("100"));

--- a/spec/src/main/asciidoc/repository.asciidoc
+++ b/spec/src/main/asciidoc/repository.asciidoc
@@ -381,7 +381,7 @@ This `PageRequest` specifies a starting page and maximum page size:
 
 [source,java]
 ----
-PageRequest pageRequest = PageRequest.ofPage(1).size(20);
+PageRequest pageRequest = PageRequest.ofSize(20).pageNumber(1);
 List<Product> first20 = products.findByName(name, pageRequest,
                             Order.by(_Product.price.desc(),
                                      _Product.id.asc()));
@@ -581,7 +581,7 @@ Code Execution:
 People people;
 
 Page<Person> page =
-        people.findAll(PageRequest.ofPage(1).size(2),
+        people.findAll(PageRequest.ofSize(2).pageNumber(1),
                        Order.by(Sort.asc("id")));
 ----
 
@@ -660,8 +660,8 @@ Or you can obtain the next (or previous) page relative to a known entity,
 [source,java]
 ----
 Customer c = ...
-PageRequest p = PageRequest.ofPage(10)
-                           .size(50)
+PageRequest p = PageRequest.ofSize(50)
+                           .pageNumber(10)
                            .afterCursor(Cursor.forKey(c.lastName, c.firstName, c.id));
 page = customers.findByZipcode(55902, p);
 ----
@@ -776,8 +776,8 @@ Order<Product> order =
         Order.by(_Product.price.asc(),
                  _Product.id.asc());
 PageRequest pageRequest =
-        PageRequest.ofPage(5)
-                   .size(10)
+        PageRequest.ofSize(10)
+                   .pageNumber(5)
                    .afterCursor(Cursor.forKey(priceMidpoint, 0L));
 CursoredPage<Product> moreExpensive =
         products.findByNameLike(pattern, pageRequest, order);
@@ -828,8 +828,8 @@ The query results are ordered first by vehicle condition. All resulting entities
 [source,java]
 ----
 PageRequest page2Request = PageRequest
-             .ofPage(2) // cosmetic when using a cursor
-             .size(25)
+             .ofSize(25)
+             .pageNumber(2) // cosmetic when using a cursor
              .afterCursor(Cursor.forKey(lastCar.vehicleCondition,
                                         lastCar.price,
                                         lastCar.vin));

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/EntityTests.java
@@ -696,7 +696,7 @@ public class EntityTests {
 
         assertFalse(it.hasNext());
 
-        assertEquals(5, page.pageRequest().page());
+        assertEquals(5, page.pageRequest().pageNumber());
         assertTrue(page.hasContent());
         assertEquals(3, page.numberOfElements());
         try {
@@ -730,7 +730,7 @@ public class EntityTests {
             }
         }
         assertTrue(page.hasContent());
-        assertEquals(5, page.pageRequest().page());
+        assertEquals(5, page.pageRequest().pageNumber());
         assertEquals(2, page.numberOfElements());
 
         Iterator<NaturalNumber> it = page.iterator();
@@ -779,7 +779,7 @@ public class EntityTests {
         }
 
         assertEquals(12, page2.numberOfElements());
-        assertEquals(2, page2.pageRequest().page());
+        assertEquals(2, page2.pageRequest().pageNumber());
 
         assertEquals(List.of(11L, 10L, 9L, // square root rounds down to 3
                              24L, 23L, 22L, 21L, 20L, 19L, 18L, 17L, 16L), // square root rounds down to 4
@@ -1215,7 +1215,7 @@ public class EntityTests {
             }
         }
 
-        assertEquals(1, page.pageRequest().page());
+        assertEquals(1, page.pageRequest().pageNumber());
         assertTrue(page.hasContent());
         assertEquals(10, page.numberOfElements());
         try {
@@ -3319,7 +3319,7 @@ public class EntityTests {
             }
         }
 
-        assertEquals(3, page.pageRequest().page());
+        assertEquals(3, page.pageRequest().pageNumber());
         assertTrue(page.hasContent());
         assertEquals(10, page.numberOfElements());
         try {
@@ -3342,7 +3342,7 @@ public class EntityTests {
         PageRequest fourth10 = page.nextPageRequest();
         page = characters.findByNumericValueBetween(48, 90, fourth10, order); // 'N' to 'W'
 
-        assertEquals(4, page.pageRequest().page());
+        assertEquals(4, page.pageRequest().pageNumber());
         assertTrue(page.hasContent());
         assertEquals(10, page.numberOfElements());
         try {
@@ -3382,7 +3382,7 @@ public class EntityTests {
             }
         }
 
-        assertEquals(3, page.pageRequest().page());
+        assertEquals(3, page.pageRequest().pageNumber());
         assertEquals(5, page.numberOfElements());
 
         assertEquals(Arrays.toString(new Long[]{37L, 31L, 29L, 23L, 19L}),
@@ -3395,7 +3395,7 @@ public class EntityTests {
 
         page = numbers.findByNumTypeAndFloorOfSquareRootLessThanEqual(NumberType.PRIME, 8L, fourth5, sort);
 
-        assertEquals(4, page.pageRequest().page());
+        assertEquals(4, page.pageRequest().pageNumber());
         assertEquals(5, page.numberOfElements());
 
         assertEquals(Arrays.toString(new Long[]{17L, 13L, 11L, 7L, 5L}),

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/SortNullableTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/SortNullableTests.java
@@ -625,7 +625,7 @@ public class SortNullableTests {
                     "OZ",
                     Order.by(_Country.daylightTimeBegins.desc().nullsFirst(),
                              _Country.code.asc()),
-                    PageRequest.ofSize(25).page(2));
+                    PageRequest.ofSize(25).pageNumber(2));
         } catch (IllegalArgumentException x) {
             if (type.capableOfSortingNullsFirst()) {
                 throw x;


### PR DESCRIPTION
This PR starts with some of Gavin's updates from #1479 and pares down to a minimum the amount of API updates needed to accommodate a developer that wants to think about making PageRequests as a 0-based offset from the first page and defining Limits in terms of a 0-based offset from first result.

To achieve this, we really only need 2 methods.

`pageOffset(offset)` for `PageRequest`:
```java
page0Request = PageRequest.ofSize(10).pageOffset(0);
```

`limit.of(maxResults, offset)` for `Limit`:
```java
limitToFifthGroupOf10 = Limit.of(10, 40);
```
