### PR TITLE
fix: TCK test deployment issues

### DIFF
--- a/.github/workflows/specification.yml
+++ b/.github/workflows/specification.yml
@@ -20,10 +20,7 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Generate specification docs
-      run: |
-        mvn package --file api/pom.xml
-        mvn package --file stateful/pom.xml
-        mvn package --file spec/pom.xml
+      run: mvn package -DskipTests -projects 'api,stateful,spec'
     - name: Assemble documentation
       run: |
         mkdir documentation/

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/JakartaEventBuiltInRepositoryTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/JakartaEventBuiltInRepositoryTest.java
@@ -15,23 +15,20 @@
  */
 package ee.jakarta.tck.data.standalone.entity;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
 import ee.jakarta.tck.data.framework.junit.anno.AnyEntity;
+import ee.jakarta.tck.data.framework.junit.anno.Assertion;
 import ee.jakarta.tck.data.framework.junit.anno.Standalone;
-import ee.jakarta.tck.data.framework.utilities.DatabaseType;
-import ee.jakarta.tck.data.framework.utilities.TestProperty;
 import ee.jakarta.tck.data.framework.utilities.TestPropertyUtility;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
-import java.util.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import jakarta.inject.Inject;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
 import java.util.List;
 
 @Standalone
@@ -39,148 +36,126 @@ import java.util.List;
 @DisplayName("Built-in repository lifecycle events")
 public class JakartaEventBuiltInRepositoryTest {
 
-    public static final Logger log = Logger.getLogger(JakartaEventBuiltInRepositoryTest.class.getCanonicalName());
-
-    protected final DatabaseType type = TestProperty.databaseType.getDatabaseType();
-
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
-                .addClasses(JakartaEventBuiltInRepositoryTest.class);
+                .addClasses(
+                    JakartaEventBuiltInRepositoryTest.class,
+                    LifecycleEventType.class,
+                    MusicRecordLifecycleObserver.class,
+                    MusicRecordRepository.class,
+                    MusicRecord.class,
+                    MusicStore.class,
+                    ObservedEvent.class
+                );
     }
 
     @Inject
-    protected MusicRecordLifecycleObserver observer;
+    MusicRecordLifecycleObserver observer;
 
     @Inject
-    protected MusicRecordRepository repository;
+    MusicRecordRepository repository;
 
     @BeforeEach
-    void setUp() {
+    public void setUp() {
         this.repository.deleteAll();
         this.observer.reset();
         TestPropertyUtility.waitForEventualConsistency();
     }
 
-    @Nested
-    @DisplayName("When inserting an entity")
-    class WhenInsert {
+    @Assertion(id = "1530",
+               strategy = "Insert one entity via the built-in insert method and verify that pre-insert and post-insert lifecycle events are fired.")
+    void shouldFireInsertEvents() {
+        // given
+        MusicRecord entity = entity();
 
-        @Test
-        @DisplayName("Should fire pre-insert and post-insert events with the inserted entity")
-        void shouldFireInsertEvents() {
-            // given
-            MusicRecord entity = entity();
+        // when
+        repository.insert(entity);
+        TestPropertyUtility.waitForEventualConsistency();
 
-            // when
-            repository.insert(entity);
-            TestPropertyUtility.waitForEventualConsistency();
-
-            // then
-            assertThat(events())
-                    .containsExactly(
-                            event(LifecycleEventType.PRE_INSERT, entity),
-                            event(LifecycleEventType.POST_INSERT, entity));
-        }
+        // then
+        assertThat(events())
+                .containsExactly(
+                        event(LifecycleEventType.PRE_INSERT, entity),
+                        event(LifecycleEventType.POST_INSERT, entity));
     }
 
-    @Nested
-    @DisplayName("When updating an entity")
-    class WhenUpdate {
+    @Assertion(id = "1530", 
+               strategy = "Update one entity via the built-in update method and verify that pre-update and post-update lifecycle events are fired.")
+    void shouldFireUpdateEvents() {
+        // given
+        MusicRecord entity = entity();
+        repository.insert(entity);
+        observer.reset();
+        TestPropertyUtility.waitForEventualConsistency();
 
-        @Test
-        @DisplayName("Should fire pre-update and post-update events with the updated entity")
-        void shouldFireUpdateEvents() {
-            // given
-            MusicRecord entity = entity();
-            repository.insert(entity);
-            observer.reset();
-            TestPropertyUtility.waitForEventualConsistency();
+        // when
+        repository.update(entity);
+        TestPropertyUtility.waitForEventualConsistency();
 
-            // when
-            repository.update(entity);
-            TestPropertyUtility.waitForEventualConsistency();
-
-            // then
-            assertThat(events())
-                    .containsExactly(
-                            event(LifecycleEventType.PRE_UPDATE, entity),
-                            event(LifecycleEventType.POST_UPDATE, entity));
-        }
+        // then
+        assertThat(events())
+                .containsExactly(
+                        event(LifecycleEventType.PRE_UPDATE, entity),
+                        event(LifecycleEventType.POST_UPDATE, entity));
     }
 
-    @Nested
-    @DisplayName("When saving a new entity")
-    class WhenSaveNewEntity {
+    @Assertion(id = "1530",
+               strategy = "Save a new entity via the built-in save method and verify that pre-upsert and post-upsert lifecycle events are fired.")
+    void shouldFireUpsertEventsWhenInserting() {
+        // given
+        MusicRecord entity = entity();
 
-        @Test
-        @DisplayName("Should fire pre-upsert and post-upsert events when inserting a missing entity")
-        void shouldFireUpsertEventsWhenInserting() {
-            // given
-            MusicRecord entity = entity();
+        // when
+        repository.save(entity);
+        TestPropertyUtility.waitForEventualConsistency();
 
-            // when
-            repository.save(entity);
-            TestPropertyUtility.waitForEventualConsistency();
-
-            // then
-            assertThat(events())
-                    .containsExactly(
-                            event(LifecycleEventType.PRE_UPSERT, entity),
-                            event(LifecycleEventType.POST_UPSERT, entity));
-        }
+        // then
+        assertThat(events())
+                .containsExactly(
+                        event(LifecycleEventType.PRE_UPSERT, entity),
+                        event(LifecycleEventType.POST_UPSERT, entity));
     }
 
-    @Nested
-    @DisplayName("When saving an existing entity")
-    class WhenSaveExistingEntity {
+    @Assertion(id = "1530",
+               strategy = "Save an existing entity via the built-in save method and verify that pre-upsert and post-upsert lifecycle events are fired.")
+    void shouldFireUpsertEventsWhenUpdating() {
+        // given
+        MusicRecord entity = entity();
 
-        @Test
-        @DisplayName("Should fire pre-upsert and post-upsert events when updating an existing entity")
-        void shouldFireUpsertEventsWhenUpdating() {
-            // given
-            MusicRecord entity = entity();
+        repository.insert(entity);
+        observer.reset();
+        TestPropertyUtility.waitForEventualConsistency();
 
-            repository.insert(entity);
-            observer.reset();
-            TestPropertyUtility.waitForEventualConsistency();
+        // when
+        repository.save(entity);
+        TestPropertyUtility.waitForEventualConsistency();
 
-            // when
-            repository.save(entity);
-            TestPropertyUtility.waitForEventualConsistency();
-
-            // then
-            assertThat(events())
-                    .containsExactly(
-                            event(LifecycleEventType.PRE_UPSERT, entity),
-                            event(LifecycleEventType.POST_UPSERT, entity));
-        }
+        // then
+        assertThat(events())
+                .containsExactly(
+                        event(LifecycleEventType.PRE_UPSERT, entity),
+                        event(LifecycleEventType.POST_UPSERT, entity));
     }
 
-    @Nested
-    @DisplayName("When deleting an entity")
-    class WhenDelete {
+    @Assertion(id = "1530",
+               strategy = "Delete one entity via the built-in delete method and verify that pre-delete and post-delete lifecycle events are fired.")
+    void shouldFireDeleteEvents() {
+        // given
+        MusicRecord entity = entity();
 
-        @Test
-        @DisplayName("Should fire pre-delete and post-delete events with the deleted entity")
-        void shouldFireDeleteEvents() {
-            // given
-            MusicRecord entity = entity();
+        repository.insert(entity);
+        observer.reset();
+        TestPropertyUtility.waitForEventualConsistency();
 
-            // when
-            repository.insert(entity);
-            observer.reset();
-            TestPropertyUtility.waitForEventualConsistency();
+        // when
+        repository.delete(entity);
 
-            // when
-            repository.delete(entity);
-
-            // then
-            assertThat(events())
-                    .containsExactly(
-                            event(LifecycleEventType.PRE_DELETE, entity),
-                            event(LifecycleEventType.POST_DELETE, entity));
-        }
+        // then
+        assertThat(events())
+                .containsExactly(
+                        event(LifecycleEventType.PRE_DELETE, entity),
+                        event(LifecycleEventType.POST_DELETE, entity));
     }
 
     private List<Tuple> events() {

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/JakartaEventCustomRepositoryTest.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/JakartaEventCustomRepositoryTest.java
@@ -15,45 +15,49 @@
  */
 package ee.jakarta.tck.data.standalone.entity;
 
-import ee.jakarta.tck.data.framework.junit.anno.AnyEntity;
-import ee.jakarta.tck.data.framework.junit.anno.Standalone;
-import ee.jakarta.tck.data.framework.utilities.DatabaseType;
-import ee.jakarta.tck.data.framework.utilities.TestProperty;
-import ee.jakarta.tck.data.framework.utilities.TestPropertyUtility;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.assertj.core.groups.Tuple;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.BeforeEach;
-import java.util.logging.Logger;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import jakarta.inject.Inject;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+
+import ee.jakarta.tck.data.framework.junit.anno.AnyEntity;
+import ee.jakarta.tck.data.framework.junit.anno.Assertion;
+import ee.jakarta.tck.data.framework.junit.anno.Standalone;
+import ee.jakarta.tck.data.framework.utilities.TestPropertyUtility;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import org.assertj.core.groups.Tuple;
+
+import org.junit.jupiter.api.BeforeEach;
+
+import jakarta.inject.Inject;
+
 import java.util.List;
 
 @Standalone
 @AnyEntity
-@DisplayName("Custom repository lifecycle events")
 public class JakartaEventCustomRepositoryTest {
-
-    public static final Logger log = Logger.getLogger(JakartaEventCustomRepositoryTest.class.getCanonicalName());
-
-    protected final DatabaseType type = TestProperty.databaseType.getDatabaseType();
 
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
-                .addClasses(JakartaEventCustomRepositoryTest.class);
+                .addClasses(
+                    JakartaEventBuiltInRepositoryTest.class,
+                    LifecycleEventType.class,
+                    MusicRecordLifecycleObserver.class,
+                    MusicRecordRepository.class,
+                    MusicRecord.class,
+                    MusicStore.class,
+                    ObservedEvent.class
+                );
     }
 
     @Inject
-    private MusicRecordLifecycleObserver observer;
+    MusicRecordLifecycleObserver observer;
 
     @Inject
-    private MusicStore repository;
+    MusicStore repository;
 
     @BeforeEach
     void setUp() {
@@ -63,302 +67,277 @@ public class JakartaEventCustomRepositoryTest {
         TestPropertyUtility.waitForEventualConsistency();
     }
 
-    @Nested
-    @DisplayName("When inserting entities")
-    class WhenInsert {
+    @Assertion(id = "1530", 
+               strategy = "Insert one entity via a custom insert method and verify that pre-insert and post-insert lifecycle events are fired.")
+    void shouldFireEventsForOneEntity() {
+        // given
+        var entity = firstEntity();
 
-        @Test
-        @DisplayName("Should fire pre-insert and post-insert events when inserting one entity")
-        void shouldFireEventsForOneEntity() {
-            // given
-            var entity = firstEntity();
+        // when
+        repository.insert(entity);
+        TestPropertyUtility.waitForEventualConsistency();
 
-            // when
-            repository.insert(entity);
-            TestPropertyUtility.waitForEventualConsistency();
-
-            // then
-            assertThat(events())
-                    .containsExactly(
-                            event(LifecycleEventType.PRE_INSERT, entity),
-                            event(LifecycleEventType.POST_INSERT, entity));
-        }
-
-        @SuppressWarnings("unchecked")
-        @Test
-        @DisplayName("Should fire pre-insert and post-insert events for each entity in a list")
-        void shouldFireEventsForEntityList() {
-            // given
-            var first = firstEntity();
-            var second = secondEntity();
-            var entities = List.of(first, second);
-
-            // when
-            repository.insert(entities);
-            TestPropertyUtility.waitForEventualConsistency();
-
-            // then
-            assertThat(events())
-                    .containsExactlyInAnyOrder(
-                            event(LifecycleEventType.PRE_INSERT, first),
-                            event(LifecycleEventType.PRE_INSERT, second),
-                            event(LifecycleEventType.POST_INSERT, first),
-                            event(LifecycleEventType.POST_INSERT, second));
-        }
-
-        @SuppressWarnings("unchecked")
-        @Test
-        @DisplayName("Should fire pre-insert and post-insert events for each entity in an array")
-        void shouldFireEventsForEntityArray() {
-            // given
-            var first = firstEntity();
-            var second = secondEntity();
-
-            // when
-            repository.insert(new MusicRecord[]{first, second});
-            TestPropertyUtility.waitForEventualConsistency();
-
-            // then
-            assertThat(events())
-                    .containsExactlyInAnyOrder(
-                            event(LifecycleEventType.PRE_INSERT, first),
-                            event(LifecycleEventType.PRE_INSERT, second),
-                            event(LifecycleEventType.POST_INSERT, first),
-                            event(LifecycleEventType.POST_INSERT, second));
-        }
+        // then
+        assertThat(events())
+                .containsExactly(
+                        event(LifecycleEventType.PRE_INSERT, entity),
+                        event(LifecycleEventType.POST_INSERT, entity));
     }
 
-    @Nested
-    @DisplayName("When updating entities")
-    class WhenUpdate {
+    @Assertion(id = "1530", 
+               strategy = "Insert a list of entities via a custom insert method and verify that pre-insert and post-insert lifecycle events are fired for each entity.")
+    void shouldFireEventsForEntityList() {
+        // given
+        var first = firstEntity();
+        var second = secondEntity();
+        var entities = List.of(first, second);
 
-        @Test
-        @DisplayName("Should fire pre-update and post-update events when updating one entity")
-        void shouldFireEventsForOneEntity() {
-            // given
-            var entity = firstEntity();
+        // when
+        repository.insert(entities);
+        TestPropertyUtility.waitForEventualConsistency();
 
-            repository.insert(entity);
-            observer.reset();
-            TestPropertyUtility.waitForEventualConsistency();
-
-            // when
-            repository.update(entity);
-            TestPropertyUtility.waitForEventualConsistency();
-
-            // then
-            assertThat(events())
-                    .containsExactly(
-                            event(LifecycleEventType.PRE_UPDATE, entity),
-                            event(LifecycleEventType.POST_UPDATE, entity));
-        }
-
-        @SuppressWarnings("unchecked")
-        @Test
-        @DisplayName("Should fire pre-update and post-update events for each entity in a list")
-        void shouldFireEventsForEntityList() {
-            // given
-            var first = firstEntity();
-            var second = secondEntity();
-            var entities = List.of(first, second);
-
-            repository.insert(entities);
-            observer.reset();
-            TestPropertyUtility.waitForEventualConsistency();
-
-            // when
-            repository.update(entities);
-            TestPropertyUtility.waitForEventualConsistency();
-
-            // then
-            assertThat(events())
-                    .containsExactlyInAnyOrder(
-                            event(LifecycleEventType.PRE_UPDATE, first),
-                            event(LifecycleEventType.PRE_UPDATE, second),
-                            event(LifecycleEventType.POST_UPDATE, first),
-                            event(LifecycleEventType.POST_UPDATE, second));
-        }
-
-        @SuppressWarnings("unchecked")
-        @Test
-        @DisplayName("Should fire pre-update and post-update events for each entity in an array")
-        void shouldFireEventsForEntityArray() {
-            // given
-            var first = firstEntity();
-            var second = secondEntity();
-
-            var entities = List.of(first, second);
-            repository.insert(entities);
-            observer.reset();
-            TestPropertyUtility.waitForEventualConsistency();
-
-            // when
-            repository.update(new MusicRecord[]{first, second});
-            TestPropertyUtility.waitForEventualConsistency();
-
-            // then
-            assertThat(events())
-                    .containsExactlyInAnyOrder(
-                            event(LifecycleEventType.PRE_UPDATE, first),
-                            event(LifecycleEventType.PRE_UPDATE, second),
-                            event(LifecycleEventType.POST_UPDATE, first),
-                            event(LifecycleEventType.POST_UPDATE, second));
-        }
+        // then
+        assertThat(events())
+                .containsExactlyInAnyOrder(
+                        event(LifecycleEventType.PRE_INSERT, first),
+                        event(LifecycleEventType.PRE_INSERT, second),
+                        event(LifecycleEventType.POST_INSERT, first),
+                        event(LifecycleEventType.POST_INSERT, second));
     }
 
-    @Nested
-    @DisplayName("When saving entities")
-    class WhenSave {
+    @Assertion(id = "1530", 
+               strategy = "Insert an array of entities via a custom insert method and verify that pre-insert and post-insert lifecycle events are fired for each entity.")
+    void shouldFireEventsForEntityArray() {
+        // given
+        var first = firstEntity();
+        var second = secondEntity();
 
-        @Test
-        @DisplayName("Should fire pre-upsert and post-upsert events when saving one new entity")
-        void shouldFireEventsForOneNewEntity() {
-            // given
-            var entity = firstEntity();
+        // when
+        repository.insert(new MusicRecord[]{first, second});
+        TestPropertyUtility.waitForEventualConsistency();
 
-            // when
-            repository.save(entity);
-            TestPropertyUtility.waitForEventualConsistency();
-
-            // then
-            assertThat(events())
-                    .containsExactly(
-                            event(LifecycleEventType.PRE_UPSERT, entity),
-                            event(LifecycleEventType.POST_UPSERT, entity));
-        }
-
-        @Test
-        @DisplayName("Should fire pre-upsert and post-upsert events when saving one existing entity")
-        void shouldFireEventsForOneExistingEntity() {
-            // given
-            var entity = firstEntity();
-
-            repository.insert(entity);
-            observer.reset();
-            TestPropertyUtility.waitForEventualConsistency();
-
-            // when
-            repository.save(entity);
-            TestPropertyUtility.waitForEventualConsistency();
-
-            // then
-            assertThat(events())
-                    .containsExactly(
-                            event(LifecycleEventType.PRE_UPSERT, entity),
-                            event(LifecycleEventType.POST_UPSERT, entity));
-        }
-
-        @Test
-        @DisplayName("Should fire pre-upsert and post-upsert events for each entity in a list")
-        void shouldFireEventsForEntityList() {
-            // given
-            var first = firstEntity();
-            var second = secondEntity();
-
-            // when
-            repository.save(List.of(first, second));
-            TestPropertyUtility.waitForEventualConsistency();
-
-            // then
-            assertThat(events())
-                    .containsExactlyInAnyOrder(
-                            event(LifecycleEventType.PRE_UPSERT, first),
-                            event(LifecycleEventType.POST_UPSERT, first),
-                            event(LifecycleEventType.PRE_UPSERT, second),
-                            event(LifecycleEventType.POST_UPSERT, second));
-        }
-
-        @Test
-        @DisplayName("Should fire pre-upsert and post-upsert events for each entity in an array")
-        void shouldFireEventsForEntityArray() {
-            // given
-            var first = firstEntity();
-            var second = secondEntity();
-
-            // when
-            repository.save(new MusicRecord[]{first, second});
-            TestPropertyUtility.waitForEventualConsistency();
-
-            // then
-            assertThat(events())
-                    .containsExactlyInAnyOrder(
-                            event(LifecycleEventType.PRE_UPSERT, first),
-                            event(LifecycleEventType.POST_UPSERT, first),
-                            event(LifecycleEventType.PRE_UPSERT, second),
-                            event(LifecycleEventType.POST_UPSERT, second));
-        }
+        // then
+        assertThat(events())
+                .containsExactlyInAnyOrder(
+                        event(LifecycleEventType.PRE_INSERT, first),
+                        event(LifecycleEventType.PRE_INSERT, second),
+                        event(LifecycleEventType.POST_INSERT, first),
+                        event(LifecycleEventType.POST_INSERT, second));
     }
 
-    @Nested
-    @DisplayName("When deleting entities")
-    class WhenDelete {
+    @Assertion(id = "1530", 
+               strategy = "Update one entity via a custom update method and verify that pre-update and post-update lifecycle events are fired.")
+    void shouldFireUpdateEventsForOneEntity() {
+        // given
+        var entity = firstEntity();
 
-        @Test
-        @DisplayName("Should fire pre-delete and post-delete events when deleting one entity")
-        void shouldFireEventsForOneEntity() {
-            // given
-            var entity = firstEntity();
-            repository.insert(entity);
-            observer.reset();
-            TestPropertyUtility.waitForEventualConsistency();
+        repository.insert(entity);
+        observer.reset();
+        TestPropertyUtility.waitForEventualConsistency();
 
-            // when
-            repository.delete(entity);
+        // when
+        repository.update(entity);
+        TestPropertyUtility.waitForEventualConsistency();
 
-            // then
-            assertThat(events())
-                    .containsExactly(
-                            event(LifecycleEventType.PRE_DELETE, entity),
-                            event(LifecycleEventType.POST_DELETE, entity));
-        }
+        // then
+        assertThat(events())
+                .containsExactly(
+                        event(LifecycleEventType.PRE_UPDATE, entity),
+                        event(LifecycleEventType.POST_UPDATE, entity));
+    }
 
-        @Test
-        @DisplayName("Should fire pre-delete and post-delete events for each entity in a list")
-        void shouldFireEventsForEntityList() {
-            // given
-            var first = firstEntity();
-            var second = secondEntity();
+    @Assertion(id = "1530", 
+               strategy = "Update a list of entities via a custom update method and verify that pre-update and post-update lifecycle events are fired for each entity.")
+    void shouldFireUpdateEventsForEntityList() {
+        // given
+        var first = firstEntity();
+        var second = secondEntity();
+        var entities = List.of(first, second);
 
-            // when
-            repository.insert(first);
-            repository.insert(second);
-            observer.reset();
-            TestPropertyUtility.waitForEventualConsistency();
+        repository.insert(entities);
+        observer.reset();
+        TestPropertyUtility.waitForEventualConsistency();
 
-            // when
-            repository.delete(List.of(first, second));
+        // when
+        repository.update(entities);
+        TestPropertyUtility.waitForEventualConsistency();
 
-            // then
-            assertThat(events())
-                    .containsExactlyInAnyOrder(
-                            event(LifecycleEventType.PRE_DELETE, first),
-                            event(LifecycleEventType.PRE_DELETE, second),
-                            event(LifecycleEventType.POST_DELETE, first),
-                            event(LifecycleEventType.POST_DELETE, second));
-        }
+        // then
+        assertThat(events())
+                .containsExactlyInAnyOrder(
+                        event(LifecycleEventType.PRE_UPDATE, first),
+                        event(LifecycleEventType.PRE_UPDATE, second),
+                        event(LifecycleEventType.POST_UPDATE, first),
+                        event(LifecycleEventType.POST_UPDATE, second));
+    }
 
-        @Test
-        @DisplayName("Should fire pre-delete and post-delete events for each entity in an array")
-        void shouldFireEventsForEntityArray() {
-            // given
-            var first = firstEntity();
-            var second = secondEntity();
-            repository.insert(first);
-            repository.insert(second);
-            observer.reset();
-            TestPropertyUtility.waitForEventualConsistency();
+    @Assertion(id = "1530", 
+               strategy = "Update an array of entities via a custom update method and verify that pre-update " + 
+                          "and post-update lifecycle events are fired for each entity.")
+    void shouldFireUpdateEventsForEntityArray() {
+        // given
+        var first = firstEntity();
+        var second = secondEntity();
 
-            // when
-            repository.delete(new MusicRecord[]{first, second});
+        var entities = List.of(first, second);
+        repository.insert(entities);
+        observer.reset();
+        TestPropertyUtility.waitForEventualConsistency();
 
-            // then
-            assertThat(events())
-                    .containsExactlyInAnyOrder(
-                            event(LifecycleEventType.PRE_DELETE, first),
-                            event(LifecycleEventType.PRE_DELETE, second),
-                            event(LifecycleEventType.POST_DELETE, first),
-                            event(LifecycleEventType.POST_DELETE, second));
-        }
+        // when
+        repository.update(new MusicRecord[]{first, second});
+        TestPropertyUtility.waitForEventualConsistency();
+
+        // then
+        assertThat(events())
+                .containsExactlyInAnyOrder(
+                        event(LifecycleEventType.PRE_UPDATE, first),
+                        event(LifecycleEventType.PRE_UPDATE, second),
+                        event(LifecycleEventType.POST_UPDATE, first),
+                        event(LifecycleEventType.POST_UPDATE, second));
+    }
+
+    @Assertion(id = "1530", 
+               strategy = "Save a new entity via a custom save method and verify that pre-upsert and post-upsert lifecycle events are fired.")
+    void shouldFireUpsertEventsForOneNewEntity() {
+        // given
+        var entity = firstEntity();
+
+        // when
+        repository.save(entity);
+        TestPropertyUtility.waitForEventualConsistency();
+
+        // then
+        assertThat(events())
+                .containsExactly(
+                        event(LifecycleEventType.PRE_UPSERT, entity),
+                        event(LifecycleEventType.POST_UPSERT, entity));
+    }
+
+    @Assertion(id = "1530", strategy = "Save an existing entity via a custom save method and verify that pre-upsert and post-upsert lifecycle events are fired.")
+    void shouldFireUpsertEventsForOneExistingEntity() {
+        // given
+        var entity = firstEntity();
+
+        repository.insert(entity);
+        observer.reset();
+        TestPropertyUtility.waitForEventualConsistency();
+
+        // when
+        repository.save(entity);
+        TestPropertyUtility.waitForEventualConsistency();
+
+        // then
+        assertThat(events())
+                .containsExactly(
+                        event(LifecycleEventType.PRE_UPSERT, entity),
+                        event(LifecycleEventType.POST_UPSERT, entity));
+    }
+
+    @Assertion(id = "1530", 
+               strategy = "Save a list of entities via a custom save method and verify that pre-upsert and post-upsert lifecycle events are fired for each entity.")
+    void shouldFireUpsertEventsForEntityList() {
+        // given
+        var first = firstEntity();
+        var second = secondEntity();
+
+        // when
+        repository.save(List.of(first, second));
+        TestPropertyUtility.waitForEventualConsistency();
+
+        // then
+        assertThat(events())
+                .containsExactlyInAnyOrder(
+                        event(LifecycleEventType.PRE_UPSERT, first),
+                        event(LifecycleEventType.POST_UPSERT, first),
+                        event(LifecycleEventType.PRE_UPSERT, second),
+                        event(LifecycleEventType.POST_UPSERT, second));
+    }
+
+    @Assertion(id = "1530", 
+               strategy = "Save an array of entities via a custom save method and verify that pre-upsert and post-upsert lifecycle events are fired for each entity.")
+    void shouldFireUpsertEventsForEntityArray() {
+        // given
+        var first = firstEntity();
+        var second = secondEntity();
+
+        // when
+        repository.save(new MusicRecord[]{first, second});
+        TestPropertyUtility.waitForEventualConsistency();
+
+        // then
+        assertThat(events())
+                .containsExactlyInAnyOrder(
+                        event(LifecycleEventType.PRE_UPSERT, first),
+                        event(LifecycleEventType.POST_UPSERT, first),
+                        event(LifecycleEventType.PRE_UPSERT, second),
+                        event(LifecycleEventType.POST_UPSERT, second));
+    }
+
+    @Assertion(id = "1530", 
+               strategy = "Delete one entity via a custom delete method and verify that pre-delete and post-delete lifecycle events are fired.")
+    void shouldFireDeleteEventsForOneEntity() {
+        // given
+        var entity = firstEntity();
+        repository.insert(entity);
+        observer.reset();
+        TestPropertyUtility.waitForEventualConsistency();
+
+        // when
+        repository.delete(entity);
+
+        // then
+        assertThat(events())
+                .containsExactly(
+                        event(LifecycleEventType.PRE_DELETE, entity),
+                        event(LifecycleEventType.POST_DELETE, entity));
+    }
+
+    @Assertion(id = "1530", 
+               strategy = "Delete a list of entities via a custom delete method and verify that pre-delete and post-delete lifecycle events are fired for each entity.")
+    void shouldFireDeleteEventsForEntityList() {
+        // given
+        var first = firstEntity();
+        var second = secondEntity();
+
+        repository.insert(first);
+        repository.insert(second);
+        observer.reset();
+        TestPropertyUtility.waitForEventualConsistency();
+
+        // when
+        repository.delete(List.of(first, second));
+
+        // then
+        assertThat(events())
+                .containsExactlyInAnyOrder(
+                        event(LifecycleEventType.PRE_DELETE, first),
+                        event(LifecycleEventType.PRE_DELETE, second),
+                        event(LifecycleEventType.POST_DELETE, first),
+                        event(LifecycleEventType.POST_DELETE, second));
+    }
+
+    @Assertion(id = "1530", 
+               strategy = "Delete an array of entities via a custom delete method and verify that pre-delete and post-delete lifecycle events are fired for each entity.")
+    void shouldFireDeleteEventsForEntityArray() {
+        // given
+        var first = firstEntity();
+        var second = secondEntity();
+        repository.insert(first);
+        repository.insert(second);
+        observer.reset();
+        TestPropertyUtility.waitForEventualConsistency();
+
+        // when
+        repository.delete(new MusicRecord[]{first, second});
+
+        // then
+        assertThat(events())
+                .containsExactlyInAnyOrder(
+                        event(LifecycleEventType.PRE_DELETE, first),
+                        event(LifecycleEventType.PRE_DELETE, second),
+                        event(LifecycleEventType.POST_DELETE, first),
+                        event(LifecycleEventType.POST_DELETE, second));
     }
 
     private List<Tuple> events() {

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/JakartaQueryDeleteTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/JakartaQueryDeleteTests.java
@@ -20,28 +20,28 @@ import ee.jakarta.tck.data.framework.junit.anno.Standalone;
 import ee.jakarta.tck.data.framework.utilities.DatabaseType;
 import ee.jakarta.tck.data.framework.utilities.TestProperty;
 import ee.jakarta.tck.data.framework.utilities.TestPropertyUtility;
+import ee.jakarta.tck.data.framework.junit.anno.Assertion;
+
 import jakarta.inject.Inject;
+
 import org.assertj.core.api.Assertions;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import ee.jakarta.tck.data.framework.junit.anno.Assertion;
 
 import java.util.List;
-import java.util.logging.Logger;
 
 @Standalone
 @AnyEntity
 @DisplayName("Jakarta Data integration with Jakarta Common Query Language for delete operations")
 public class JakartaQueryDeleteTests {
 
-    public static final Logger log =
-            Logger.getLogger(JakartaQueryDeleteTests.class.getCanonicalName());
-
-    protected final DatabaseType type = TestProperty.databaseType.getDatabaseType();
+    private final DatabaseType type = TestProperty.databaseType.getDatabaseType();
 
     @Deployment
     public static WebArchive createDeployment() {
@@ -52,9 +52,9 @@ public class JakartaQueryDeleteTests {
     }
 
     @Inject
-    protected VegetableRepository vegetableRepository;
+    VegetableRepository vegetableRepository;
 
-    protected List<Vegetable> vegetables = VegetableRepository.VEGGIES;
+    List<Vegetable> vegetables = VegetableRepository.VEGGIES;
 
     @BeforeEach
     public void setup() {

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/JakartaQueryTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/JakartaQueryTests.java
@@ -19,13 +19,6 @@ import ee.jakarta.tck.data.framework.junit.anno.AnyEntity;
 import ee.jakarta.tck.data.framework.junit.anno.Standalone;
 import ee.jakarta.tck.data.framework.utilities.DatabaseType;
 import ee.jakarta.tck.data.framework.utilities.TestProperty;
-import jakarta.inject.Inject;
-import org.assertj.core.api.Assertions;
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import ee.jakarta.tck.data.framework.junit.anno.Assertion;
 import ee.jakarta.tck.data.framework.junit.anno.ReadOnlyTest;
 import ee.jakarta.tck.data.framework.read.only.Fruit;
@@ -33,13 +26,23 @@ import ee.jakarta.tck.data.framework.read.only.FruitPopulator;
 import ee.jakarta.tck.data.framework.read.only.FruitRepository;
 import ee.jakarta.tck.data.framework.read.only.FruitSummary;
 
+import jakarta.inject.Inject;
+
+import org.assertj.core.api.Assertions;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.logging.Logger;
 
 @Standalone
 @AnyEntity
@@ -47,9 +50,7 @@ import java.util.logging.Logger;
 @DisplayName("Jakarta Data integration with Jakarta Common Query Language for select operations")
 public class JakartaQueryTests {
 
-    public static final Logger log = Logger.getLogger(JakartaQueryTests.class.getCanonicalName());
-
-    protected final DatabaseType type = TestProperty.databaseType.getDatabaseType();
+    private final DatabaseType type = TestProperty.databaseType.getDatabaseType();
 
     @Deployment
     public static WebArchive createDeployment() {
@@ -58,9 +59,9 @@ public class JakartaQueryTests {
     }
 
     @Inject
-    protected FruitRepository fruitRepository;
+    FruitRepository fruitRepository;
 
-    protected List<Fruit> fruits = FruitPopulator.FRUITS;
+    private final List<Fruit> fruits = FruitPopulator.FRUITS;
 
     @BeforeEach
     //Inject doesn't happen until after BeforeClass so this is necessary before each test

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/JakartaQueryUpdateTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/entity/JakartaQueryUpdateTests.java
@@ -17,8 +17,6 @@ package ee.jakarta.tck.data.standalone.entity;
 
 import ee.jakarta.tck.data.framework.junit.anno.AnyEntity;
 import ee.jakarta.tck.data.framework.junit.anno.Standalone;
-import ee.jakarta.tck.data.framework.utilities.DatabaseType;
-import ee.jakarta.tck.data.framework.utilities.TestProperty;
 import ee.jakarta.tck.data.framework.utilities.TestPropertyUtility;
 import jakarta.inject.Inject;
 import org.assertj.core.api.Assertions;
@@ -31,15 +29,11 @@ import org.junit.jupiter.api.DisplayName;
 import ee.jakarta.tck.data.framework.junit.anno.Assertion;
 
 import java.util.List;
-import java.util.logging.Logger;
 
 @Standalone
 @AnyEntity
 @DisplayName("Jakarta Data integration with Jakarta Common Query Language for update operations")
 public class JakartaQueryUpdateTests {
-
-    public static final Logger log = Logger.getLogger(JakartaQueryUpdateTests.class.getCanonicalName());
-
 
     @Deployment
     public static WebArchive createDeployment() {
@@ -50,11 +44,9 @@ public class JakartaQueryUpdateTests {
     }
 
     @Inject
-    protected VegetableRepository vegetableRepository;
+    VegetableRepository vegetableRepository;
 
-    protected final DatabaseType type = TestProperty.databaseType.getDatabaseType();
-
-    protected List<Vegetable> vegetables = VegetableRepository.VEGGIES;
+    private final List<Vegetable> vegetables = VegetableRepository.VEGGIES;
 
     private static final String UPDATED = "updated";
 

--- a/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/stateful/StatefulPersistenceEntityTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/standalone/persistence/stateful/StatefulPersistenceEntityTests.java
@@ -50,6 +50,7 @@ public class StatefulPersistenceEntityTests {
                 .create(WebArchive.class)
                 .addClasses(Inventory.class,
                             Product.class,
+                            _Product.class,
                             Products.class);
     }
 

--- a/tck/src/main/java/ee/jakarta/tck/data/web/validation/ValidationTests.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/web/validation/ValidationTests.java
@@ -50,7 +50,7 @@ public class ValidationTests {
     }
 
     @Inject
-    private Rectangles rectangles;
+    Rectangles rectangles;
 
     private DatabaseType type = TestProperty.databaseType.getDatabaseType();
 


### PR DESCRIPTION
- make sure deployments have the right set of classes to be able to run
- use `@Assertion` instead of `@DisplayName/@Test` we scan for `@Assertion` to automate sections of the TCK Distribution documentation.
- other cleanup of TCK tests.