### PR TITLE
Double insert in TCK test results in EntityExistsException

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/JakartaEventCustomRepositoryTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/JakartaEventCustomRepositoryTest.java
@@ -190,10 +190,6 @@ public class JakartaEventCustomRepositoryTest {
             var entities = List.of(first, second);
             repository.insert(entities);
             observer.reset();
-
-            // when
-            repository.insert(entities);
-            observer.reset();
             TestPropertyUtility.waitForEventualConsistency();
 
             // when


### PR DESCRIPTION
Found a TCK bug where repeated insert of the same entities results in EntityExistsException.  It looks like the insert of the entities was only intended to be done once.