### PR TITLE
Replace accidentally included non-ASCII char in test data

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/CountryPopulator.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/CountryPopulator.java
@@ -565,7 +565,7 @@ public class CountryPopulator implements Populator<Countries> {
                                null,
                                null,
                                true,
-                               City.of("Reykjavík", 133262)),
+                               City.of("Reykjavik", 133262)),
                     Country.of("IN", "India", ASIA,
                                2973193L, 1419316933L, 13173000000000L, 6125445000000L,
                                null,

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/ConstraintTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/ConstraintTests.java
@@ -827,7 +827,7 @@ public class ConstraintTests {
                             .sorted()
                             .collect(Collectors.toList());
             assertEquals(List.of("Niamey",
-                                 "Reykjavík"),
+                                 "Reykjavik"),
                          found);
         } catch (UnsupportedOperationException x) {
             if (type.capableOfConstraintsOnNonIdAttributes() &&


### PR DESCRIPTION
The test data for the Data 1.1 TCK was intended to only use ASCII characters to maximize compatibility with different data stores that might be used to run the TCK.  Somehow, one character wasn't detected and made it in. This PR switches that character to ASCII.