### PR TITLE
Review comments from tech writer on recently added messages

### DIFF
--- a/api/src/main/java/jakarta/data/Sort.java
+++ b/api/src/main/java/jakarta/data/Sort.java
@@ -218,15 +218,11 @@ public record Sort<T>(@Nullable ComparableExpression<T, ? extends Comparable<?>>
      * An expression to order by, or {@code null} if this {@code Sort}
      * instance was constructed without an expression.
      *
-     * @return The attribute name to order by, or {@code null} if this
+     * @return The expression to order by, or {@code null} if this
      *         {@code Sort} instance was constructed without an expression.
      */
-    @Nonnull
+    @Nullable
     public ComparableExpression<T, ? extends Comparable<?>> expression() {
-        if ( expression == null ) {
-            throw new IllegalStateException(
-                    Messages.get("013.no-expression"));
-        }
         return expression;
     }
 

--- a/api/src/main/resources/jakarta/data/messages/DataMessages.properties
+++ b/api/src/main/resources/jakarta/data/messages/DataMessages.properties
@@ -40,4 +40,3 @@
  and a {0} mode.
 015.cursor.uncomputable=The requested operation is not available because a \
  cursor cannot be computed from sort criteria that include an expression.
-013.no-expression=The instance is not backed by an Expression

--- a/api/src/main/resources/jakarta/data/messages/DataMessages.properties
+++ b/api/src/main/resources/jakarta/data/messages/DataMessages.properties
@@ -35,9 +35,9 @@
  identify the entity class that declares the attribute. For static metamodel \
  classes, use an .of method that is defined on an Attribute subtype to supply \
  the entity class and entity attribute type.
-013.arg.invalid=The {0} argument cannot be {1}
-014.mode.disallows.offset=A page cannot be requested to have an offset \
- and a mode of {0}
+013.arg.invalid=The {0} argument cannot have a value of {1}.
+014.mode.disallows.offset=A page request cannot include both an offset \
+ and a {0} mode.
 015.cursor.uncomputable=The requested operation is not available because a \
- cursor cannot be computed from sort criteria that includes an expression.
+ cursor cannot be computed from sort criteria that include an expression.
 013.no-expression=The instance is not backed by an Expression


### PR DESCRIPTION
When we pulled in the latest spec API to Open Liberty, one of our tech writers reviewed the recently added (013, 014, and 015) messages and recommended changes which I have copied to this PR.