### PR TITLE
Life cycle events do not enforce nonnull

### DIFF
--- a/api/src/main/java/jakarta/data/event/LifecycleEvent.java
+++ b/api/src/main/java/jakarta/data/event/LifecycleEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024,2026 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 package jakarta.data.event;
 
 import jakarta.annotation.Nonnull;
+import jakarta.data.messages.Messages;
 
 /**
  * <p>Abstract supertype of events relating to lifecycle methods.</p>
@@ -52,7 +53,15 @@ public abstract class LifecycleEvent<E> {
     @Nonnull
     private final E entity;
 
+    /**
+     * Abstract constructor for {@code LifeCycleEvent} that populates the
+     * {@link #entity() value}.
+     *
+     * @param entity entity instance
+     * @throws NullPointerException if the given entity is {@code null}
+     */
     public LifecycleEvent(@Nonnull E entity) {
+        Messages.requireNonNull(entity, "entity");
         this.entity = entity;
     }
 

--- a/api/src/main/java/jakarta/data/event/PostDeleteEvent.java
+++ b/api/src/main/java/jakarta/data/event/PostDeleteEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024,2026 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,12 @@ import jakarta.annotation.Nonnull;
  * @param <E> the entity type
  */
 public class PostDeleteEvent<E> extends LifecycleEvent<E> {
+    /**
+     * Constructs a {@code PostDeleteEvent} for the given {@code entity}.
+     *
+     * @param entity entity instance
+     * @throws NullPointerException if the given entity is {@code null}
+     */
     public PostDeleteEvent(@Nonnull E entity) {
         super(entity);
     }

--- a/api/src/main/java/jakarta/data/event/PostInsertEvent.java
+++ b/api/src/main/java/jakarta/data/event/PostInsertEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024,2026 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,12 @@ import jakarta.annotation.Nonnull;
  * @param <E> the entity type
  */
 public class PostInsertEvent<E> extends LifecycleEvent<E> {
+    /**
+     * Constructs a {@code PostInsertEvent} for the given {@code entity}.
+     *
+     * @param entity entity instance
+     * @throws NullPointerException if the given entity is {@code null}
+     */
     public PostInsertEvent(@Nonnull E entity) {
         super(entity);
     }

--- a/api/src/main/java/jakarta/data/event/PostUpdateEvent.java
+++ b/api/src/main/java/jakarta/data/event/PostUpdateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024,2026 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,12 @@ import jakarta.annotation.Nonnull;
  * @param <E> the entity type
  */
 public class PostUpdateEvent<E> extends LifecycleEvent<E> {
+    /**
+     * Constructs a {@code PostUpdateEvent} for the given {@code entity}.
+     *
+     * @param entity entity instance
+     * @throws NullPointerException if the given entity is {@code null}
+     */
     public PostUpdateEvent(@Nonnull E entity) {
         super(entity);
     }

--- a/api/src/main/java/jakarta/data/event/PostUpsertEvent.java
+++ b/api/src/main/java/jakarta/data/event/PostUpsertEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025,2026 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,12 @@ import jakarta.annotation.Nonnull;
  * @param <E> the entity type
  */
 public class PostUpsertEvent<E> extends LifecycleEvent<E> {
+    /**
+     * Constructs a {@code PostUpsertEvent} for the given {@code entity}.
+     *
+     * @param entity entity instance
+     * @throws NullPointerException if the given entity is {@code null}
+     */
     public PostUpsertEvent(@Nonnull E entity) {
         super(entity);
     }

--- a/api/src/main/java/jakarta/data/event/PreDeleteEvent.java
+++ b/api/src/main/java/jakarta/data/event/PreDeleteEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024,2026 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,12 @@ import jakarta.annotation.Nonnull;
  * @param <E> the entity type
  */
 public class PreDeleteEvent<E> extends LifecycleEvent<E> {
+    /**
+     * Constructs a {@code PreDeleteEvent} for the given {@code entity}.
+     *
+     * @param entity entity instance
+     * @throws NullPointerException if the given entity is {@code null}
+     */
     public PreDeleteEvent(@Nonnull E entity) {
         super(entity);
     }

--- a/api/src/main/java/jakarta/data/event/PreInsertEvent.java
+++ b/api/src/main/java/jakarta/data/event/PreInsertEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024,2026 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,12 @@ import jakarta.annotation.Nonnull;
  * @param <E> the entity type
  */
 public class PreInsertEvent<E> extends LifecycleEvent<E> {
+    /**
+     * Constructs a {@code PreInsertEvent} for the given {@code entity}.
+     *
+     * @param entity entity instance
+     * @throws NullPointerException if the given entity is {@code null}
+     */
     public PreInsertEvent(@Nonnull E entity) {
         super(entity);
     }

--- a/api/src/main/java/jakarta/data/event/PreUpdateEvent.java
+++ b/api/src/main/java/jakarta/data/event/PreUpdateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2024,2026 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,12 @@ import jakarta.annotation.Nonnull;
  * @param <E> the entity type
  */
 public class PreUpdateEvent<E> extends LifecycleEvent<E> {
+    /**
+     * Constructs a {@code PreUpdateEvent} for the given {@code entity}.
+     *
+     * @param entity entity instance
+     * @throws NullPointerException if the given entity is {@code null}
+     */
     public PreUpdateEvent(@Nonnull E entity) {
         super(entity);
     }

--- a/api/src/main/java/jakarta/data/event/PreUpsertEvent.java
+++ b/api/src/main/java/jakarta/data/event/PreUpsertEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025,2026 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,12 @@ import jakarta.annotation.Nonnull;
  * @param <E> the entity type
  */
 public class PreUpsertEvent<E> extends LifecycleEvent<E> {
+    /**
+     * Constructs a {@code PreUpsertEvent} for the given {@code entity}.
+     *
+     * @param entity entity instance
+     * @throws NullPointerException if the given entity is {@code null}
+     */
     public PreUpsertEvent(@Nonnull E entity) {
         super(entity);
     }


### PR DESCRIPTION
LifeCycleEvent is accepting a null entity value and returns the null value from `entity()` despite the NonNull annotations on both.  This PR adds enforcement to prevent a null entity value from being accepted.