### PR TITLE
Subtle behavior change in metamodel with Sort.equals due to the addition of expressions

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/impl/TextAttributeRecord.java
+++ b/api/src/main/java/jakarta/data/metamodel/impl/TextAttributeRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024,2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024,2026 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
  */
 package jakarta.data.metamodel.impl;
 
+import jakarta.data.Sort;
 import jakarta.data.metamodel.TextAttribute;
 
 /**
@@ -28,4 +29,28 @@ import jakarta.data.metamodel.TextAttribute;
 @Deprecated(since = "1.1")
 public record TextAttributeRecord<T>(String name)
         implements TextAttribute<T> {
+
+    // The following overrides preserve the Data 1.0 behavior where
+    // static metamodels for different entities that have an identically named
+    // entity attribute can create Sort instances that are equal.
+
+    @Override
+    public Sort<T> asc() {
+        return Sort.asc(name);
+    }
+
+    @Override
+    public Sort<T> ascIgnoreCase() {
+        return Sort.ascIgnoreCase(name);
+    }
+
+    @Override
+    public Sort<T> desc() {
+        return Sort.desc(name);
+    }
+
+    @Override
+    public Sort<T> descIgnoreCase() {
+        return Sort.descIgnoreCase(name);
+    }
 }


### PR DESCRIPTION
The TCK caught a behavior change where it compares a Sort that has a String entity attribute name to a Sort obtained from the metamodel attribute,

```java
        assertEquals(Sort.ascIgnoreCase(_AsciiChar.HEXADECIMAL),
                     _AsciiChar.hexadecimal.ascIgnoreCase());
```

Previously, both of these were backed by String values and were equal.  However, the latter now also has an `expression` (in this case, `_AsciiChar.hexadecimal`) causing `.equals` to report false.  Similarly, `.hashCode` will now compute different values for the two Sort instances as well.

I would argue the new behavior is better because it means `_Product.name.asc()` will not equal `_Employee.name.asc()`.  However, in Data 1.0, the two were `.equals` because there was no `expression` component and the other components (property="name", isAscending=true, ignoreCase=false) all match.

With respect to `Sort` itself, there is no breaking change. `Sort.asc(_Product.NAME)` and `Sort.asc(_Employee.NAME)` are still `.equals`.  The new behavior only applies when an expression is added, which is new in 1.1.  The behavior change is really isolated to Sort obtained from `TextAttribute`.  I think we can address this by continuing to obtain Sort without an expression from `TextAttribute` when the deprecated [TextAttributeRecord](https://github.com/jakartaee/data/blob/2ef28b65e73ddeec9ff22d0435e5e1e335b4934a/api/src/main/java/jakarta/data/metamodel/impl/TextAttributeRecord.java#L29) is used, and defaulting to Sort backed by the TextAttribute as the expression when the [TextAttribute.of](https://github.com/jakartaee/data/blob/2ef28b65e73ddeec9ff22d0435e5e1e335b4934a/api/src/main/java/jakarta/data/metamodel/TextAttribute.java#L52) method that we introduced in Data 1.1 as the recommended approach is used.