### PR TITLE
refactor: standardize api/spec/tck-dist documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,7 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build project
-      run: |
-        mvn -B \
-        --file pom.xml \
-        clean package
+      run: mvn -B --file pom.xml clean package
 
   # Catch dependency issues in the tck-dist starters
   analyze:

--- a/.github/workflows/specification.yml
+++ b/.github/workflows/specification.yml
@@ -5,10 +5,6 @@ name: Generate specification documentation
 
 on: 
     workflow_dispatch:
-        inputs:
-            specVersion:
-                description: 'Major and Minor level of release. Example: 1.0'
-                required: true
 
 jobs:
   generate:
@@ -25,18 +21,28 @@ jobs:
         cache: maven
     - name: Generate specification docs
       run: |
-        mvn package --file api/pom.xml -Dspec.version=${{ github.event.inputs.specVersion }}
-        mvn package --file spec/pom.xml -Drevremark=FINAL -Dspec.version=${{ github.event.inputs.specVersion }}
+        mvn package --file api/pom.xml
+        mvn package --file stateful/pom.xml
+        mvn package --file spec/pom.xml
     - name: Assemble documentation
       run: |
         mkdir documentation/
-        cp spec/target/generated-docs/jakarta-data-${{ github.event.inputs.specVersion }}.pdf   documentation/jakarta-data-${{ github.event.inputs.specVersion }}.pdf
-        cp spec/target/generated-docs/jakarta-method-name-query-${{ github.event.inputs.specVersion }}.pdf   documentation/jakarta-method-name-query-${{ github.event.inputs.specVersion }}.pdf
 
-        cp spec/target/generated-docs/jakarta-data-${{ github.event.inputs.specVersion }}.html  documentation/jakarta-data-${{ github.event.inputs.specVersion }}.html
-        cp spec/target/generated-docs/jakarta-method-name-query-${{ github.event.inputs.specVersion }}.html  documentation/jakarta-method-name-query-${{ github.event.inputs.specVersion }}.html
+        cp spec/target/generated-docs/jakarta-data.pdf \
+          documentation/jakarta-data.pdf
+        cp spec/target/generated-docs/jakarta-method-name-query.pdf \
+           documentation/jakarta-method-name-query.pdf
 
-        cp -r api/target/reports/apidocs/ documentation/apidocs
+        cp spec/target/generated-docs/jakarta-data.html \
+           documentation/jakarta-data.html
+        cp spec/target/generated-docs/jakarta-method-name-query.html \
+           documentation/jakarta-method-name-query.html
+
+        cp -r api/target/reports/apidocs/ \ 
+              documentation/api/apidocs
+        
+        cp -r stateful/target/reports/apidocs/ \ 
+              documentation/stateful/apidocs
     - name: Upload documentation
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -33,10 +33,6 @@
     <name>Jakarta Data Core API</name>
     <description>Jakarta Data :: Core API</description>
 
-    <properties>
-        <assertj.version>3.27.7</assertj.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -51,38 +47,32 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
-            <version>${jakarta.annotation.version}</version>
             <scope>provided</scope>
         </dependency>
         <!-- For Javadoc references only: -->
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
-            <version>${jakarta.enterprise.cdi.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
-            <version>${jakarta.inject.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
-            <version>${jakarta.persistence.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.transaction</groupId>
             <artifactId>jakarta.transaction-api</artifactId>
-            <version>${jakarta.transaction.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -231,7 +221,6 @@ Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>${maven.javadoc.plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
@@ -240,7 +229,8 @@ Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">
                                 </goals>
                                 <configuration>
                                     <links>
-                                        <link>https://jakarta.ee/specifications/persistence/4.0/apidocs/</link>
+                                        <link>
+                                            https://jakarta.ee/specifications/persistence/4.0/apidocs/</link>
                                     </links>
                                     <tags>
                                         <tag>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -35,9 +35,6 @@
 
     <properties>
         <assertj.version>3.27.7</assertj.version>
-        <!-- default is the same for backward compatibility reason
-        Easy to override when building with a system property -->
-        <spec.version>1.1</spec.version>
     </properties>
 
     <dependencies>
@@ -260,5 +257,4 @@ Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">
             </build>
         </profile>
     </profiles>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,9 @@
         <sonar.maven.version>5.7.0.6970</sonar.maven.version>
 
         <nexus.staging.repository>data-maven2-staging</nexus.staging.repository>
+
+        <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
+        <revisiondate>${maven.build.timestamp}</revisiondate>
         
         <!-- Allow TCK populator classes to exceed max MethodLength -->
         <!-- Allow static metamodel constants -->

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <developerConnection>scm:git:ssh://github.com:jakartaee/data.git</developerConnection>
         <url>https://github.com/jakartaee/data</url>
     </scm>
-    
+
     <issueManagement>
         <system>GitHub</system>
         <url>https://github.com/jakartaee/data/issues</url>
@@ -84,19 +84,19 @@
         <maven.pmd.plugin.version>3.28.0</maven.pmd.plugin.version>
         <maven.bundle.plugin.version>6.1.0</maven.bundle.plugin.version>
         <maven.jar.plugin.version>3.5.1</maven.jar.plugin.version>
-        
+
         <lifecycle.mapping.version>1.0.0</lifecycle.mapping.version>
 
         <jakarta.annotation.version>3.0.0</jakarta.annotation.version>
         <jakarta.concurrency.version>3.1.1</jakarta.concurrency.version>
-        <jakarta.enterprise.cdi.version>4.1.0</jakarta.enterprise.cdi.version>   
-        <jakarta.inject.version>2.0.1</jakarta.inject.version>     
+        <jakarta.enterprise.cdi.version>4.1.0</jakarta.enterprise.cdi.version>
+        <jakarta.inject.version>2.0.1</jakarta.inject.version>
         <jakarta.json.bind.version>3.0.0</jakarta.json.bind.version>
         <jakarta.json.version>2.1.3</jakarta.json.version>
         <jakarta.data.version>${project.version}</jakarta.data.version>
         <jakarta.persistence.version>4.0.0-M6</jakarta.persistence.version>
         <jakarta.nosql.version>1.0.1</jakarta.nosql.version>
-        <jakarta.servlet.version>6.1.0</jakarta.servlet.version> 
+        <jakarta.servlet.version>6.1.0</jakarta.servlet.version>
         <jakarta.transaction.version>2.0.1</jakarta.transaction.version>
         <jakarta.validation.version>3.1.1</jakarta.validation.version>
 
@@ -105,19 +105,19 @@
         <arquillian.version>1.10.2.Final</arquillian.version>
         <arquillian.jakarta.version>10.0.0.Final</arquillian.jakarta.version>
         <shrinkwrap.version>1.2.6</shrinkwrap.version>
-        <shrinkwrap.resolver.version>3.3.7</shrinkwrap.resolver.version>
-        
+
         <exec.maven.plugin.version>3.6.3</exec.maven.plugin.version>
         <checkstyle.version>12.3.1</checkstyle.version>
         <jacoco.maven.version>0.8.15</jacoco.maven.version>
-        
+
         <junit.version>6.1.3</junit.version>
-        
+        <assertj.version>3.27.7</assertj.version>
+
         <pi.test.version>1.25.9</pi.test.version>
         <pitest.junit5.plugin.version>1.2.3</pitest.junit5.plugin.version>
-        
+
         <sigtest.version>2.7</sigtest.version>
-        
+
         <sonar.jacoco.reportPath>../target/jacoco.exec</sonar.jacoco.reportPath>
         <sonar.maven.version>5.7.0.6970</sonar.maven.version>
 
@@ -160,11 +160,59 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>org.jboss.shrinkwrap.resolver</groupId>
-                <artifactId>shrinkwrap-resolver-bom</artifactId>
-                <version>${shrinkwrap.resolver.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.annotation</groupId>
+                <artifactId>jakarta.annotation-api</artifactId>
+                <version>${jakarta.annotation.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.enterprise.concurrent</groupId>
+                <artifactId>jakarta.enterprise.concurrent-api</artifactId>
+                <version>${jakarta.concurrency.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>${jakarta.enterprise.cdi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.inject</groupId>
+                <artifactId>jakarta.inject-api</artifactId>
+                <version>${jakarta.inject.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.nosql</groupId>
+                <artifactId>jakarta.nosql-api</artifactId>
+                <version>${jakarta.nosql.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.persistence</groupId>
+                <artifactId>jakarta.persistence-api</artifactId>
+                <version>${jakarta.persistence.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>${jakarta.servlet.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.tck</groupId>
+                <artifactId>sigtest-maven-plugin</artifactId>
+                <version>${sigtest.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.transaction</groupId>
+                <artifactId>jakarta.transaction-api</artifactId>
+                <version>${jakarta.transaction.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.validation</groupId>
+                <artifactId>jakarta.validation-api</artifactId>
+                <version>${jakarta.validation.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -183,7 +231,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.5.0</version> <!-- Use the latest stable version -->
+                <version>${build.helper.maven.plugin.version}</version>
                 <executions>
                     
                     <!-- 1. Parse spec.version (Takes the first two parts, e.g., 3.0 from 3.0.0-SNAPSHOT) -->

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <build.helper.maven.plugin.version>3.6.0</build.helper.maven.plugin.version>
         <maven.antrun.plugin.version>3.2.0</maven.antrun.plugin.version>
         <maven.compile.version>3.15.0</maven.compile.version>
         <maven.dependency.plugin.version>3.11.0</maven.dependency.plugin.version>
@@ -179,6 +180,80 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.5.0</version> <!-- Use the latest stable version -->
+                <executions>
+                    
+                    <!-- 1. Parse spec.version (Takes the first two parts, e.g., 3.0 from 3.0.0-SNAPSHOT) -->
+                    <execution>
+                        <id>parse-spec-version</id>
+                        <goals>
+                            <goal>regex-property</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <name>spec.version</name>
+                            <value>${project.version}</value>
+                            <!-- Matches major.minor and captures it -->
+                            <regex>^([0-9]+\.[0-9]+)\..*</regex>
+                            <replacement>$1</replacement>
+                            <failIfNoMatch>true</failIfNoMatch>
+                        </configuration>
+                    </execution>
+
+                    <!-- 2. Parse minor.version (Takes the third digit, e.g., 1 from 3.0.1-M1) -->
+                    <execution>
+                        <id>parse-minor-version</id>
+                        <goals>
+                            <goal>regex-property</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <name>minor.version</name>
+                            <value>${project.version}</value>
+                            <!-- Skips major.minor, captures the incremental digit, ignores suffixes -->
+                            <regex>^[0-9]+\.[0-9]+\.([0-9]+).*</regex>
+                            <replacement>$1</replacement>
+                            <failIfNoMatch>true</failIfNoMatch>
+                        </configuration>
+                    </execution>
+
+                    <!-- 3. Parse doc.mark for DRAFT versions (-SNAPSHOT, -M*, -RC*) -->
+                    <execution>
+                        <id>parse-doc-mark-draft</id>
+                        <goals>
+                            <goal>regex-property</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <name>doc.mark</name>
+                            <value>${project.version}</value>
+                            <!-- Matches if version contains -SNAPSHOT, -M, or -RC -->
+                            <regex>.*-(SNAPSHOT|M[0-9]+|RC[0-9]+).*</regex>
+                            <replacement>DRAFT</replacement>
+                            <failIfNoMatch>false</failIfNoMatch>
+                        </configuration>
+                    </execution>
+
+                    <!-- 4. Parse doc.mark for FINAL versions (Fallback if no DRAFT suffix matches) -->
+                    <execution>
+                        <id>parse-doc-mark-final</id>
+                        <goals>
+                            <goal>regex-property</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <name>doc.mark</name>
+                            <value>${doc.mark}</value>
+                            <regex>^(?!DRAFT$).*$</regex>
+                            <replacement>FINAL</replacement>
+                            <failIfNoMatch>false</failIfNoMatch>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -35,8 +35,6 @@
         <asciidoctorj-pdf.version>2.3.23</asciidoctorj-pdf.version>
         <asciidoctorj.diagram.version>3.2.1</asciidoctorj.diagram.version>
 
-        <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
-        <revisiondate>${maven.build.timestamp}</revisiondate>
         <gen-doc-dir>${project.build.directory}/generated-docs</gen-doc-dir>
     </properties>
 
@@ -69,7 +67,7 @@
                         <configuration>
                             <sourceDocumentName>jakarta-data.adoc</sourceDocumentName>
                             <backend>pdf</backend>
-                            <outputFile>${gen-doc-dir}/jakarta-data-${spec.version}.pdf</outputFile>
+                            <outputFile>${gen-doc-dir}/jakarta-data.pdf</outputFile>
                         </configuration>
                     </execution>
                     <execution>
@@ -81,7 +79,7 @@
                         <configuration>
                             <sourceDocumentName>method-query.asciidoc</sourceDocumentName>
                             <backend>pdf</backend>
-                            <outputFile>${gen-doc-dir}/jakarta-method-name-query-${spec.version}.pdf</outputFile>
+                            <outputFile>${gen-doc-dir}/jakarta-method-name-query.pdf</outputFile>
                         </configuration>
                     </execution>
                     <execution>
@@ -93,7 +91,7 @@
                         <configuration>
                             <sourceDocumentName>jakarta-data.adoc</sourceDocumentName>
                             <backend>html5</backend>
-                            <outputFile>${gen-doc-dir}/jakarta-data-${spec.version}.html</outputFile>
+                            <outputFile>${gen-doc-dir}/jakarta-data.html</outputFile>
                         </configuration>
                     </execution>
                     <execution>
@@ -105,7 +103,7 @@
                         <configuration>
                             <sourceDocumentName>method-query.asciidoc</sourceDocumentName>
                             <backend>html5</backend>
-                            <outputFile>${gen-doc-dir}/jakarta-method-name-query-${spec.version}.html</outputFile>
+                            <outputFile>${gen-doc-dir}/jakarta-method-name-query.html</outputFile>
                             <attributes>
                                 <doctitle>Jakarta Data: Query by Method Name Extension</doctitle>
                             </attributes>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -37,12 +37,7 @@
 
         <maven.build.timestamp.format>MMMM dd, yyyy</maven.build.timestamp.format>
         <revisiondate>${maven.build.timestamp}</revisiondate>
-        <revremark>Draft</revremark>
         <gen-doc-dir>${project.build.directory}/generated-docs</gen-doc-dir>
-
-        <!-- default is the same for backward compatibility reason
-        Easy to override when building with a system property -->
-        <spec.version>${parsedVersion.majorVersion}.${parsedVersion.minorVersion}</spec.version>
     </properties>
 
     <build>
@@ -127,25 +122,12 @@
                         <license>Apache License v2.0</license>
                         <specification>Jakarta Data</specification>
                         <revnumber>${spec.version}</revnumber>
-                        <revremark>${revremark}</revremark>
+                        <revremark>${doc.mark}</revremark>
                         <revdate>${revisiondate}</revdate>
                         <sourceHighlighter>coderay</sourceHighlighter>
                         <doctitle>Jakarta Data</doctitle>
                     </attributes>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.6.1</version>
-                <executions>
-                    <execution>
-                        <id>parse-version</id>
-                        <goals>
-                            <goal>parse-version</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
         <pluginManagement>

--- a/stateful/pom.xml
+++ b/stateful/pom.xml
@@ -31,10 +31,6 @@
     <name>Jakarta Data Stateful Repository API</name>
     <description>Jakarta Data :: Stateful Repository API</description>
 
-    <properties>
-        <assertj.version>3.27.7</assertj.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -54,13 +50,11 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
-            <version>${jakarta.annotation.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -70,7 +64,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.15.0</version>
+                <version>${maven.compile.version}</version>
                 <configuration>
                     <compilerArgs>
                         <arg>-parameters</arg>
@@ -78,14 +72,13 @@
                 </configuration>
             </plugin>
 
-
-            <!-- 
+            <!--
             Create Javadoc for API jar
             -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.12.0</version>
+                <version>${maven.javadoc.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-api-javadocs</id>
@@ -121,7 +114,7 @@ Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-pmd-plugin</artifactId>
-                <version>3.28.0</version>
+                <version>${maven.pmd.plugin.version}</version>
                 <configuration>
                     <rulesets>
                         <ruleset>src/main/resources/rules.xml</ruleset>
@@ -140,7 +133,7 @@ Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>6.1.0</version>
+                <version>${maven.bundle.plugin.version}</version>
                 <configuration>
                     <niceManifest>true</niceManifest>
                     <supportedProjectTypes>
@@ -173,7 +166,7 @@ Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.5.1</version>
+                <version>${maven.jar.plugin.version}</version>
                 <configuration>
                     <archive>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>

--- a/stateful/pom.xml
+++ b/stateful/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2025 Contributors to the Eclipse Foundation
+  ~ Copyright (c) 2025, 2026 Contributors to the Eclipse Foundation
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -33,9 +33,6 @@
 
     <properties>
         <assertj.version>3.27.7</assertj.version>
-        <!-- default is the same for backward compatibility reason
-        Easy to override when building with a system property -->
-        <spec.version>1.1</spec.version>
     </properties>
 
     <dependencies>
@@ -188,5 +185,4 @@ Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/tck-dist/pom.xml
+++ b/tck-dist/pom.xml
@@ -166,7 +166,7 @@
                         </goals>
                         <configuration>
                             <backend>html5</backend>
-                            <outputFile>${project.build.directory}/generated-docs/data-tck-reference-guide-${spec.version}.html</outputFile>
+                            <outputFile>${project.build.directory}/generated-docs/data-tck-reference-guide.html</outputFile>
                         </configuration>
                     </execution>
                     <execution>
@@ -177,14 +177,19 @@
                         </goals>
                         <configuration>
                             <backend>pdf</backend>
-                            <outputFile>${project.build.directory}/generated-docs/data-tck-reference-guide-${spec.version}.pdf</outputFile>
+                            <outputFile>${project.build.directory}/generated-docs/data-tck-reference-guide.pdf</outputFile>
                         </configuration>
                     </execution>
                 </executions>
                 <configuration>
                     <toc>left</toc>
                     <sourceDocumentName>data-tck-reference-guide.adoc</sourceDocumentName>
-                    <sourceHighlighter>coderay</sourceHighlighter>
+                    <attributes>
+                        <revnumber>${spec.version}</revnumber>
+                        <revremark>${doc.mark}</revremark>
+                        <revdate>${revisiondate}</revdate>
+                        <sourceHighlighter>coderay</sourceHighlighter>
+                    </attributes>
                     <skip>${maven.adoc.skip}</skip>
                 </configuration>
             </plugin>
@@ -203,7 +208,7 @@
                             <descriptors>
                                 <descriptor>src/main/assembly/assembly.xml</descriptor>
                             </descriptors>
-                            <finalName>data-tck-${spec.version}</finalName>
+                            <finalName>data-tck</finalName>
                         </configuration>
                     </execution>
                 </executions>

--- a/tck-dist/pom.xml
+++ b/tck-dist/pom.xml
@@ -15,204 +15,199 @@
  ~ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
- xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
- <modelVersion>4.0.0</modelVersion>
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
- <parent>
-  <groupId>jakarta.data</groupId>
-  <artifactId>jakarta.data-parent</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
- </parent>
+    <parent>
+        <groupId>jakarta.data</groupId>
+        <artifactId>jakarta.data-parent</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+    </parent>
 
- <artifactId>jakarta.data-tck-dist</artifactId>
- <name>Jakarta Data Technology Compatibility Kit Distribution</name>
- <description>Jakarta Data :: TCK Distribution</description>
+    <artifactId>jakarta.data-tck-dist</artifactId>
+    <name>Jakarta Data Technology Compatibility Kit Distribution</name>
+    <description>Jakarta Data :: TCK Distribution</description>
 
- <licenses>
-  <license>
-   <name>Eclipse Public License 2.0</name>
-   <url>https://projects.eclipse.org/license/epl-2.0</url>
-   <distribution>repo</distribution>
-  </license>
-  <license>
-   <name>GNU General Public License, version 2 with the GNU Classpath Exception</name>
-   <url>https://projects.eclipse.org/license/secondary-gpl-2.0-cp</url>
-   <distribution>repo</distribution>
-  </license>
- </licenses>
+    <licenses>
+        <license>
+            <name>Eclipse Public License 2.0</name>
+            <url>https://projects.eclipse.org/license/epl-2.0</url>
+            <distribution>repo</distribution>
+        </license>
+        <license>
+            <name>GNU General Public License, version 2 with the GNU Classpath Exception</name>
+            <url>https://projects.eclipse.org/license/secondary-gpl-2.0-cp</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
- <properties>
-  <jakarta.data.tck.version>${project.version}</jakarta.data.tck.version>
-  <jakarta.data.api.version>${project.version}</jakarta.data.api.version>
+    <properties>
+        <jakarta.data.tck.version>${project.version}</jakarta.data.tck.version>
+        <jakarta.data.api.version>${project.version}</jakarta.data.api.version>
 
-  <maven.site.skip>true</maven.site.skip>
-  <asciidoctor.maven.plugin.version>3.2.0</asciidoctor.maven.plugin.version>
-  <asciidoctorj.version>3.0.1</asciidoctorj.version>
-  <asciidoctorj.pdf.version>2.3.23</asciidoctorj.pdf.version>
-  <jruby.version>9.4.15.0</jruby.version>
- </properties>
+        <maven.site.skip>true</maven.site.skip>
+        <asciidoctor.maven.plugin.version>3.2.0</asciidoctor.maven.plugin.version>
+        <asciidoctorj.version>3.0.1</asciidoctorj.version>
+        <asciidoctorj.pdf.version>2.3.23</asciidoctorj.pdf.version>
+        <jruby.version>9.4.15.0</jruby.version>
+    </properties>
 
- <dependencies>
-  <!-- The TCK, used to auto generate docs -->
-  <dependency>
-   <groupId>jakarta.data</groupId>
-   <artifactId>jakarta.data-tck</artifactId>
-   <version>${jakarta.data.tck.version}</version>
-  </dependency>
-  <!-- Provided dependencies for the TCK -->
-  <dependency>
-    <groupId>jakarta.servlet</groupId>
-    <artifactId>jakarta.servlet-api</artifactId>
-    <version>${jakarta.servlet.version}</version>
-  </dependency>
-
-  <dependency>
-    <groupId>jakarta.data</groupId>
-    <artifactId>jakarta.data-api</artifactId>
-    <version>${jakarta.data.api.version}</version>
-  </dependency>
- </dependencies>
-
- <build>
-  <plugins>
-   <!-- Skip checking for Apache license in this sub-module since it needs 
-    to use EPL/GPL -->
-   <plugin>
-    <groupId>org.apache.rat</groupId>
-    <artifactId>apache-rat-plugin</artifactId>
-    <version>${apache.rat.version}</version>
-    <configuration>
-     <skip>true</skip>
-    </configuration>
-   </plugin>
-
-   <plugin>
-    <groupId>org.apache.maven.plugins</groupId>
-    <artifactId>maven-dependency-plugin</artifactId>
-    <version>${maven.dependency.plugin.version}</version>
-    <executions>
-    <!-- Load TCK dependency location as variable -->
-     <execution>
-      <phase>initialize</phase>
-      <goals>
-       <goal>properties</goal>
-      </goals>
-     </execution>
-     <!-- Copy tck sources to a known location -->
-     <execution>
-       <id>get-dependency-sources</id>
-       <phase>package</phase>
-       <goals>
-         <goal>copy-dependencies</goal>
-       </goals>
-       <configuration>
-         <includeArtifactIds>jakarta.data-tck</includeArtifactIds>
-         <classifier>sources</classifier>
-         <prependGroupId>true</prependGroupId>
-         <outputDirectory>${project.build.directory}/copied-sources/</outputDirectory>
-       </configuration>
-     </execution>
-    </executions>
-   </plugin>
-
-   <!-- Automatically generate a list of excluded tests and test counts -->
-   <plugin>
-    <groupId>org.codehaus.mojo</groupId>
-    <artifactId>exec-maven-plugin</artifactId>
-    <version>${exec.maven.plugin.version}</version>
-    <executions>
-     <execution>
-      <id>generate-asciidoc</id>
-      <phase>process-classes</phase>
-      <goals>
-       <goal>java</goal>
-      </goals>
-     </execution>
-    </executions>
-    <configuration>
-     <mainClass>ee.jakarta.tck.data.metadata.CollectMetaData</mainClass>
-     <arguments>
-      <argument>false</argument> <!-- debug -->
-      <argument>${jakarta.data:jakarta.data-tck:jar}</argument>
-      <argument>${project.basedir}/src/main/asciidoc/sections/generated</argument>
-     </arguments>
-    </configuration>
-   </plugin>
-
-   <!-- Aciidoctor will create the html and pdf distributions of the user-guide -->
-   <plugin>
-    <groupId>org.asciidoctor</groupId>
-    <artifactId>asciidoctor-maven-plugin</artifactId>
-    <version>${asciidoctor.maven.plugin.version}</version>
     <dependencies>
-     <dependency>
-      <groupId>org.jruby</groupId>
-      <artifactId>jruby</artifactId>
-      <version>${jruby.version}</version>
-     </dependency>
-     <dependency>
-      <groupId>org.asciidoctor</groupId>
-      <artifactId>asciidoctorj</artifactId>
-      <version>${asciidoctorj.version}</version>
-     </dependency>
-     <dependency>
-      <groupId>org.asciidoctor</groupId>
-      <artifactId>asciidoctorj-pdf</artifactId>
-      <version>${asciidoctorj.pdf.version}</version>
-     </dependency>
-    </dependencies>
-    <executions>
-     <execution>
-      <id>asciidoc-to-html</id>
-      <phase>prepare-package</phase>
-      <goals>
-       <goal>process-asciidoc</goal>
-      </goals>
-      <configuration>
-       <backend>html5</backend>
-       <outputFile>${project.build.directory}/generated-docs/data-tck-reference-guide-${spec.version}.html</outputFile>
-      </configuration>
-     </execution>
-     <execution>
-      <id>asciidoc-to-pdf</id>
-      <phase>prepare-package</phase>
-      <goals>
-       <goal>process-asciidoc</goal>
-      </goals>
-      <configuration>
-       <backend>pdf</backend>
-       <outputFile>${project.build.directory}/generated-docs/data-tck-reference-guide-${spec.version}.pdf</outputFile>
-      </configuration>
-     </execution>
-    </executions>
-    <configuration>
-     <toc>left</toc>
-     <sourceDocumentName>data-tck-reference-guide.adoc</sourceDocumentName>
-     <sourceHighlighter>coderay</sourceHighlighter>
-     <skip>${maven.adoc.skip}</skip>
-    </configuration>
-   </plugin>
+        <!-- The TCK, used to auto generate docs -->
+        <dependency>
+            <groupId>jakarta.data</groupId>
+            <artifactId>jakarta.data-tck</artifactId>
+            <version>${jakarta.data.tck.version}</version>
+        </dependency>
+        <!-- Provided dependencies for the TCK -->
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+        </dependency>
 
-   <!-- Assembly plugin to collect everything into a single distribution -->
-   <plugin>
-    <artifactId>maven-assembly-plugin</artifactId>
-    <executions>
-     <execution>
-      <id>distribution</id>
-      <phase>package</phase>
-      <goals>
-       <goal>single</goal>
-      </goals>
-      <configuration>
-       <descriptors>
-        <descriptor>src/main/assembly/assembly.xml</descriptor>
-       </descriptors>
-       <finalName>data-tck-${spec.version}</finalName>
-      </configuration>
-     </execution>
-    </executions>
-   </plugin>
-  </plugins>
- </build>
+        <dependency>
+            <groupId>jakarta.data</groupId>
+            <artifactId>jakarta.data-api</artifactId>
+            <version>${jakarta.data.api.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Skip checking for Apache license in this sub-module since it needs to use EPL/GPL -->
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <!-- Load TCK dependency location as variable -->
+                    <execution>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                    <!-- Copy tck sources to a known location -->
+                    <execution>
+                        <id>get-dependency-sources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeArtifactIds>jakarta.data-tck</includeArtifactIds>
+                            <classifier>sources</classifier>
+                            <prependGroupId>true</prependGroupId>
+                            <outputDirectory>${project.build.directory}/copied-sources/</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Automatically generate a list of excluded tests and test counts -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-asciidoc</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <mainClass>ee.jakarta.tck.data.metadata.CollectMetaData</mainClass>
+                    <arguments>
+                        <argument>false</argument> <!-- debug -->
+                        <argument>${jakarta.data:jakarta.data-tck:jar}</argument>
+                        <argument>${project.basedir}/src/main/asciidoc/sections/generated</argument>
+                    </arguments>
+                </configuration>
+            </plugin>
+
+            <!-- Asciidoctor will create the html and pdf distributions of the user-guide -->
+            <plugin>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctor-maven-plugin</artifactId>
+                <version>${asciidoctor.maven.plugin.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jruby</groupId>
+                        <artifactId>jruby</artifactId>
+                        <version>${jruby.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctorj</artifactId>
+                        <version>${asciidoctorj.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctorj-pdf</artifactId>
+                        <version>${asciidoctorj.pdf.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>asciidoc-to-html</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <backend>html5</backend>
+                            <outputFile>${project.build.directory}/generated-docs/data-tck-reference-guide-${spec.version}.html</outputFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>asciidoc-to-pdf</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <backend>pdf</backend>
+                            <outputFile>${project.build.directory}/generated-docs/data-tck-reference-guide-${spec.version}.pdf</outputFile>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <toc>left</toc>
+                    <sourceDocumentName>data-tck-reference-guide.adoc</sourceDocumentName>
+                    <sourceHighlighter>coderay</sourceHighlighter>
+                    <skip>${maven.adoc.skip}</skip>
+                </configuration>
+            </plugin>
+
+            <!-- Assembly plugin to collect everything into a single distribution -->
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>distribution</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/assembly.xml</descriptor>
+                            </descriptors>
+                            <finalName>data-tck-${spec.version}</finalName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/tck-dist/pom.xml
+++ b/tck-dist/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- ~ Copyright (c) 2022, 2024 Contributors to the Eclipse Foundation
+ ~ Copyright (c) 2022, 2026 Contributors to the Eclipse Foundation
  ~
  ~ This program and the accompanying materials are made available under the
  ~ terms of the Eclipse Public License v. 2.0, which is available at
@@ -171,7 +171,7 @@
       </goals>
       <configuration>
        <backend>html5</backend>
-       <outputFile>${project.build.directory}/generated-docs/data-tck-reference-guide-${jakarta.data.tck.version}.html</outputFile>
+       <outputFile>${project.build.directory}/generated-docs/data-tck-reference-guide-${spec.version}.html</outputFile>
       </configuration>
      </execution>
      <execution>
@@ -182,7 +182,7 @@
       </goals>
       <configuration>
        <backend>pdf</backend>
-       <outputFile>${project.build.directory}/generated-docs/data-tck-reference-guide-${jakarta.data.tck.version}.pdf</outputFile>
+       <outputFile>${project.build.directory}/generated-docs/data-tck-reference-guide-${spec.version}.pdf</outputFile>
       </configuration>
      </execution>
     </executions>
@@ -208,7 +208,7 @@
        <descriptors>
         <descriptor>src/main/assembly/assembly.xml</descriptor>
        </descriptors>
-       <finalName>data-tck-${jakarta.data.tck.version}</finalName>
+       <finalName>data-tck-${spec.version}</finalName>
       </configuration>
      </execution>
     </executions>

--- a/tck-dist/src/main/asciidoc/data-tck-reference-guide.adoc
+++ b/tck-dist/src/main/asciidoc/data-tck-reference-guide.adoc
@@ -1,13 +1,12 @@
 = Jakarta Data TCK Reference Guide
 :author: Kyle Aure
 :email: data-dev@eclipse.org
-:revnumber: 1.0
 :toc:
 :sectnums:
 
 :APIShortName: Data
 :APILongName: Jakarta Data
-:APIVersion: 1.0.0
+:APIVersion: {revnumber}
 
 :APISpecSite: https://jakarta.ee/specifications/data/
 :APIEclipseSite: https://projects.eclipse.org/projects/ee4j.data

--- a/tck-dist/src/main/pom.xml
+++ b/tck-dist/src/main/pom.xml
@@ -15,24 +15,23 @@
  ~ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
- xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
- xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
- <modelVersion>4.0.0</modelVersion>
- 
- <!-- 
-      This is just an aggregator pom so that dependabot can find the starter poms
-      This aggregator is not packaged into the tck distribution
-  -->
-  
- <groupId>jakarta.data</groupId>
- <artifactId>data-tck-aggregator</artifactId>
- <version>1.0-SNAPSHOT</version>
- <packaging>pom</packaging>
-  
-  <modules>
-      <module>starter/ee-pom.xml</module>
-      <module>starter/se-pom.xml</module>
-  </modules>
- 
- </project>
+    <!--
+         This is just an aggregator pom so that dependabot can find the starter poms.
+         This aggregator is not packaged into the tck distribution.
+     -->
+
+    <groupId>jakarta.data</groupId>
+    <artifactId>data-tck-aggregator</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>starter/ee-pom.xml</module>
+        <module>starter/se-pom.xml</module>
+    </modules>
+
+</project>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -158,11 +158,6 @@
       <artifactId>sigtest-maven-plugin</artifactId>
       <version>${sigtest.version}</version>
     </dependency>
-    
-     <dependency>
-        <groupId>org.jboss.shrinkwrap.resolver</groupId>
-        <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -14,389 +14,373 @@
  ~
  ~ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
   -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>jakarta.data</groupId>
-    <artifactId>jakarta.data-parent</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
-  </parent>
-
-  <artifactId>jakarta.data-tck</artifactId>
-  <name>Jakarta Data Technology Compatibility Kit</name>
-  <description>Jakarta Data :: TCK</description>
-
-  <licenses>
-    <license>
-      <name>Eclipse Public License 2.0</name>
-      <url>https://projects.eclipse.org/license/epl-2.0</url>
-      <distribution>repo</distribution>
-    </license>
-    <license>
-      <name>GNU General Public License, version 2 with the GNU Classpath Exception</name>
-      <url>https://projects.eclipse.org/license/secondary-gpl-2.0-cp</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
-
-  <properties>
-    <assertj.version>3.27.7</assertj.version>
-  </properties>
-
-  <dependencies>
-    <!-- Test framework -->
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.platform</groupId>
-      <artifactId>junit-platform-launcher</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <version>${assertj.version}</version>
-    </dependency>
-    
-    <!-- Data API -->
-    <dependency>
+    <parent>
         <groupId>jakarta.data</groupId>
-        <artifactId>jakarta.data-api</artifactId>
-        <version>${jakarta.data.version}</version>
-        <scope>provided</scope>
-    </dependency>
+        <artifactId>jakarta.data-parent</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+    </parent>
 
-    <!-- Data Stateful API -->
-    <dependency>
-        <groupId>jakarta.data</groupId>
-        <artifactId>jakarta.data.stateful-api</artifactId>
-        <version>${jakarta.data.version}</version>
-        <scope>provided</scope>
-    </dependency>
+    <artifactId>jakarta.data-tck</artifactId>
+    <name>Jakarta Data Technology Compatibility Kit</name>
+    <description>Jakarta Data :: TCK</description>
 
-    <!-- EE Server Integration framework -->
-    <dependency>
-      <groupId>org.jboss.arquillian.junit5</groupId>
-      <artifactId>arquillian-junit5-container</artifactId>
-    </dependency>
+    <licenses>
+        <license>
+            <name>Eclipse Public License 2.0</name>
+            <url>https://projects.eclipse.org/license/epl-2.0</url>
+            <distribution>repo</distribution>
+        </license>
+        <license>
+            <name>GNU General Public License, version 2 with the GNU Classpath Exception</name>
+            <url>https://projects.eclipse.org/license/secondary-gpl-2.0-cp</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
 
-    <!-- EE Servlet Integration framework -->
-    <dependency>
-      <groupId>org.jboss.arquillian.protocol</groupId>
-      <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
-    </dependency>
+    <dependencies>
+        <!-- Test framework -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
 
-    <!-- Provided Jakarta APIs -->
-    <dependency>
-      <groupId>jakarta.annotation</groupId>
-      <artifactId>jakarta.annotation-api</artifactId>
-      <version>${jakarta.annotation.version}</version>
-      <scope>provided</scope>
-    </dependency>
+        <!-- Data API -->
+        <dependency>
+            <groupId>jakarta.data</groupId>
+            <artifactId>jakarta.data-api</artifactId>
+            <version>${jakarta.data.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>jakarta.enterprise.concurrent</groupId>
-      <artifactId>jakarta.enterprise.concurrent-api</artifactId>
-      <version>${jakarta.concurrency.version}</version>
-      <scope>provided</scope>
-    </dependency>
+        <!-- Data Stateful API -->
+        <dependency>
+            <groupId>jakarta.data</groupId>
+            <artifactId>jakarta.data.stateful-api</artifactId>
+            <version>${jakarta.data.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
-    <dependency>
-      <groupId>jakarta.servlet</groupId>
-      <artifactId>jakarta.servlet-api</artifactId>
-      <version>${jakarta.servlet.version}</version>
-      <scope>provided</scope>
-    </dependency>
+        <!-- EE Server Integration framework -->
+        <dependency>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>jakarta.inject</groupId>
-      <artifactId>jakarta.inject-api</artifactId>
-      <version>${jakarta.inject.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>jakarta.enterprise</groupId>
-      <artifactId>jakarta.enterprise.cdi-api</artifactId>
-      <version>${jakarta.enterprise.cdi.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>jakarta.transaction</groupId>
-      <artifactId>jakarta.transaction-api</artifactId>
-      <version>${jakarta.transaction.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    
-    <dependency>
-      <groupId>jakarta.validation</groupId>
-      <artifactId>jakarta.validation-api</artifactId>
-      <version>${jakarta.validation.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    
-    <!-- Provided Entity APIs -->
-    <dependency>
-      <groupId>jakarta.nosql</groupId>
-      <artifactId>jakarta.nosql-api</artifactId>
-      <version>${jakarta.nosql.version}</version>
-    </dependency>
+        <!-- EE Servlet Integration framework -->
+        <dependency>
+            <groupId>org.jboss.arquillian.protocol</groupId>
+            <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
+        </dependency>
 
-    <dependency>
-      <groupId>jakarta.persistence</groupId>
-      <artifactId>jakarta.persistence-api</artifactId>
-      <version>${jakarta.persistence.version}</version>
-      <scope>provided</scope>
-    </dependency>
-    
-    <!-- Test Dependencies -->
-    <dependency>
-      <groupId>jakarta.tck</groupId>
-      <artifactId>sigtest-maven-plugin</artifactId>
-      <version>${sigtest.version}</version>
-    </dependency>
-  </dependencies>
+        <!-- Provided Jakarta APIs -->
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
-  <build>
-    <resources>
-      <!-- The default resource location -->
-      <resource>
-        <directory>src/main/resources</directory>
-        <includes>
-          <include>**/*.*</include>
-        </includes>
-      </resource>
+        <dependency>
+            <groupId>jakarta.enterprise.concurrent</groupId>
+            <artifactId>jakarta.enterprise.concurrent-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
-      <!-- Additional resources kept inside packages for ease of development -->
-      <resource>
-        <directory>src/main/java</directory>
-        <includes>
-          <include>**/*.xml</include>
-          <include>**/*.jsp</include>
-        </includes>
-      </resource>
-    </resources>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
-    <plugins>
-      <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-        <version>${apache.rat.version}</version>
-        <!-- Skip checking for Apache license in this sub-module since it needs to use EPL/GPL -->
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>${maven.compile.version}</version>
-        <configuration>
-          <source>17</source>
-          <target>17</target>
-          <compilerArgs>
-            <arg>-parameters</arg>
-          </compilerArgs>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>jar-no-fork</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>attach-tck-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-            <configuration>
-              <source>17</source>
-              <quiet>true</quiet>
-              <additionalJOption>-Xdoclint:none</additionalJOption>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
-  <profiles>
-    <profile>
-      <!-- 
-      ~ This profile can be used to (re)generate signatures of Data API.
-      ~ Note that they differ based on JDK used to build them 
-      ~ All .sig files should be included in the generated jar files! 
-      -->
-      <id>signature-generation</id>
-      <activation>
-        <property>
-          <name>signature</name>
-        </property>
-      </activation>
-      <properties>
-        <!--Default assumed JDK version, can be overriden via -Dmajor.jdk.version=X -->
-        <jdk.major.version>17</jdk.major.version>
-      </properties>
-      <build>
-        <plugins>
-          <!-- Extract apis into output directory for use by signature plugin -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>unpack</id>
-                <phase>generate-sources</phase>
-                <goals>
-                  <goal>unpack</goal>
-                </goals>
-                <configuration>
-                  <artifactItems>
-                    <artifactItem>
-                      <groupId>jakarta.data</groupId>
-                      <artifactId>jakarta.data-api</artifactId>
-                      <version>${project.version}</version>
-                      <type>jar</type>
-                      <overWrite>false</overWrite>
-                      <outputDirectory>${project.build.directory}/jakarta.data-api</outputDirectory>
-                      <includes>**/*.class,**/*.xml</includes>
-                    </artifactItem>
-                    <artifactItem>
-                      <groupId>jakarta.data</groupId>
-                      <artifactId>jakarta.data.stateful-api</artifactId>
-                      <version>${project.version}</version>
-                      <type>jar</type>
-                      <overWrite>false</overWrite>
-                      <outputDirectory>${project.build.directory}/jakarta.data-stateful-api</outputDirectory>
-                      <includes>**/*.class,**/*.xml</includes>
-                    </artifactItem>
-                  </artifactItems>
-                  <includes>**/*.java</includes>
-                  <excludes>**/*.properties</excludes>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
-          <!-- Extract JDK modules into output directory for use by signature plugin -->
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>exec-maven-plugin</artifactId>
-            <version>${exec.maven.plugin.version}</version>
-            <executions>
-                <execution>
-                    <id>extractModules</id>
-                    <phase>generate-sources</phase>
-                    <goals>
-                        <goal>exec</goal>
-                    </goals>
-                </execution>
-            </executions>
-            <configuration>
-                <executable>jimage</executable>
-                <arguments>
-                    <argument>extract</argument>
-                    <argument>--dir=${project.build.directory}/jimage</argument>
-                    <argument>${java.home}/lib/modules</argument>
-                </arguments>
-            </configuration>
-          </plugin>
-          
-          <!-- Run signature plugin to generate base and stateful signature files -->
-          <plugin>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Provided Entity APIs -->
+        <dependency>
+            <groupId>jakarta.nosql</groupId>
+            <artifactId>jakarta.nosql-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>${sigtest.version}</version>
-            <executions>
-              <execution>
-                <id>createSigFile</id>
-                <phase>generate-resources</phase>
-                <goals>
-                  <goal>generate</goal>
-                </goals>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <!-- The default resource location -->
+            <resource>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>**/*.*</include>
+                </includes>
+            </resource>
+
+            <!-- Additional resources kept inside packages for ease of development -->
+            <resource>
+                <directory>src/main/java</directory>
+                <includes>
+                    <include>**/*.xml</include>
+                    <include>**/*.jsp</include>
+                </includes>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <!-- Skip checking for Apache license in this sub-module since it needs to use EPL/GPL -->
                 <configuration>
-                  <classes>${project.build.directory}/jakarta.data-api</classes>
-                  <classes>${project.build.directory}/jimage/java.base</classes>
-                  <packages>
-                      jakarta.data,
-                      jakarta.data.exceptions,
-                      jakarta.data.metamodel,
-                      jakarta.data.metamodel.impl,
-                      jakarta.data.page,
-                      jakarta.data.page.impl,
-                      jakarta.data.repository,
-                      jakarta.data.spi
-                  </packages>
-                  <version>${project.version}</version>
-                  <attach>false</attach>
-                  <sigfile>${project.build.directory}/jakarta.data.sig_${java.version}</sigfile>
+                    <skip>true</skip>
                 </configuration>
-              </execution>
-              <execution>
-                <id>createStatefulSigFile</id>
-                <phase>generate-resources</phase>
-                <goals>
-                  <goal>generate</goal>
-                </goals>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                  <classes>${project.build.directory}/jakarta.data-stateful-api</classes>
-                  <classes>${project.build.directory}/jimage/java.base</classes>
-                  <packages>
-                      jakarta.data.repository.stateful
-                  </packages>
-                  <version>${project.version}</version>
-                  <attach>false</attach>
-                  <sigfile>${project.build.directory}/jakarta.data.repository.stateful.sig_${java.version}</sigfile>
+                    <source>17</source>
+                    <target>17</target>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
                 </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          
-          <!-- Copy signature file to tck resources with major java version -->
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <version>${maven.antrun.plugin.version}</version>
-            <executions>
-              <execution>
-                <id>copySigFile</id>
-                <phase>process-resources</phase>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-                <configuration>
-                  <target>
-                    <mkdir dir="${project.basedir}/src/main/resources/ee/jakarta/tck/data/framework/signature/"/>
-                    <copy todir="${project.basedir}/src/main/resources/ee/jakarta/tck/data/framework/signature/">
-                      <fileset dir="${project.build.directory}" includes="jakarta.data.sig_${java.version}"/>
-                      <mapper from="^(jakarta.data.sig_[0-9]+)" to="\1" type="regexp"/>
-                    </copy>
-                    <copy todir="${project.basedir}/src/main/resources/ee/jakarta/tck/data/framework/signature/">
-                      <fileset dir="${project.build.directory}" includes="jakarta.data.repository.stateful.sig_${java.version}"/>
-                      <mapper from="^(jakarta.data.repository.stateful.sig_[0-9]+)" to="\1" type="regexp"/>
-                    </copy>
-                  </target>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-tck-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <source>17</source>
+                            <quiet>true</quiet>
+                            <additionalJOption>-Xdoclint:none</additionalJOption>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
-      </build>
-    </profile>
-  </profiles>
+    </build>
+
+    <profiles>
+        <profile>
+            <!--
+            ~ This profile can be used to (re)generate signatures of Data API.
+            ~ Note that they differ based on JDK used to build them
+            ~ All .sig files should be included in the generated jar files!
+            -->
+            <id>signature-generation</id>
+            <activation>
+                <property>
+                    <name>signature</name>
+                </property>
+            </activation>
+            <properties>
+                <!--Default assumed JDK version, can be overriden via -Dmajor.jdk.version=X -->
+                <jdk.major.version>17</jdk.major.version>
+            </properties>
+            <build>
+                <plugins>
+                    <!-- Extract apis into output directory for use by signature plugin -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>jakarta.data</groupId>
+                                            <artifactId>jakarta.data-api</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>jar</type>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>${project.build.directory}/jakarta.data-api</outputDirectory>
+                                            <includes>**/*.class,**/*.xml</includes>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>jakarta.data</groupId>
+                                            <artifactId>jakarta.data.stateful-api</artifactId>
+                                            <version>${project.version}</version>
+                                            <type>jar</type>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>${project.build.directory}/jakarta.data-stateful-api</outputDirectory>
+                                            <includes>**/*.class,**/*.xml</includes>
+                                        </artifactItem>
+                                    </artifactItems>
+                                    <includes>**/*.java</includes>
+                                    <excludes>**/*.properties</excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Extract JDK modules into output directory for use by signature plugin -->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>extractModules</id>
+                                <phase>generate-sources</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <executable>jimage</executable>
+                            <arguments>
+                                <argument>extract</argument>
+                                <argument>--dir=${project.build.directory}/jimage</argument>
+                                <argument>${java.home}/lib/modules</argument>
+                            </arguments>
+                        </configuration>
+                    </plugin>
+
+                    <!-- Run signature plugin to generate base and stateful signature files -->
+                    <plugin>
+                        <groupId>jakarta.tck</groupId>
+                        <artifactId>sigtest-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>createSigFile</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>generate</goal>
+                                </goals>
+                                <configuration>
+                                    <classes>${project.build.directory}/jakarta.data-api</classes>
+                                    <classes>${project.build.directory}/jimage/java.base</classes>
+                                    <packages>
+                                        jakarta.data,
+                                        jakarta.data.exceptions,
+                                        jakarta.data.metamodel,
+                                        jakarta.data.metamodel.impl,
+                                        jakarta.data.page,
+                                        jakarta.data.page.impl,
+                                        jakarta.data.repository,
+                                        jakarta.data.spi
+                                    </packages>
+                                    <version>${project.version}</version>
+                                    <attach>false</attach>
+                                    <sigfile>${project.build.directory}/jakarta.data.sig_${java.version}</sigfile>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>createStatefulSigFile</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>generate</goal>
+                                </goals>
+                                <configuration>
+                                    <classes>${project.build.directory}/jakarta.data-stateful-api</classes>
+                                    <classes>${project.build.directory}/jimage/java.base</classes>
+                                    <packages>
+                                        jakarta.data.repository.stateful
+                                    </packages>
+                                    <version>${project.version}</version>
+                                    <attach>false</attach>
+                                    <sigfile>${project.build.directory}/jakarta.data.repository.stateful.sig_${java.version}</sigfile>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Copy signature file to tck resources with major java version -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copySigFile</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <mkdir dir="${project.basedir}/src/main/resources/ee/jakarta/tck/data/framework/signature/" />
+                                        <copy todir="${project.basedir}/src/main/resources/ee/jakarta/tck/data/framework/signature/">
+                                            <fileset dir="${project.build.directory}"
+                                                includes="jakarta.data.sig_${java.version}" />
+                                            <mapper from="^(jakarta.data.sig_[0-9]+)" to="\1" type="regexp" />
+                                        </copy>
+                                        <copy todir="${project.basedir}/src/main/resources/ee/jakarta/tck/data/framework/signature/">
+                                            <fileset dir="${project.build.directory}"
+                                                includes="jakarta.data.repository.stateful.sig_${java.version}" />
+                                            <mapper from="^(jakarta.data.repository.stateful.sig_[0-9]+)" to="\1" type="regexp" />
+                                        </copy>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
- calculate the spec.version minor.version and doc.mark based on the current projects version number.
  - spec.version = 1.1 when project.version = 1.1.0-SNAPSHOT
  - minor.version = 0 when project.version = 1.1.0-SNAPSHOT 
  - doc.mark = DRAFT when project.version = 1.1.0-SNAPSHOT or 1.1.0-M2
  - doc.mark = FINAL when project.version = 1.1.0
- format poms for correct whitespace, version consistency, and using the above calculated versions
- modify workflows to reflect changes to poms. 