### PR TITLE
Define how inherited attributes work in static metamodel

### DIFF
--- a/api/src/main/java/jakarta/data/metamodel/StaticMetamodel.java
+++ b/api/src/main/java/jakarta/data/metamodel/StaticMetamodel.java
@@ -32,9 +32,9 @@ import jakarta.data.restrict.Restriction;
  * Annotates a static metamodel class.
  *
  * <p>
- * A static metamodel class represents the declared attributes of an entity
- * class, an association (such as a Jakarta Persistence Embeddable class),
- * or a superclass of an entity or association. The static metamodel enables
+ * A static metamodel class holds a representation of the declared attributes of an entity
+ * class, an associated class (such as a Jakarta Persistence Embeddable class),
+ * or a superclass of an entity or associated class. The static metamodel enables
  * type-safe access to attribute names as well as an {@code *Attribute} object
  * from which is obtained {@link Expression}s, {@link Restriction}s, and
  * {@link Sort}s on the attribute. A metamodel class contains one or more

--- a/api/src/main/java/jakarta/data/metamodel/StaticMetamodel.java
+++ b/api/src/main/java/jakarta/data/metamodel/StaticMetamodel.java
@@ -25,48 +25,71 @@ import java.lang.annotation.Target;
 import java.util.UUID;
 
 import jakarta.data.Sort;
+import jakarta.data.expression.Expression;
+import jakarta.data.restrict.Restriction;
 
 /**
- * <p>Annotates a class which serves as a static metamodel for an entity,
- * enabling
- * type-safe access to entity attribute names and related objects such as
- * instances of {@link Sort}s for an attribute. A metamodel class contains one
- * or more {@code public static} fields corresponding to attributes of the
- * entity class. The type of each of these fields must be either {@link String},
- * {@link Attribute}, or a subinterface of {@code Attribute} defined in this
- * package.</p>
+ * Annotates a static metamodel class.
  *
- * <p>The following subinterfaces of {@code Attribute} are recommended to
- * obtain
- * the full benefit of the static metamodel:</p>
+ * <p>
+ * A static metamodel class represents the declared attributes of an entity
+ * class, an association (such as a Jakarta Persistence Embeddable class),
+ * or a superclass of an entity or association. The static metamodel enables
+ * type-safe access to attribute names as well as an {@code *Attribute} object
+ * from which is obtained {@link Expression}s, {@link Restriction}s, and
+ * {@link Sort}s on the attribute. A metamodel class contains one or more
+ * {@code public static} fields, all corresponding to attributes declared by
+ * the class. The type of each of these fields must be either {@link String}
+ * (for attribute names) or the most specific subinterface of {@link Attribute}
+ * defined in this package or by vendor API.
+ *
+ * <p>Jakarta Data static metamodel classes must follow the entity model for
+ * the respective entity (usually Jakarta Persistence or Jakarta NoSQL)
+ * regarding what is and is not an attribute.
+ *
+ * <p>Some entity models allow inheritance of attributes from a superclass.
+ * For example, Jakarta Persistence entity classes inherit attributes of a
+ * superclass annotated {@link jakarta.persistence.MappedSuperclass}
+ * (from the Jakarta Persistence API) and Jakarta NoSQL entity classes
+ * inherit superclass attributes that have a Jakarta NoSQL annotation.
+ * In cases where attributes are inherited, the static metamodel class for
+ * the entity or association does not include fields for the inherited
+ * attributes, but instead inherits the fields by inheriting a static
+ * metamodel class for the superclass.
+ *
+ * <p>The following subinterfaces of {@code Attribute} are provided to
+ * obtain the full benefit of the static metamodel:
  * <ul>
- * <li>{@link TextAttribute} for entity attributes that represent text,
+ * <li>{@link TextAttribute} for attributes that represent text,
  *     typically of type {@link String}.</li>
- * <li>{@link NumericAttribute} for entity attributes of numeric types, such as
+ * <li>{@link NumericAttribute} for attributes of numeric types, such as
  *     {@code int}, {@link Double}, and {@link java.math.BigInteger}.</li>
- * <li>{@link BooleanAttribute} for entity attributes that represent
+ * <li>{@link BooleanAttribute} for attributes that represent
  *     {@code true} or {@code false} values of type {@code boolean} or
  *     {@link Boolean}.</li>
- * <li>{@link TemporalAttribute} for entity attributes of temporal types, such as
+ * <li>{@link TemporalAttribute} for attributes of temporal types, such as
  *     {@link java.time.LocalDate}, {@link java.time.LocalTime}, and
  *     {@link java.time.Instant}.</li>
- * <li>{@link ComparableAttribute} for entity attributes that represent other
+ * <li>{@link ComparableAttribute} for attributes that represent other
  *     sortable and comparable values, such as {@code char}, enumerations,
  *     and {@link UUID}</li>
- * <li>{@link NavigableAttribute} for entity attributes that are embeddables
- *     or relations.</li>
- * <li>{@link BasicAttribute} for other types of entity attributes, such as
+ * <li>{@link NavigableAttribute} for attributes that are associations,
+ *     such as Jakarta Persistence embeddables.</li>
+ * <li>{@link BasicAttribute} for other types of attributes, such as
  *     collections.</li>
  * </ul>
  *
- * <p>Jakarta Data defines the following conventions for static metamodel classes:</p>
+ * <p>Jakarta Data defines the following conventions for static metamodel
+ * classes:
  * <ul>
  * <li>The metamodel class can be an interface or concrete class.</li>
- * <li>The name of the static metamodel class should consist of underscore ({@code _})
- *     followed by the entity class name.</li>
+ * <li>The name of the static metamodel class should consist of underscore
+ *     ({@code _}) followed by the name of the modeled class.</li>
+ * <li>Static metamodel classes should have the same package as the modeled
+ *     class.</li>
  * <li>Fields of type {@code String} should be named with all upper case.</li>
- * <li>Fields that are subtypes of {@code Attribute} should be named in lower case
- *     or mixed case.</li>
+ * <li>Fields that are subtypes of {@code Attribute} should be named in lower
+ *     case or mixed case, matching the name of the modeled attribute.</li>
  * </ul>
  *
  * <p>For example, for the following entity,</p>

--- a/api/src/main/java/jakarta/data/metamodel/StaticMetamodel.java
+++ b/api/src/main/java/jakarta/data/metamodel/StaticMetamodel.java
@@ -83,8 +83,8 @@ import jakarta.data.restrict.Restriction;
  * classes:
  * <ul>
  * <li>The metamodel class can be an interface or concrete class.</li>
- * <li>The name of the static metamodel class should consist of underscore
- *     ({@code _}) followed by the name of the modeled class.</li>
+ * <li>The name of the static metamodel class is formed by prefixing
+ *     the name of the modeled class with an underscore ({@code _}).</li>
  * <li>Static metamodel classes should have the same package as the modeled
  *     class.</li>
  * <li>Fields of type {@code String} should be named with all upper case.</li>

--- a/api/src/main/java/jakarta/data/metamodel/StaticMetamodel.java
+++ b/api/src/main/java/jakarta/data/metamodel/StaticMetamodel.java
@@ -35,7 +35,7 @@ import jakarta.data.restrict.Restriction;
  * A static metamodel class holds a representation of the declared attributes of an entity
  * class, an associated class (such as a Jakarta Persistence Embeddable class),
  * or a superclass of an entity or associated class. The static metamodel enables
- * type-safe access to attribute names as well as an {@code *Attribute} object
+ * type-safe access to attribute names as well as an {@code Attribute} subclass
  * from which is obtained {@link Expression}s, {@link Restriction}s, and
  * {@link Sort}s on the attribute. A metamodel class contains one or more
  * {@code public static} fields, all corresponding to attributes declared by

--- a/spec/src/main/asciidoc/entity.asciidoc
+++ b/spec/src/main/asciidoc/entity.asciidoc
@@ -382,12 +382,14 @@ NOTE: Application programmers are strongly encouraged to follow Java's camel cas
 
 Jakarta Data provides a static metamodel that allows entity attributes to be accessed by applications in a type-safe manner.
 
-For each entity class, the application developer or a compile-time annotation processor can define a corresponding metamodel class following a prescribed set of conventions.
+A static metamodel class represents the declared attributes of an entity class, an association (such as a Jakarta Persistence embeddable class), or a superclass of an entity or association.
+For each such class, the application developer or a compile-time annotation processor can define a corresponding metamodel class following a prescribed set of conventions.
 
 - The metamodel class can be an interface or concrete class.
-- The metamodel class must be annotated with `@StaticMetamodel`, specifying the entity class as its `value`.
-- The metamodel class contains one or more `public static` fields corresponding to persistent attributes of the entity class.
+- The metamodel class must be annotated with `@StaticMetamodel`, specifying the modeled class as its `value`.
+- The metamodel class contains one or more `public static` fields corresponding to persistent attributes declared by the modeled class.
 - Each field must be either of type `java.lang.String` (used primarily for annotation-based configurations) or `jakarta.data.metamodel.Attribute`, including any of its subinterfaces.
+- The metamodel class does not include fields for inherited attributes, but instead inherits the fields by inheriting a static metamodel class for the superclass.
 
 The application can use the field values of the metamodel class to obtain artifacts relating to the entity attribute in a type-safe manner, for example, `_Book.title.asc()` or `Sort.asc(_Book.title.name())` or `Sort.asc(_Book.TITLE)` rather than `Sort.asc("title")`.
 
@@ -416,7 +418,8 @@ The fields may be statically initialized, or they may be initialized by the prov
 
 The following are conventions for static metamodel classes:
 
-- The name of the static metamodel class should consist of underscore (`_`) followed by the entity class name.
+- The name of the static metamodel class should consist of underscore (`_`) followed by the name of the modeled class.
+- Static metamodel classes should have the same package as the modeled class.
 - Fields of type `String` should be named with all upper case.
 - Fields of type `Attribute` (or a subinterface of `Attribute`) should be named in lower case or mixed case.
 - Uninitialized fields should have modifiers `public`, `static`, and `volatile`.
@@ -425,12 +428,12 @@ The following are conventions for static metamodel classes:
 
 The following subinterfaces of `Attribute` are recommended to obtain the full benefit of the static metamodel:
 
-- `TextAttribute` for entity attributes that represent text, typically of type `String`.
-- `NumericAttribute` for entity attributes of numeric types, such as `long`, `Integer`, and `BigDecimal`.
-- `TemporalAttribute` for entity attributes of temporal types, such as `LocalDateTime`, and `Instant`.
-- `ComparableAttribute` for entity attributes that represent other comparable values, such as `boolean` and enumerations.
-- `NavigableAttribute` for entity attributes that are embeddables or associations.
-- `BasicAttribute` for other types of entity attributes, such as collections.
+- `TextAttribute` for attributes that represent text, typically of type `String`.
+- `NumericAttribute` for attributes of numeric types, such as `long`, `Integer`, and `BigDecimal`.
+- `BooleanAttribute` for attributes that represent `true` or `false` values of type `boolean` or `Boolean`.
+- `ComparableAttribute` for attributes that represent other comparable values, such as `char`, enumerations, and `UUID`.
+- `NavigableAttribute` for attributes that are associations, such as Jakarta Persistence embeddables.
+- `BasicAttribute` for other types of attributes, such as collections.
 
 To assist developers in selecting the appropriate subinterface of `Attribute` when declaring static metamodel fields, the following table maps common Java types to the corresponding attribute interface. While multiple Java types may be compatible with the same subinterface, this guidance ensures consistent and type-safe usage across different entity models.
 

--- a/spec/src/main/asciidoc/entity.asciidoc
+++ b/spec/src/main/asciidoc/entity.asciidoc
@@ -382,7 +382,7 @@ NOTE: Application programmers are strongly encouraged to follow Java's camel cas
 
 Jakarta Data provides a static metamodel that allows entity attributes to be accessed by applications in a type-safe manner.
 
-A static metamodel class represents the declared attributes of an entity class, an association (such as a Jakarta Persistence embeddable class), or a superclass of an entity or association.
+A static metamodel class holds a representation of the declared attributes of an entity class, an associated class (such as a Jakarta Persistence embeddable class), or a superclass of an entity or associated class.
 For each such class, the application developer or a compile-time annotation processor can define a corresponding metamodel class following a prescribed set of conventions.
 
 - The metamodel class can be an interface or concrete class.

--- a/spec/src/main/asciidoc/entity.asciidoc
+++ b/spec/src/main/asciidoc/entity.asciidoc
@@ -418,7 +418,7 @@ The fields may be statically initialized, or they may be initialized by the prov
 
 The following are conventions for static metamodel classes:
 
-- The name of the static metamodel class is formed by prefising the name of the modeled class with an underscore (`_`).
+- The name of the static metamodel class is formed by prefixing the name of the modeled class with an underscore (`_`).
 - Static metamodel classes should have the same package as the modeled class.
 - Fields of type `String` should be named with all upper case.
 - Fields of type `Attribute` (or a subinterface of `Attribute`) should be named in lower case or mixed case.

--- a/spec/src/main/asciidoc/entity.asciidoc
+++ b/spec/src/main/asciidoc/entity.asciidoc
@@ -418,7 +418,7 @@ The fields may be statically initialized, or they may be initialized by the prov
 
 The following are conventions for static metamodel classes:
 
-- The name of the static metamodel class should consist of underscore (`_`) followed by the name of the modeled class.
+- The name of the static metamodel class is formed by prefising the name of the modeled class with an underscore (`_`).
 - Static metamodel classes should have the same package as the modeled class.
 - Fields of type `String` should be named with all upper case.
 - Fields of type `Attribute` (or a subinterface of `Attribute`) should be named in lower case or mixed case.

--- a/spec/src/main/asciidoc/entity.asciidoc
+++ b/spec/src/main/asciidoc/entity.asciidoc
@@ -431,6 +431,7 @@ The following subinterfaces of `Attribute` are recommended to obtain the full be
 - `TextAttribute` for attributes that represent text, typically of type `String`.
 - `NumericAttribute` for attributes of numeric types, such as `long`, `Integer`, and `BigDecimal`.
 - `BooleanAttribute` for attributes that represent `true` or `false` values of type `boolean` or `Boolean`.
+- `TemporalAttribute` for attributes of temporal types, such as `LocalDateTime`, and `Instant`.
 - `ComparableAttribute` for attributes that represent other comparable values, such as `char`, enumerations, and `UUID`.
 - `NavigableAttribute` for attributes that are associations, such as Jakarta Persistence embeddables.
 - `BasicAttribute` for other types of attributes, such as collections.


### PR DESCRIPTION
The spec should indicate how static metamodel classes are generated when some attributes are inherited from a superclass rather than being declared directly on the entity/embeddable class.
