### PR TITLE
Fix cursors check when no results are present

### DIFF
--- a/api/src/main/java/jakarta/data/page/impl/CursoredPageRecord.java
+++ b/api/src/main/java/jakarta/data/page/impl/CursoredPageRecord.java
@@ -123,21 +123,21 @@ public record CursoredPageRecord<T>
 
     @Override
     public PageRequest nextPageRequest() {
+        if (nextPageRequest == null)
+            throw new NoSuchElementException();
         if (cursors.isEmpty())
             throw new UnsupportedOperationException(
                     Messages.get("015.cursor.uncomputable"));
-        if (nextPageRequest == null)
-            throw new NoSuchElementException();
         return nextPageRequest;
     }
 
     @Override
     public PageRequest previousPageRequest() {
+        if (previousPageRequest == null)
+            throw new NoSuchElementException();
         if (cursors.isEmpty())
             throw new UnsupportedOperationException(
                     Messages.get("015.cursor.uncomputable"));
-        if (previousPageRequest == null)
-            throw new NoSuchElementException();
         return previousPageRequest;
     }
 


### PR DESCRIPTION
When https://github.com/jakartaee/data/commit/66f5a7efdd66 introduced the new `UnsupportedOperationException`, it only checked that `cursors.isEmpty()` as a signal of uncomputable sort-criterias. Queries returning no results though will also produce no cursors in the first place, so this fix should restore the expected exception order (and the failing test reported in the issue).

* Fixes https://github.com/jakartaee/data/issues/1512