### PR TITLE
Adjust tests to use matching types and add missing ordering

### DIFF
--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/AsciiCharacters.java
@@ -100,8 +100,8 @@ public interface AsciiCharacters extends DataRepository<AsciiCharacter, Long> {
     Optional<AsciiCharacter> findFirstByHexadecimalStartsWithAndIsControlOrderByIdAsc(String firstHexDigit, boolean isControlChar);
 
     @Find
-    Page<AsciiCharacter> fromRange(@By(ID) @Is(AtLeast.class) int min,
-                                   @By(ID) @Is(AtMost.class) int max,
+    Page<AsciiCharacter> fromRange(@By(ID) @Is(AtLeast.class) long min,
+                                   @By(ID) @Is(AtMost.class) long max,
                                    PageRequest pagination,
                                    Order<AsciiCharacter> order);
 

--- a/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers.java
+++ b/tck/src/main/java/ee/jakarta/tck/data/framework/read/only/NaturalNumbers.java
@@ -194,6 +194,7 @@ public interface NaturalNumbers extends BasicRepository<NaturalNumber, Long> {
                                       PageRequest pageReq,
                                       Order<NaturalNumber> order);
 
+    @OrderBy(ID)
     @Find
     CursoredPage<NaturalNumber> withTruncatedSquareRoot(long floorOfSquareRoot,
                                                         PageRequest pagination);


### PR DESCRIPTION
From Hibernate ORM builds against the recent TCK snapshots:

- Since `AsciiCharacter` uses a long id having those its for the filters does not play very nicely 😕 
- missing sorting/oredering results in:
```
error: method with return type 'jakarta.data.page.CursoredPage' has no parameter of type 'Order' or 'Sort' and no '@OrderBy' annotation for inherited member 'withTruncatedSquareRoot'
interface NaturalNumbers$ extends NaturalNumbers {
```

cc: @gavinking @njr-11 