### PR TITLE
TCK tests for QueryOptions on JakartaQuery

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/stateful/Inventory.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/stateful/Inventory.java
@@ -27,6 +27,9 @@ import jakarta.data.repository.stateful.Merge;
 import jakarta.data.repository.stateful.Persist;
 import jakarta.data.repository.stateful.Remove;
 import jakarta.data.restrict.Restriction;
+import jakarta.persistence.QueryFlushMode;
+import jakarta.persistence.query.JakartaQuery;
+import jakarta.persistence.query.QueryOptions;
 import jakarta.transaction.Transactional;
 
 /**
@@ -60,4 +63,12 @@ public interface Inventory {
             """)
     List<Product> withDiscountedPriceUpTo(double max,
                                           double percentOff);
+
+    @JakartaQuery("""
+        SELECT AVG(p.price)
+          FROM Product p
+         WHERE p.productNum = ?1
+        """)
+    @QueryOptions(flush = QueryFlushMode.FLUSH)
+    double averagePrice(String productNumber);
 }

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/stateful/StatefulPersistenceEntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/stateful/StatefulPersistenceEntityTests.java
@@ -34,6 +34,9 @@ import ee.jakarta.tck.data.standalone.persistence.Product.Department;
 
 import jakarta.data.Order;
 import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.FlushModeType;
+import jakarta.persistence.PersistenceContext;
 import jakarta.transaction.UserTransaction;
 
 /**
@@ -61,6 +64,9 @@ public class StatefulPersistenceEntityTests {
 
     @Inject
     UserTransaction tran;
+
+    @PersistenceContext
+    EntityManager entityManager;
 
     @Assertion(id = "471", strategy = """
             Use the Detach annotation to detach entities from the persistence context.
@@ -472,5 +478,36 @@ public class StatefulPersistenceEntityTests {
 
         assertEquals(false,
                      products.byNumber("TEST-PROD-1015").isPresent());
+    }
+
+    @Assertion(id = "965", strategy = """
+    Use a repository method annotated with JakartaQuery and QueryOptions
+    with QueryFlushMode.FLUSH. Set the persistence context flush mode to
+    EXPLICIT, modify a managed entity without explicitly flushing, and
+    verify that the query sees the modification.
+    """)
+    public void testJakartaQueryWithQueryOptions() throws Exception {
+        inventory.erase();
+
+        Product product = Product.of("tennis racket",
+                82.99,
+                "TEST-PROD-1017",
+                Department.SPORTING_GOODS);
+
+        tran.begin();
+        inventory.persist(product);
+        product.setPrice(84.98);
+
+        entityManager.setFlushMode(FlushModeType.EXPLICIT);
+
+        assertEquals(84.98,
+                inventory.averagePrice("TEST-PROD-1017"),
+                0.01);
+
+        entityManager.setFlushMode(FlushModeType.AUTO);
+
+        tran.commit();
+
+        inventory.remove(product);
     }
 }


### PR DESCRIPTION
## Summary

Adds TCK coverage for `@QueryOptions` on a repository method annotated with `@JakartaQuery`.

### Changes

* Added a `@JakartaQuery` repository method using `@QueryOptions(flush = QueryFlushMode.FLUSH)`.
* Added a stateful persistence TCK test covering the `@JakartaQuery` + `@QueryOptions` combination.
* Uses a pending entity modification before executing the query to exercise the query option.

### Verification

* `mvn clean verify` — **BUILD SUCCESS**
* API tests: **321 passed**
* TCK framework tests: **8 passed**
* Checkstyle: **0 violations**
* `git diff --check` — **clean**

### Runtime testing

The new test was also attempted against the local Open Liberty Jakarta Data 1.1 TCK server.

The test currently cannot reach the test body because persistence-unit bootstrap fails in Open Liberty with an `InMemoryUrlStreamHandler$PsURLConnection` `NullPointerException`.

The same persistence bootstrap failure was reproduced with existing TCK tests, including:

* `StatefulPersistenceEntityTests#testModifyPersistedEntity`
* `JakartaQueryTests#testJPQLSelectAggregate`

Therefore, this runtime failure is independent of the changes in this PR.

Issue: #965
