### PR TITLE
Add Jakarta Annotations security annotation support to spec and TCK

### DIFF
--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1430,8 +1430,9 @@ import java.util.Set;
  *
  * <h2>Jakarta Annotations</h2>
  *
- * <p>A repository interface or method of a repository interface may be annotated with a
- * security annotation defined in the {@code jakarta.annotation.security} package:
+ * <p>A repository interface or method of a repository interface may be
+ * annotated with one of the following annotations defined in the
+ * {@code jakarta.annotation.security} package:
  * {@code @DeclareRoles}, {@code @DenyAll}, {@code @PermitAll}, {@code @RolesAllowed},
  * or {@code @RunAs}.
  * In the Jakarta EE environment, or in any other environment where Jakarta Annotations
@@ -1440,12 +1441,6 @@ import java.util.Set;
  * as if it were placed directly on the repository implementation bean. The security
  * constraints declared by the annotation are enforced automatically by the Jakarta EE
  * container.</p>
- *
- * <p>The {@code jakarta.annotation.security} annotations are defined by the Jakarta
- * Annotations specification, but their processing semantics are defined by other
- * specifications such as Jakarta Enterprise Beans and Jakarta Servlet. Depending on
- * the Jakarta EE container, some of these annotations—in particular
- * {@code @DeclareRoles} and {@code @RunAs}—may not be supported on CDI beans.</p>
  */
 //TODO switch @code to @link for jakarta.persistence.query.* once it is determined
 // why Javadoc links to API from other Jakarta spec modules are not working

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1432,7 +1432,8 @@ import java.util.Set;
  *
  * <p>A repository interface or method of a repository interface may be annotated with a
  * security annotation defined in the {@code jakarta.annotation.security} package:
- * {@code @DenyAll}, {@code @PermitAll}, or {@code @RolesAllowed}.
+ * {@code @DeclareRoles}, {@code @DenyAll}, {@code @PermitAll}, {@code @RolesAllowed},
+ * or {@code @RunAs}.
  * In the Jakarta EE environment, or in any other environment where Jakarta Annotations
  * is available and integrated with Jakarta CDI, the security annotation is inherited
  * by the repository implementation. That is, the security annotation must be treated
@@ -1440,9 +1441,11 @@ import java.util.Set;
  * constraints declared by the annotation are enforced automatically by the Jakarta EE
  * container.</p>
  *
- * <p>The behavior of {@code @DeclareRoles} and {@code @RunAs} on a repository interface
- * is not defined by this specification, and is not portable between Jakarta Data
- * providers.</p>
+ * <p>The {@code jakarta.annotation.security} annotations are defined by the Jakarta
+ * Annotations specification, but their processing semantics are defined by other
+ * specifications such as Jakarta Enterprise Beans and Jakarta Servlet. Depending on
+ * the Jakarta EE container, some of these annotations—in particular
+ * {@code @DeclareRoles} and {@code @RunAs}—may not be supported on CDI beans.</p>
  */
 //TODO switch @code to @link for jakarta.persistence.query.* once it is determined
 // why Javadoc links to API from other Jakarta spec modules are not working

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1427,6 +1427,22 @@ import java.util.Set;
  *     CompletionStage<Integer> setPriceAsync(float newPrice, Long productId);
  * }
  * }</pre>
+ *
+ * <h2>Jakarta Annotations</h2>
+ *
+ * <p>A repository interface or method of a repository interface may be annotated with a
+ * security annotation defined in the {@code jakarta.annotation.security} package:
+ * {@code @DenyAll}, {@code @PermitAll}, or {@code @RolesAllowed}.
+ * In the Jakarta EE environment, or in any other environment where Jakarta Annotations
+ * is available and integrated with Jakarta CDI, the security annotation is inherited
+ * by the repository implementation. That is, the security annotation must be treated
+ * as if it were placed directly on the repository implementation bean. The security
+ * constraints declared by the annotation are enforced automatically by the Jakarta EE
+ * container.</p>
+ *
+ * <p>The behavior of {@code @DeclareRoles} and {@code @RunAs} on a repository interface
+ * is not defined by this specification, and is not portable between Jakarta Data
+ * providers.</p>
  */
 //TODO switch @code to @link for jakarta.persistence.query.* once it is determined
 // why Javadoc links to API from other Jakarta spec modules are not working

--- a/spec/src/main/asciidoc/jakarta-ee.adoc
+++ b/spec/src/main/asciidoc/jakarta-ee.adoc
@@ -221,10 +221,10 @@ public interface School extends DataRepository<Student, String> {
 
 === Jakarta Annotations
 
-A repository interface or method of a repository interface may be annotated with a security annotation defined in the `jakarta.annotation.security` package: `@DenyAll`, `@PermitAll`, or `@RolesAllowed`.footnote:[Jakarta Annotations 3.0, https://jakarta.ee/specifications/annotations/3.0/]
+A repository interface or method of a repository interface may be annotated with a security annotation defined in the `jakarta.annotation.security` package: `@DeclareRoles`, `@DenyAll`, `@PermitAll`, `@RolesAllowed`, or `@RunAs`.footnote:[Jakarta Annotations 3.0, https://jakarta.ee/specifications/annotations/3.0/]
 In the Jakarta EE environment--or in any other environment where Jakarta Annotations is available and integrated with Jakarta CDI--the security annotation is inherited by the repository implementation. That is, the security annotation must be treated as if it were placed directly on the repository implementation bean. The security constraints declared by the annotation are enforced automatically by the Jakarta EE container.
 
-NOTE: The behavior of `@DeclareRoles` and `@RunAs` on a repository interface is not defined by this specification, and is not portable between Jakarta Data providers.
+NOTE: The `jakarta.annotation.security` annotations are defined by the Jakarta Annotations specification, but their processing semantics are defined by other specifications such as Jakarta Enterprise Beans and Jakarta Servlet.footnote:[See also https://github.com/jakartaee/security/issues/295[Jakarta Security issue #295\].] Depending on the Jakarta EE container, some of these annotations--in particular `@DeclareRoles` and `@RunAs`--may not be supported on CDI beans.
 
 The following example illustrates how security annotations might be applied to a repository:
 

--- a/spec/src/main/asciidoc/jakarta-ee.adoc
+++ b/spec/src/main/asciidoc/jakarta-ee.adoc
@@ -221,7 +221,7 @@ public interface School extends DataRepository<Student, String> {
 
 === Jakarta Annotations
 
-A repository interface or method of a repository interface may be annotated with a security annotation defined in the `jakarta.annotation.security` package: `@DeclareRoles`, `@DenyAll`, `@PermitAll`, `@RolesAllowed`, or `@RunAs`.footnote:[Jakarta Annotations 3.0, https://jakarta.ee/specifications/annotations/3.0/]
+A repository interface or method of a repository interface may be annotated with one of the following annotations defined in the `jakarta.annotation.security` package: `@DeclareRoles`, `@DenyAll`, `@PermitAll`, `@RolesAllowed`, or `@RunAs`.footnote:[Jakarta Annotations 3.1, https://jakarta.ee/specifications/annotations/3.1/]
 In the Jakarta EE environment--or in any other environment where Jakarta Annotations is available and integrated with Jakarta CDI--the security annotation is inherited by the repository implementation. That is, the security annotation must be treated as if it were placed directly on the repository implementation bean. The security constraints declared by the annotation are enforced automatically by the Jakarta EE container.
 
 NOTE: The `jakarta.annotation.security` annotations are defined by the Jakarta Annotations specification, but their processing semantics are defined by other specifications such as Jakarta Enterprise Beans and Jakarta Servlet.footnote:[See also https://github.com/jakartaee/security/issues/295[Jakarta Security issue #295\].] Depending on the Jakarta EE container, some of these annotations--in particular `@DeclareRoles` and `@RunAs`--may not be supported on CDI beans.
@@ -238,8 +238,8 @@ public interface BookRepository {
     @PermitAll
     List<Book> findAll();
 
-    @Delete
+    @Insert
     @RolesAllowed({"manager", "admin"})
-    void delete(Book book);
+    void add(Book book);
 }
 ----

--- a/spec/src/main/asciidoc/jakarta-ee.adoc
+++ b/spec/src/main/asciidoc/jakarta-ee.adoc
@@ -218,3 +218,28 @@ public interface School extends DataRepository<Student, String> {
     List<Student> findByAgeLessThanEqual(@Min(18) int age);
 }
 ----
+
+=== Jakarta Annotations
+
+A repository interface or method of a repository interface may be annotated with a security annotation defined in the `jakarta.annotation.security` package: `@DenyAll`, `@PermitAll`, or `@RolesAllowed`.footnote:[Jakarta Annotations 3.0, https://jakarta.ee/specifications/annotations/3.0/]
+In the Jakarta EE environment--or in any other environment where Jakarta Annotations is available and integrated with Jakarta CDI--the security annotation is inherited by the repository implementation. That is, the security annotation must be treated as if it were placed directly on the repository implementation bean. The security constraints declared by the annotation are enforced automatically by the Jakarta EE container.
+
+NOTE: The behavior of `@DeclareRoles` and `@RunAs` on a repository interface is not defined by this specification, and is not portable between Jakarta Data providers.
+
+The following example illustrates how security annotations might be applied to a repository:
+
+[source,java]
+----
+@Repository
+@RolesAllowed("user")
+public interface BookRepository {
+
+    @Find
+    @PermitAll
+    List<Book> findAll();
+
+    @Delete
+    @RolesAllowed({"manager", "admin"})
+    void delete(Book book);
+}
+----

--- a/tck-dist/src/main/asciidoc/sections/05inventory.adoc
+++ b/tck-dist/src/main/asciidoc/sections/05inventory.adoc
@@ -76,3 +76,4 @@ EE Mode:
 - The {APILongName} API, Arquillian SPI, and JUnit5 libraries available to the `Test Client` | <<Test Client Dependencies>>
 - An Arquillian SPI implementation for your Application Server | <<Configure Arquillian>>
 - A logging configuration for TCK logging on `Test Client` and `Test Server` | <<Configure Client and Server Logging>>
+- A `TestSecurityContext` CDI bean for security annotation tests | <<Configure Security for Annotation Tests>>

--- a/tck-dist/src/main/asciidoc/sections/07.2ee-mode.adoc
+++ b/tck-dist/src/main/asciidoc/sections/07.2ee-mode.adoc
@@ -118,3 +118,24 @@ Example META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension:
 ----
 include::{starterLoc}/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension[]
 ----
+
+==== Configure Security for Annotation Tests
+
+The `@Web` tests in the `ee.jakarta.tck.data.web.annotations` package verify that security annotations
+(`@DenyAll`, `@PermitAll`, `@RolesAllowed`) on repository interfaces are enforced by the repository implementation.
+
+These tests require a CDI bean implementing `ee.jakarta.tck.data.framework.security.TestSecurityContext`.
+This interface defines two methods:
+
+- `setCallerRoles(String... roles)` -- configures the security roles for the current caller.
+- `clearCallerRoles()` -- removes all security roles from the current caller.
+
+The implementation is container-specific.
+For example, on a Jakarta EE server the implementation might programmatically update the caller's identity
+using the container's security SPI so that subsequent repository method calls are subject to the configured roles.
+
+To provide the implementation:
+
+1. Create a class implementing `TestSecurityContext` and annotate it as a CDI bean (e.g. `@ApplicationScoped`).
+2. Include the class in the test deployment. This can be done using an Arquillian `ApplicationArchiveProcessor`
+   as described in <<Advanced Arquillian Configuration>>.

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/security/TestSecurityContext.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/security/TestSecurityContext.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.framework.security;
+
+/**
+ * Contract for configuring the caller's security roles during TCK tests
+ * that verify security annotation behavior.
+ *
+ * <p>TCK runners must provide a CDI bean implementing this interface.
+ * The implementation determines how the configured roles are enforced
+ * when security-annotated repository methods are invoked.</p>
+ */
+public interface TestSecurityContext {
+
+    /**
+     * Set the security roles for the current caller.
+     */
+    void setCallerRoles(String... roles);
+
+    /**
+     * Clear the security roles for the current caller.
+     */
+    void clearCallerRoles();
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/web/annotations/AnnotationsSecurityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/web/annotations/AnnotationsSecurityTests.java
@@ -15,9 +15,10 @@
  */
 package ee.jakarta.tck.data.web.annotations;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
@@ -59,7 +60,7 @@ public class AnnotationsSecurityTests {
     TestSecurityContext securityContext;
 
     @AfterEach
-    public void clearSecurityContext() {
+    public void tearDown() {
         securityContext.clearCallerRoles();
     }
 
@@ -85,21 +86,34 @@ public class AnnotationsSecurityTests {
     @Assertion(id = "1293", strategy = """
             Verify that a repository method annotated with @RolesAllowed
             rejects access when the caller does not have a matching role.
+            The insert must be rejected, and findAll must confirm
+            that no product was added.
             """)
     public void testRolesAllowedRejectsWithoutMatchingRole() {
+        int before = products.findAll().size();
+
         securityContext.setCallerRoles("user");
         assertThrows(SecurityException.class,
-                     () -> products.remove(
-                             new SecuredProduct("P999", "any")));
+                     () -> products.add(
+                             new SecuredProduct("P999", "Gadget")));
+
+        securityContext.clearCallerRoles();
+        assertEquals(before, products.findAll().size());
     }
 
     @Assertion(id = "1293", strategy = """
             Verify that a repository method annotated with @RolesAllowed
             allows access when the caller has one of the required roles.
+            The insert must succeed, and findAll must confirm
+            that the product was added.
             """)
     public void testRolesAllowedAllowsWithMatchingRole() {
+        int before = products.findAll().size();
+
         securityContext.setCallerRoles("admin");
-        assertDoesNotThrow(() -> products.remove(
-                new SecuredProduct("P999", "any")));
+        products.add(new SecuredProduct("P888", "Gizmo"));
+
+        securityContext.clearCallerRoles();
+        assertTrue(products.findAll().size() > before);
     }
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/web/annotations/AnnotationsSecurityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/web/annotations/AnnotationsSecurityTests.java
@@ -30,6 +30,7 @@ import ee.jakarta.tck.data.framework.junit.anno.Assertion;
 import ee.jakarta.tck.data.framework.junit.anno.AnyEntity;
 import ee.jakarta.tck.data.framework.junit.anno.Web;
 import ee.jakarta.tck.data.framework.security.TestSecurityContext;
+import ee.jakarta.tck.data.framework.utilities.TestPropertyUtility;
 
 import jakarta.inject.Inject;
 
@@ -97,6 +98,8 @@ public class AnnotationsSecurityTests {
                      () -> products.add(
                              new SecuredProduct("P999", "Gadget")));
 
+        TestPropertyUtility.waitForEventualConsistency();
+
         securityContext.clearCallerRoles();
         assertEquals(before, products.findAll().size());
     }
@@ -113,7 +116,9 @@ public class AnnotationsSecurityTests {
         securityContext.setCallerRoles("admin");
         products.add(new SecuredProduct("P888", "Gizmo"));
 
+        TestPropertyUtility.waitForEventualConsistency();
+
         securityContext.clearCallerRoles();
-        assertTrue(products.findAll().size() > before);
+        assertEquals(before + 1, products.findAll().size());
     }
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/web/annotations/AnnotationsSecurityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/web/annotations/AnnotationsSecurityTests.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.web.annotations;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import ee.jakarta.tck.data.framework.junit.anno.Assertion;
+import ee.jakarta.tck.data.framework.junit.anno.AnyEntity;
+import ee.jakarta.tck.data.framework.junit.anno.Web;
+import ee.jakarta.tck.data.framework.security.TestSecurityContext;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.AfterEach;
+
+/**
+ * Tests that security annotations on repository interface methods
+ * are enforced by the repository implementation.
+ *
+ * <p>TCK runners must provide a CDI bean implementing
+ * {@link TestSecurityContext}.</p>
+ */
+@Web
+@AnyEntity
+public class AnnotationsSecurityTests {
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addClasses(SecuredProduct.class,
+                            SecuredProducts.class);
+    }
+
+    @Inject
+    SecuredProducts products;
+
+    @Inject
+    TestSecurityContext securityContext;
+
+    @AfterEach
+    public void clearSecurityContext() {
+        securityContext.clearCallerRoles();
+    }
+
+    @Assertion(id = "1293", strategy = """
+            Verify that a repository method annotated with @DenyAll
+            always rejects access by throwing a SecurityException.
+            """)
+    public void testDenyAllRejectsAccess() {
+        assertThrows(SecurityException.class,
+                     () -> products.findByProductId("P001"));
+    }
+
+    @Assertion(id = "1293", strategy = """
+            Verify that a repository method annotated with @PermitAll
+            allows access regardless of whether any security roles are set.
+            """)
+    public void testPermitAllAllowsAccessWithoutRoles() {
+        securityContext.clearCallerRoles();
+        List<SecuredProduct> result = products.findAll();
+        assertNotNull(result);
+    }
+
+    @Assertion(id = "1293", strategy = """
+            Verify that a repository method annotated with @RolesAllowed
+            rejects access when the caller does not have a matching role.
+            """)
+    public void testRolesAllowedRejectsWithoutMatchingRole() {
+        securityContext.setCallerRoles("user");
+        assertThrows(SecurityException.class,
+                     () -> products.remove(
+                             new SecuredProduct("P999", "any")));
+    }
+
+    @Assertion(id = "1293", strategy = """
+            Verify that a repository method annotated with @RolesAllowed
+            allows access when the caller has one of the required roles.
+            """)
+    public void testRolesAllowedAllowsWithMatchingRole() {
+        securityContext.setCallerRoles("admin");
+        assertDoesNotThrow(() -> products.remove(
+                new SecuredProduct("P999", "any")));
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/web/annotations/SecuredProduct.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/web/annotations/SecuredProduct.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.web.annotations;
+
+@jakarta.nosql.Entity
+@jakarta.persistence.Entity
+public class SecuredProduct {
+
+    @jakarta.nosql.Id
+    @jakarta.persistence.Id
+    public String productId;
+
+    @jakarta.nosql.Column
+    public String name;
+
+    public SecuredProduct() {
+    }
+
+    public SecuredProduct(String productId, String name) {
+        this.productId = productId;
+        this.name = name;
+    }
+}

--- a/tck/src/main/java/ee/jakarta/tck/data/web/annotations/SecuredProducts.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/web/annotations/SecuredProducts.java
@@ -20,8 +20,8 @@ import java.util.List;
 import jakarta.annotation.security.DenyAll;
 import jakarta.annotation.security.PermitAll;
 import jakarta.annotation.security.RolesAllowed;
-import jakarta.data.repository.Delete;
 import jakarta.data.repository.Find;
+import jakarta.data.repository.Insert;
 import jakarta.data.repository.Repository;
 
 @Repository
@@ -35,7 +35,7 @@ public interface SecuredProducts {
     @PermitAll
     List<SecuredProduct> findAll();
 
-    @Delete
+    @Insert
     @RolesAllowed({"manager", "admin"})
-    void remove(SecuredProduct product);
+    void add(SecuredProduct product);
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/web/annotations/SecuredProducts.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/web/annotations/SecuredProducts.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.data.web.annotations;
+
+import java.util.List;
+
+import jakarta.annotation.security.DenyAll;
+import jakarta.annotation.security.PermitAll;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.data.repository.Delete;
+import jakarta.data.repository.Find;
+import jakarta.data.repository.Repository;
+
+@Repository
+public interface SecuredProducts {
+
+    @Find
+    @DenyAll
+    SecuredProduct findByProductId(String productId);
+
+    @Find
+    @PermitAll
+    List<SecuredProduct> findAll();
+
+    @Delete
+    @RolesAllowed({"manager", "admin"})
+    void remove(SecuredProduct product);
+}


### PR DESCRIPTION
Specify that some security annotations from the `jakarta.annotation.security` package (`@DenyAll`,` @PermitAll`, `@RolesAllowed`) on repository interfaces must be treated as if placed directly on the repository implementation, analogously to interceptor bindings.

Add tests to the "web" TCK -- since that's the kind of environment where security annotations must be handled.
Note this involves a CDI bean implementing a custom `TestSecurityContext` interface, to let tests configure caller roles; I'm not entirely sure if we want to add that kind of requirement to the TCK, but I'm sure someone will let me know :)

* Fixes #1293