### PR TITLE
Limitations on cursor-based pagination when sort criteria includes an expression

### DIFF
--- a/api/src/main/java/jakarta/data/page/CursoredPage.java
+++ b/api/src/main/java/jakarta/data/page/CursoredPage.java
@@ -162,6 +162,10 @@ public interface CursoredPage<T> extends Page<T> {
      *
      * @param index position (0 is first) of a result on the page.
      * @return cursor for key values at the specified position.
+     * @throws UnsupportedOperationException if the sort criteria includes an
+     *                                       {@linkplain Sort#expression()
+     *                                       expression} that is not an
+     *                                       entity attribute
      */
     PageRequest.Cursor cursor(int index);
 
@@ -189,6 +193,10 @@ public interface CursoredPage<T> extends Page<T> {
      *                                this exception, check for a {@code true}
      *                                result of {@link #hasNext()} before
      *                                invoking this method.
+     * @throws UnsupportedOperationException if the sort criteria includes an
+     *                                       {@linkplain Sort#expression()
+     *                                       expression} that is not an
+     *                                       entity attribute
      */
     @Override
     PageRequest nextPageRequest();
@@ -220,6 +228,10 @@ public interface CursoredPage<T> extends Page<T> {
      *                                {@code true} result of
      *                                {@link #hasPrevious()} before invoking
      *                                this method.
+     * @throws UnsupportedOperationException if the sort criteria includes an
+     *                                       {@linkplain Sort#expression()
+     *                                       expression} that is not an
+     *                                       entity attribute
      */
     @Override
     PageRequest previousPageRequest();

--- a/api/src/main/java/jakarta/data/page/impl/CursoredPageRecord.java
+++ b/api/src/main/java/jakarta/data/page/impl/CursoredPageRecord.java
@@ -32,7 +32,12 @@ import java.util.NoSuchElementException;
  * @param content             The page content, that is, the query results, in
  *                            order
  * @param cursors             A list of {@link PageRequest.Cursor} instances for
- *                            result, in order
+ *                            result, in order. An empty list indicates cursors
+ *                            cannot be computed, causing the following methods
+ *                            to raise {@link UnsupportedOperationException}:
+ *                            {@link #cursor(int)},
+ *                            {@link #nextPageRequest()},
+ *                            {@link #previousPageRequest()}
  * @param totalElements       The total number of elements across all pages that
  *                            can be requested for the query
  * @param pageRequest         The {@link PageRequest page request} for which
@@ -116,6 +121,9 @@ public record CursoredPageRecord<T>
 
     @Override
     public PageRequest nextPageRequest() {
+        if (cursors.isEmpty())
+            throw new UnsupportedOperationException(
+                    Messages.get("013.cursor.uncomputable"));
         if (nextPageRequest == null)
             throw new NoSuchElementException();
         return nextPageRequest;
@@ -123,6 +131,9 @@ public record CursoredPageRecord<T>
 
     @Override
     public PageRequest previousPageRequest() {
+        if (cursors.isEmpty())
+            throw new UnsupportedOperationException(
+                    Messages.get("013.cursor.uncomputable"));
         if (previousPageRequest == null)
             throw new NoSuchElementException();
         return previousPageRequest;
@@ -135,6 +146,9 @@ public record CursoredPageRecord<T>
 
     @Override
     public PageRequest.Cursor cursor(int index) {
+        if (cursors.isEmpty())
+            throw new UnsupportedOperationException(
+                    Messages.get("013.cursor.uncomputable"));
         return cursors.get(index);
     }
 

--- a/api/src/main/resources/jakarta/data/messages/DataMessages.properties
+++ b/api/src/main/resources/jakarta/data/messages/DataMessages.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2025 Contributors to the Eclipse Foundation
+# Copyright (c) 2025,2026 Contributors to the Eclipse Foundation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,3 +35,5 @@
  identify the entity class that declares the attribute. For static metamodel \
  classes, use an .of method that is defined on an Attribute subtype to supply \
  the entity class and entity attribute type.
+013.cursor.uncomputable=The requested operation is not available because a \
+ cursor cannot be computed from sort criteria that includes an expression.


### PR DESCRIPTION
When cursor-based pagination is used, the cursor is determined from the sort criteria. This is straightforward for sort criteria that consists of entity attributes. However, when the sort criteria includes more complex expressions, which is now possible, the computation of these expressions is not something the Data provider should be doing apart of the database.  This PR adds in language to allow 3 API methods that rely on computation of a cursor to raise an appropriate error if the sort criteria includes an expression rather than an entity attribute.