### PR TITLE
Add TCK coverage for exceptional async completion

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/web/async/AsyncTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/web/async/AsyncTests.java
@@ -207,13 +207,13 @@ public class AsyncTests {
                 LocalDateTime.of(2026, 7, 28, 10, 30, 00),
                 "asyncUser108@eclipse.org");
 
+        CompletionStage<Void> insert;
         try {
-            CompletionStage<Void> insert;
-            try {
-                insert = accounts.add(account);
-            } catch (UnsupportedOperationException x) {
-                return; // Data provider is not capable of CompletionStage return type
-            }
+            insert = accounts.add(account);
+        } catch (UnsupportedOperationException x) {
+            return; // Data provider is not capable of CompletionStage return type
+        }
+        try {
 
             insert.toCompletableFuture()
                     .get(TIMEOUT_SECONDS, TimeUnit.SECONDS);

--- a/tck/src/main/java/ee/jakarta/tck/data/web/async/AsyncTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/web/async/AsyncTests.java
@@ -32,6 +32,8 @@ import ee.jakarta.tck.data.framework.junit.anno.AnyEntity;
 import ee.jakarta.tck.data.framework.junit.anno.Assertion;
 import ee.jakarta.tck.data.framework.junit.anno.Web;
 import ee.jakarta.tck.data.framework.utilities.TestPropertyUtility;
+
+import jakarta.data.exceptions.EntityExistsException;
 import jakarta.inject.Inject;
 
 @Web
@@ -185,6 +187,51 @@ public class AsyncTests {
         accounts.delete(account3);
 
         TestPropertyUtility.waitForEventualConsistency();
+    }
+
+    @Assertion(id = "19", strategy = """
+    Tests that an asynchronous repository method completes
+    exceptionally when the operation fails.
+    """)
+    public void testAsynchronousInsertExceptionalCompletion() throws Exception {
+        try {
+            Class.forName("jakarta.enterprise.concurrent.Asynchronous");
+        } catch (ClassNotFoundException x) {
+            return; // Jakarta Concurrency API is not present
+        }
+
+        Account account = Account.of(
+                108,
+                true,
+                25.99f,
+                LocalDateTime.of(2026, 7, 28, 10, 30, 00),
+                "asyncUser108@eclipse.org");
+
+        try {
+            CompletionStage<Void> insert;
+            try {
+                insert = accounts.add(account);
+            } catch (UnsupportedOperationException x) {
+                return; // Data provider is not capable of CompletionStage return type
+            }
+
+            insert.toCompletableFuture()
+                    .get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+            CompletionStage<Void> duplicateInsert = accounts.add(account);
+
+            try {
+                duplicateInsert.toCompletableFuture()
+                        .get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                throw new AssertionError(
+                        "Expected CompletionStage to complete exceptionally");
+            } catch (java.util.concurrent.ExecutionException x) {
+                assertEquals(EntityExistsException.class, x.getCause().getClass());
+            }
+        } finally {
+            accounts.delete(account);
+            TestPropertyUtility.waitForEventualConsistency();
+        }
     }
 
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/web/async/AsyncTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/web/async/AsyncTests.java
@@ -218,6 +218,8 @@ public class AsyncTests {
             insert.toCompletableFuture()
                     .get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
+            TestPropertyUtility.waitForEventualConsistency();
+
             CompletionStage<Void> duplicateInsert = accounts.add(account);
 
             try {


### PR DESCRIPTION
## Description

Adds TCK coverage for exceptional completion of an asynchronous Jakarta Data repository method.

The new test verifies that when an asynchronous `@Insert` operation fails because an entity with the same identifier already exists, the returned `CompletionStage` completes exceptionally with `EntityExistsException` as the underlying cause.

### Testing

* `mvn clean verify` — successful
* `AsyncTests` against Open Liberty — 3 tests passed
* `testAsynchronousInsertExceptionalCompletion` against Open Liberty — passed
* `git diff --check` — clean

The change is limited to `tck/src/main/java/ee/jakarta/tck/data/web/async/AsyncTests.java`.

Related to #19.
